### PR TITLE
feat: minswap v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Shai is a Cardano Multi-DEX oracle and matcher bot. It monitors the blockchain f
 ## Features
 
 - DEX Oracle: Real-time pool state tracking from on-chain data
-- Multi-DEX Support: Minswap v2, SundaeSwap v3, Splash v1, WingRiders v2, VyFi
+- Multi-DEX Support: Minswap v1/v2, SundaeSwap v3, Splash v1, WingRiders v2, VyFi
 - Spectrum Batching: Matcher bot for Spectrum-compatible DEXs
 - Mempool Monitoring: Track pending transactions for faster matching
 - Cardano Node: Acts as both NtN (Node-to-Node) and NtC (Node-to-Client) peer
@@ -61,6 +61,7 @@ Shai can be configured via YAML file, environment variables, or both.
 ```yaml
 network: mainnet
 profiles:
+  - minswap-v1
   - minswap-v2
   - sundaeswap-v3
   - splash-v1
@@ -87,6 +88,7 @@ wallet:
 ### Available Profiles
 
 Oracle profiles (price tracking):
+- `minswap-v1` - Minswap V1 pools (legacy)
 - `minswap-v2` - Minswap V2 pools
 - `sundaeswap-v3` - SundaeSwap V3 pools
 - `splash-v1` - Splash (formerly Spectrum) pools
@@ -116,7 +118,7 @@ Track pool prices across multiple DEXs:
 
 ```bash
 export NETWORK=mainnet
-export PROFILES=minswap-v2,sundaeswap-v3,splash-v1,wingriders-v2,vyfi
+export PROFILES=minswap-v1,minswap-v2,sundaeswap-v3,splash-v1,wingriders-v2,vyfi
 export INDEXER_TCP_ADDRESS=localhost:3001
 ./shai
 ```

--- a/cmd/shai/main.go
+++ b/cmd/shai/main.go
@@ -185,6 +185,8 @@ func main() {
 // getOracleParser returns the appropriate parser for an oracle protocol
 func getOracleParser(protocol string) oracle.PoolParser {
 	switch protocol {
+	case "minswap-v1":
+		return oracle.NewMinswapV1Parser()
 	case "minswap-v2", "minswap":
 		return oracle.NewMinswapV2Parser()
 	case "sundaeswap-v3", "sundaeswap":

--- a/internal/config/profiles.go
+++ b/internal/config/profiles.go
@@ -102,6 +102,22 @@ var Profiles = map[string]map[string]Profile{
 		},
 	},
 	"mainnet": {
+		"minswap-v1": {
+			Name:          "minswap-v1",
+			Type:          ProfileTypeOracle,
+			InterceptSlot: 51340496, // Minswap V1 deployment (March 2022)
+			InterceptHash: "ba74da9715acfd2a01c88b52e41b574621c65c91e8eda35c9c3cd8e8c5f64d4c",
+			Config: OracleProfileConfig{
+				Protocol: "minswap-v1",
+				PoolAddresses: []ProfileConfigAddress{
+					// Minswap V1 pool script address (mainnet)
+					{
+						Address: "addr1z8snz7c4974vzdpxu65ruphl3zjdvtxw8strf2c2tmqnxzfgf2ypu62xjxel6aqdmr333p0ds377t4phv8098c8s8fmqffc3l3",
+					},
+				},
+				InputRefs: []ProfileConfigInputRef{},
+			},
+		},
 		"minswap-v2": {
 			Name:          "minswap-v2",
 			Type:          ProfileTypeOracle,

--- a/internal/oracle/minswap.go
+++ b/internal/oracle/minswap.go
@@ -25,6 +25,11 @@ type MinswapParser struct {
 	parser *minswap.Parser
 }
 
+// NewMinswapV1Parser creates a parser for Minswap V1 pools
+func NewMinswapV1Parser() *MinswapParser {
+	return &MinswapParser{parser: minswap.NewV1Parser()}
+}
+
 // NewMinswapV2Parser creates a parser for Minswap V2 pools
 func NewMinswapV2Parser() *MinswapParser {
 	return &MinswapParser{parser: minswap.NewV2Parser()}

--- a/internal/oracle/minswap/models.go
+++ b/internal/oracle/minswap/models.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package minswap provides datum types and parsing for Minswap V2 DEX protocol.
+// Package minswap provides datum types and parsing for Minswap DEX protocols.
 package minswap
 
 import (
@@ -41,6 +41,39 @@ type V2PoolDatum struct {
 	BaseFee             BaseFee
 	FeeSharingNumerator OptionalUint64
 	AllowDynamicFee     Bool
+}
+
+// V1PoolDatum represents the Minswap V1 pool datum structure
+type V1PoolDatum struct {
+	cbor.StructAsArray
+	cbor.DecodeStoreCbor
+	AssetA         Asset
+	AssetB         Asset
+	TotalLiquidity uint64
+	RootKLast      uint64
+	FeeSharing     FeeSharing
+}
+
+func (d *V1PoolDatum) UnmarshalCBOR(cborData []byte) error {
+	var tmpConstr cbor.Constructor
+	if _, err := cbor.Decode(cborData, &tmpConstr); err != nil {
+		return err
+	}
+	if tmpConstr.Constructor() != 0 {
+		return fmt.Errorf(
+			"expected constructor 0, got %d",
+			tmpConstr.Constructor(),
+		)
+	}
+
+	type tV1PoolDatum V1PoolDatum
+	var tmp tV1PoolDatum
+	if _, err := cbor.Decode(tmpConstr.FieldsCbor(), &tmp); err != nil {
+		return err
+	}
+	*d = V1PoolDatum(tmp)
+	d.SetCbor(cborData)
+	return nil
 }
 
 func (d *V2PoolDatum) UnmarshalCBOR(cborData []byte) error {
@@ -176,6 +209,45 @@ func (f *BaseFee) UnmarshalCBOR(cborData []byte) error {
 		return err
 	}
 	*f = BaseFee(tmp)
+	return nil
+}
+
+// FeeSharing represents optional fee sharing in V1
+type FeeSharing struct {
+	IsPresent      bool
+	FeeTo          []byte
+	FeeToDatumHash []byte
+}
+
+func (f *FeeSharing) UnmarshalCBOR(cborData []byte) error {
+	var tmpConstr cbor.Constructor
+	if _, err := cbor.Decode(cborData, &tmpConstr); err != nil {
+		return err
+	}
+	switch tmpConstr.Constructor() {
+	case 1:
+		f.IsPresent = false
+		f.FeeTo = nil
+		f.FeeToDatumHash = nil
+		return nil
+	case 0:
+		f.IsPresent = true
+	default:
+		return fmt.Errorf(
+			"invalid FeeSharing constructor: expected 0 or 1, got %d",
+			tmpConstr.Constructor(),
+		)
+	}
+	var wrapper struct {
+		cbor.StructAsArray
+		FeeTo          []byte
+		FeeToDatumHash []byte
+	}
+	if _, err := cbor.Decode(tmpConstr.FieldsCbor(), &wrapper); err != nil {
+		return err
+	}
+	f.FeeTo = wrapper.FeeTo
+	f.FeeToDatumHash = wrapper.FeeToDatumHash
 	return nil
 }
 

--- a/internal/oracle/minswap/parser.go
+++ b/internal/oracle/minswap/parser.go
@@ -15,12 +15,15 @@
 package minswap
 
 import (
+	"bytes"
 	"encoding/hex"
 	"fmt"
 	"math"
 	"time"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/shai/internal/common"
 )
 
@@ -39,22 +42,164 @@ type PoolState struct {
 }
 
 // Parser implements pool parsing for Minswap V2
-type Parser struct{}
+type Parser struct {
+	version int // 1 or 2
+}
+
+// NewV1Parser creates a parser for Minswap V1 pools
+func NewV1Parser() *Parser {
+	return &Parser{version: 1}
+}
 
 // NewV2Parser creates a parser for Minswap V2 pools
 func NewV2Parser() *Parser {
-	return &Parser{}
+	return &Parser{version: 2}
 }
 
 // Protocol returns the protocol name
 func (p *Parser) Protocol() string {
+	if p.version == 1 {
+		return ProtocolName + "-v1"
+	}
 	return ProtocolName + "-v2"
 }
 
-// ParsePoolDatum parses a Minswap V2 pool datum
+// ParsePoolDatum parses a Minswap pool datum.
+// utxoValue is consumed by V1 parsing for reserve extraction and ignored by V2.
 func (p *Parser) ParsePoolDatum(
 	datum []byte,
-	utxoValue []byte, // Not used for Minswap v2
+	utxoValue []byte,
+	txHash string,
+	txIndex uint32,
+	slot uint64,
+	timestamp time.Time,
+) (*PoolState, error) {
+	if p.version == 1 {
+		return p.parseV1Datum(datum, utxoValue, txHash, txIndex, slot, timestamp)
+	}
+	return p.parseV2Datum(datum, txHash, txIndex, slot, timestamp)
+}
+
+func (p *Parser) parseV1Datum(
+	datum []byte,
+	utxoValue []byte,
+	txHash string,
+	txIndex uint32,
+	slot uint64,
+	timestamp time.Time,
+) (*PoolState, error) {
+	var poolDatum V1PoolDatum
+	if _, err := cbor.Decode(datum, &poolDatum); err != nil {
+		return nil, fmt.Errorf("failed to decode Minswap V1 datum: %w", err)
+	}
+
+	poolId := GeneratePoolId(
+		poolDatum.AssetA.PolicyId,
+		poolDatum.AssetA.AssetName,
+		poolDatum.AssetB.PolicyId,
+		poolDatum.AssetB.AssetName,
+	)
+
+	reserveA, reserveB, err := p.extractReservesFromValue(
+		utxoValue,
+		poolDatum.AssetA,
+		poolDatum.AssetB,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract V1 reserves: %w", err)
+	}
+
+	return &PoolState{
+		PoolId:   poolId,
+		Protocol: p.Protocol(),
+		AssetX: common.AssetAmount{
+			Class:  poolDatum.AssetA.ToCommonAssetClass(),
+			Amount: reserveA,
+		},
+		AssetY: common.AssetAmount{
+			Class:  poolDatum.AssetB.ToCommonAssetClass(),
+			Amount: reserveB,
+		},
+		FeeNum:    9970, // default 0.3% swap fee
+		FeeDenom:  FeeDenom,
+		Slot:      slot,
+		TxHash:    txHash,
+		TxIndex:   txIndex,
+		Timestamp: timestamp,
+	}, nil
+}
+
+func (p *Parser) extractReservesFromValue(
+	utxoValue []byte,
+	assetA Asset,
+	assetB Asset,
+) (uint64, uint64, error) {
+	txOut, err := ledger.NewTransactionOutputFromCbor(utxoValue)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to decode UTxO output: %w", err)
+	}
+
+	reserveA, err := p.getAssetAmount(txOut, assetA.PolicyId, assetA.AssetName)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to get asset A amount: %w", err)
+	}
+	reserveB, err := p.getAssetAmount(txOut, assetB.PolicyId, assetB.AssetName)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to get asset B amount: %w", err)
+	}
+	return reserveA, reserveB, nil
+}
+
+func (p *Parser) getAssetAmount(
+	txOut lcommon.TransactionOutput,
+	policyId []byte,
+	assetName []byte,
+) (uint64, error) {
+	if len(policyId) == 0 {
+		if len(assetName) != 0 {
+			return 0, fmt.Errorf(
+				"malformed asset: empty policyId with non-empty assetName %x",
+				assetName,
+			)
+		}
+		return txOut.Amount().Uint64(), nil
+	}
+
+	assets := txOut.Assets()
+	if assets == nil {
+		return 0, fmt.Errorf("no native assets in UTxO for policy %x", policyId)
+	}
+
+	var policyHash lcommon.Blake2b224
+	if len(policyId) != len(policyHash) {
+		return 0, fmt.Errorf(
+			"invalid policy ID length: expected %d, got %d",
+			len(policyHash),
+			len(policyId),
+		)
+	}
+	copy(policyHash[:], policyId)
+
+	for _, policy := range assets.Policies() {
+		if policy != policyHash {
+			continue
+		}
+		for _, name := range assets.Assets(policy) {
+			if bytes.Equal(name, assetName) {
+				return assets.Asset(policy, name).Uint64(), nil
+			}
+		}
+	}
+
+	return 0, fmt.Errorf(
+		"asset not found: policy=%x, name=%x",
+		policyId,
+		assetName,
+	)
+}
+
+func (p *Parser) parseV2Datum(
+	datum []byte,
 	txHash string,
 	txIndex uint32,
 	slot uint64,

--- a/internal/oracle/minswap_test.go
+++ b/internal/oracle/minswap_test.go
@@ -15,10 +15,13 @@
 package oracle
 
 import (
+	"math/big"
 	"testing"
 	"time"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/mary"
 	"github.com/blinklabs-io/shai/internal/oracle/minswap"
 )
 
@@ -29,6 +32,16 @@ func TestNewMinswapV2Parser(t *testing.T) {
 	}
 	if parser.Protocol() != "minswap-v2" {
 		t.Errorf("expected protocol 'minswap-v2', got %s", parser.Protocol())
+	}
+}
+
+func TestNewMinswapV1Parser(t *testing.T) {
+	parser := NewMinswapV1Parser()
+	if parser == nil {
+		t.Fatal("expected non-nil parser")
+	}
+	if parser.Protocol() != "minswap-v1" {
+		t.Errorf("expected protocol 'minswap-v1', got %s", parser.Protocol())
 	}
 }
 
@@ -234,4 +247,171 @@ func TestMinswapOptionalUint64(t *testing.T) {
 	if optSome.Value != 42 {
 		t.Errorf("expected value 42, got %d", optSome.Value)
 	}
+}
+
+func TestMinswapV1DatumUnmarshal(t *testing.T) {
+	assetA := cbor.NewConstructor(0, cbor.IndefLengthList{
+		[]byte{}, // Empty policy = ADA
+		[]byte{},
+	})
+
+	assetB := cbor.NewConstructor(0, cbor.IndefLengthList{
+		[]byte{0xab, 0xcd, 0xef},
+		[]byte("MIN"),
+	})
+
+	feeSharingNone := cbor.NewConstructor(1, cbor.IndefLengthList{})
+
+	datum := cbor.NewConstructor(0, cbor.IndefLengthList{
+		assetA,
+		assetB,
+		uint64(1000000000), // totalLiquidity
+		uint64(12345678),   // rootKLast
+		feeSharingNone,
+	})
+
+	cborData, err := cbor.Encode(&datum)
+	if err != nil {
+		t.Fatalf("failed to encode test datum: %v", err)
+	}
+
+	var poolDatum minswap.V1PoolDatum
+	if _, err := cbor.Decode(cborData, &poolDatum); err != nil {
+		t.Fatalf("failed to decode datum: %v", err)
+	}
+
+	if poolDatum.TotalLiquidity != 1000000000 {
+		t.Errorf(
+			"expected totalLiquidity 1000000000, got %d",
+			poolDatum.TotalLiquidity,
+		)
+	}
+	if poolDatum.RootKLast != 12345678 {
+		t.Errorf("expected rootKLast 12345678, got %d", poolDatum.RootKLast)
+	}
+	if poolDatum.FeeSharing.IsPresent {
+		t.Error("expected FeeSharing.IsPresent to be false")
+	}
+}
+
+func TestMinswapV1ParserParsePoolDatum(t *testing.T) {
+	tokenPolicy := make([]byte, 28)
+	for i := range tokenPolicy {
+		tokenPolicy[i] = 0xab
+	}
+
+	assetA := cbor.NewConstructor(0, cbor.IndefLengthList{
+		[]byte{},
+		[]byte{},
+	})
+
+	assetB := cbor.NewConstructor(0, cbor.IndefLengthList{
+		tokenPolicy,
+		[]byte("TEST"),
+	})
+
+	feeSharingNone := cbor.NewConstructor(1, cbor.IndefLengthList{})
+
+	datum := cbor.NewConstructor(0, cbor.IndefLengthList{
+		assetA,
+		assetB,
+		uint64(1000000000), // totalLiquidity
+		uint64(12345678),   // rootKLast
+		feeSharingNone,
+	})
+
+	cborData, err := cbor.Encode(&datum)
+	if err != nil {
+		t.Fatalf("failed to encode: %v", err)
+	}
+	utxoValue, err := buildMaryOutputCbor(
+		100000000, // 100 ADA
+		tokenPolicy,
+		[]byte("TEST"),
+		200000000, // 200 TEST
+	)
+	if err != nil {
+		t.Fatalf("failed to build UTxO output: %v", err)
+	}
+
+	parser := NewMinswapV1Parser()
+	state, err := parser.ParsePoolDatum(
+		cborData,
+		utxoValue,
+		"def456",
+		1,
+		67890,
+		time.Now(),
+	)
+	if err != nil {
+		t.Fatalf("failed to parse datum: %v", err)
+	}
+
+	if state.Protocol != "minswap-v1" {
+		t.Errorf("expected protocol 'minswap-v1', got %s", state.Protocol)
+	}
+	if state.Slot != 67890 {
+		t.Errorf("expected slot 67890, got %d", state.Slot)
+	}
+	if state.TxHash != "def456" {
+		t.Errorf("expected txHash 'def456', got %s", state.TxHash)
+	}
+	if state.TxIndex != 1 {
+		t.Errorf("expected txIndex 1, got %d", state.TxIndex)
+	}
+	if state.AssetX.Amount != 100000000 {
+		t.Errorf("expected assetX amount 100000000, got %d", state.AssetX.Amount)
+	}
+	if state.AssetY.Amount != 200000000 {
+		t.Errorf("expected assetY amount 200000000, got %d", state.AssetY.Amount)
+	}
+	if state.FeeNum != 9970 {
+		t.Errorf("expected feeNum 9970, got %d", state.FeeNum)
+	}
+	if state.FeeDenom != 10000 {
+		t.Errorf("expected feeDenom 10000, got %d", state.FeeDenom)
+	}
+
+	// Check price calculation: 200 TEST / 100 ADA = 2.0
+	if state.PriceXY() != 2.0 {
+		t.Errorf("expected price 2.0, got %f", state.PriceXY())
+	}
+}
+
+func buildMaryOutputCbor(
+	lovelace uint64,
+	tokenPolicy []byte,
+	tokenName []byte,
+	tokenAmount uint64,
+) ([]byte, error) {
+	addr, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeKeyKey,
+		lcommon.AddressNetworkMainnet,
+		make([]byte, 28),
+		make([]byte, 28),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var policyHash lcommon.Blake2b224
+	copy(policyHash[:], tokenPolicy)
+
+	assets := lcommon.NewMultiAsset[lcommon.MultiAssetTypeOutput](
+		map[lcommon.Blake2b224]map[cbor.ByteString]lcommon.MultiAssetTypeOutput{
+			policyHash: {
+				cbor.NewByteString(tokenName): new(big.Int).SetUint64(tokenAmount),
+			},
+		},
+	)
+
+	txOut := mary.MaryTransactionOutput{
+		OutputAddress: addr,
+		OutputAmount: mary.MaryTransactionOutputValue{
+			Amount: lovelace,
+			Assets: &assets,
+		},
+	}
+
+	return cbor.Encode(&txOut)
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Minswap v1 support to the oracle to track legacy pools on mainnet.

- **New Features**
  - Added Minswap v1 parser and models (V1PoolDatum, FeeSharing); extracts reserves from UTxO value and uses 0.3% fee (9970/10000).
  - Parser is now versioned (v1/v2) and reports protocol as "minswap-v1" or "minswap-v2"; wired into CLI and oracle wrapper.
  - Added mainnet profile "minswap-v1" with intercept slot/hash and pool script address; README and env examples updated.
  - New tests for v1 datum decoding and reserve extraction.

<sup>Written for commit 53f511be73257074f30dfac07139eeaf62970d07. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Minswap V1 protocol alongside existing V2 support.
  * New minswap-v1 profile configuration now available for mainnet deployments.

* **Documentation**
  * Updated documentation to reflect expanded Multi-DEX support including Minswap V1 and V2.

* **Tests**
  * Added comprehensive test coverage for Minswap V1 parsing and protocol functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->