### PR TITLE
feat: cswap support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Shai is a Cardano Multi-DEX oracle and matcher bot. It monitors the blockchain f
 ## Features
 
 - DEX Oracle: Real-time pool state tracking from on-chain data
-- Multi-DEX Support: Minswap v1/v2, SundaeSwap v3, Splash v1, WingRiders v2, VyFi
+- Multi-DEX Support: Minswap v1/v2, SundaeSwap v3, Splash v1, WingRiders v2, VyFi, CSWAP
 - Spectrum Batching: Matcher bot for Spectrum-compatible DEXs
 - Mempool Monitoring: Track pending transactions for faster matching
 - Cardano Node: Acts as both NtN (Node-to-Node) and NtC (Node-to-Client) peer
@@ -94,6 +94,7 @@ Oracle profiles (price tracking):
 - `splash-v1` - Splash (formerly Spectrum) pools
 - `wingriders-v2` - WingRiders V2 pools
 - `vyfi` - VyFi pools
+- `cswap` - CSWAP pools
 
 Spectrum batching profiles (matcher bot):
 - `spectrum` - Spectrum DEX on mainnet
@@ -118,10 +119,13 @@ Track pool prices across multiple DEXs:
 
 ```bash
 export NETWORK=mainnet
-export PROFILES=minswap-v1,minswap-v2,sundaeswap-v3,splash-v1,wingriders-v2,vyfi
+export PROFILES=minswap-v1,minswap-v2,sundaeswap-v3,splash-v1,wingriders-v2,vyfi,cswap
 export INDEXER_TCP_ADDRESS=localhost:3001
 ./shai
 ```
+
+`cswap` is wired to the verified mainnet DEX pool contract address and can be enabled like the other oracle profiles.
+The bundled profile values were sourced from the public CRFA offchain registry plus CSWAP's live contract registry, and the intercept point was verified from the earliest on-chain `dex` contract transaction.
 
 ### Example: Batcher Mode
 

--- a/cmd/shai/main.go
+++ b/cmd/shai/main.go
@@ -216,6 +216,8 @@ func getOracleParser(protocol string) oracle.PoolParser {
 		return oracle.NewWingRidersV2Parser()
 	case "vyfi":
 		return oracle.NewVyFiParser()
+	case "cswap":
+		return oracle.NewCSwapParser()
 	default:
 		return nil
 	}

--- a/internal/config/profiles.go
+++ b/internal/config/profiles.go
@@ -211,6 +211,23 @@ var Profiles = map[string]map[string]Profile{
 				InputRefs: []ProfileConfigInputRef{},
 			},
 		},
+		"cswap": {
+			Name: "cswap",
+			Type: ProfileTypeOracle,
+			// CSWAP DEX pool script launch (mainnet)
+			InterceptSlot: 149650740,
+			InterceptHash: "6027a8e3af4cd1cd2b3de0a1b583882573953c200c0ccf120119a04d1def5b49",
+			Config: OracleProfileConfig{
+				Protocol: "cswap",
+				PoolAddresses: []ProfileConfigAddress{
+					// CSWAP DEX pool script address (mainnet)
+					{
+						Address: "addr1z8ke0c9p89rjfwmuh98jpt8ky74uy5mffjft3zlcld9h7ml3lmln3mwk0y3zsh3gs3dzqlwa9rjzrxawkwm4udw9axhs6fuu6e",
+					},
+				},
+				InputRefs: []ProfileConfigInputRef{},
+			},
+		},
 		"spectrum": {
 			Name:          "spectrum",
 			Type:          ProfileTypeSpectrum,

--- a/internal/config/profiles_test.go
+++ b/internal/config/profiles_test.go
@@ -1,0 +1,50 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMainnetCSwapProfileIsWired(t *testing.T) {
+	t.Parallel()
+
+	mainnetProfiles, ok := Profiles["mainnet"]
+	if !ok {
+		t.Fatal("missing mainnet profiles")
+	}
+
+	profile, ok := mainnetProfiles["cswap"]
+	if !ok {
+		t.Fatal("missing cswap profile")
+	}
+
+	if profile.Type != ProfileTypeOracle {
+		t.Fatalf("unexpected profile type: got %v want %v", profile.Type, ProfileTypeOracle)
+	}
+	if profile.InterceptSlot == 0 {
+		t.Fatal("cswap intercept slot must be non-zero")
+	}
+	if len(profile.InterceptHash) != 64 {
+		t.Fatalf("unexpected intercept hash length: got %d want 64", len(profile.InterceptHash))
+	}
+
+	oracleCfg, ok := profile.Config.(OracleProfileConfig)
+	if !ok {
+		t.Fatalf("unexpected config type: %T", profile.Config)
+	}
+	if oracleCfg.Protocol != "cswap" {
+		t.Fatalf("unexpected protocol: got %q want %q", oracleCfg.Protocol, "cswap")
+	}
+	if len(oracleCfg.PoolAddresses) == 0 {
+		t.Fatal("cswap pool addresses must not be empty")
+	}
+
+	for i, poolAddress := range oracleCfg.PoolAddresses {
+		if poolAddress.Address == "" {
+			t.Fatalf("pool address %d must not be empty", i)
+		}
+		if !strings.HasPrefix(poolAddress.Address, "addr1") {
+			t.Fatalf("pool address %d has unexpected format: %q", i, poolAddress.Address)
+		}
+	}
+}

--- a/internal/oracle/cswap.go
+++ b/internal/oracle/cswap.go
@@ -1,0 +1,71 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oracle
+
+import (
+	"time"
+
+	"github.com/blinklabs-io/shai/internal/oracle/cswap"
+)
+
+// CSwapParser wraps cswap.Parser to implement oracle.PoolParser.
+type CSwapParser struct {
+	parser *cswap.Parser
+}
+
+// NewCSwapParser creates a parser for CSWAP pools.
+func NewCSwapParser() *CSwapParser {
+	return &CSwapParser{parser: cswap.NewParser()}
+}
+
+// Protocol returns the protocol name.
+func (p *CSwapParser) Protocol() string {
+	return p.parser.Protocol()
+}
+
+// ParsePoolDatum parses a CSWAP pool datum.
+func (p *CSwapParser) ParsePoolDatum(
+	datum []byte,
+	utxoValue []byte,
+	txHash string,
+	txIndex uint32,
+	slot uint64,
+	timestamp time.Time,
+) (*PoolState, error) {
+	state, err := p.parser.ParsePoolDatum(
+		datum,
+		utxoValue,
+		txHash,
+		txIndex,
+		slot,
+		timestamp,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &PoolState{
+		PoolId:    state.PoolId,
+		Protocol:  state.Protocol,
+		AssetX:    state.AssetX,
+		AssetY:    state.AssetY,
+		FeeNum:    state.FeeNum,
+		FeeDenom:  state.FeeDenom,
+		Slot:      state.Slot,
+		TxHash:    state.TxHash,
+		TxIndex:   state.TxIndex,
+		Timestamp: state.Timestamp,
+	}, nil
+}

--- a/internal/oracle/cswap/models.go
+++ b/internal/oracle/cswap/models.go
@@ -1,0 +1,78 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cswap provides datum types and parsing for the CSWAP DEX protocol.
+package cswap
+
+import (
+	"fmt"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/shai/internal/common"
+)
+
+const (
+	ProtocolName = "cswap"
+	FeeDenom     = 10000
+)
+
+// PoolDatum is the on-chain pool datum defined in the Cardano datum registry.
+type PoolDatum struct {
+	cbor.StructAsArray
+	cbor.DecodeStoreCbor
+	TotalLpTokens uint64
+	PoolFee       uint64
+	QuotePolicy   []byte
+	QuoteName     []byte
+	BasePolicy    []byte
+	BaseName      []byte
+	LPTokenPolicy []byte
+	LPTokenName   []byte
+}
+
+func (d *PoolDatum) UnmarshalCBOR(cborData []byte) error {
+	var tmpConstr cbor.Constructor
+	if _, err := cbor.Decode(cborData, &tmpConstr); err != nil {
+		return err
+	}
+	if tmpConstr.Constructor() != 0 {
+		return fmt.Errorf(
+			"expected constructor 0, got %d",
+			tmpConstr.Constructor(),
+		)
+	}
+
+	type tPoolDatum PoolDatum
+	var tmp tPoolDatum
+	if _, err := cbor.Decode(tmpConstr.FieldsCbor(), &tmp); err != nil {
+		return err
+	}
+	*d = PoolDatum(tmp)
+	d.SetCbor(cborData)
+	return nil
+}
+
+func (d PoolDatum) QuoteAsset() common.AssetClass {
+	return common.AssetClass{
+		PolicyId: d.QuotePolicy,
+		Name:     d.QuoteName,
+	}
+}
+
+func (d PoolDatum) BaseAsset() common.AssetClass {
+	return common.AssetClass{
+		PolicyId: d.BasePolicy,
+		Name:     d.BaseName,
+	}
+}

--- a/internal/oracle/cswap/parser.go
+++ b/internal/oracle/cswap/parser.go
@@ -1,0 +1,192 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cswap
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/shai/internal/common"
+)
+
+// PoolState represents the state of a CSWAP liquidity pool.
+type PoolState struct {
+	PoolId    string
+	Protocol  string
+	AssetX    common.AssetAmount
+	AssetY    common.AssetAmount
+	FeeNum    uint64
+	FeeDenom  uint64
+	Slot      uint64
+	TxHash    string
+	TxIndex   uint32
+	Timestamp time.Time
+}
+
+// Parser implements pool parsing for CSWAP pools.
+type Parser struct{}
+
+// NewParser creates a parser for CSWAP pools.
+func NewParser() *Parser {
+	return &Parser{}
+}
+
+// Protocol returns the protocol name.
+func (p *Parser) Protocol() string {
+	return ProtocolName
+}
+
+// ParsePoolDatum parses a CSWAP pool datum and extracts reserves from utxoValue.
+func (p *Parser) ParsePoolDatum(
+	datum []byte,
+	utxoValue []byte,
+	txHash string,
+	txIndex uint32,
+	slot uint64,
+	timestamp time.Time,
+) (*PoolState, error) {
+	var poolDatum PoolDatum
+	if _, err := cbor.Decode(datum, &poolDatum); err != nil {
+		return nil, fmt.Errorf("failed to decode CSWAP datum: %w", err)
+	}
+
+	if poolDatum.PoolFee > FeeDenom {
+		return nil, fmt.Errorf(
+			"invalid fee: pool_fee %d exceeds denominator %d",
+			poolDatum.PoolFee,
+			FeeDenom,
+		)
+	}
+
+	reserveQuote, reserveBase, err := p.extractReservesFromValue(utxoValue, poolDatum)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract reserves: %w", err)
+	}
+
+	return &PoolState{
+		PoolId:   GeneratePoolId(poolDatum.LPTokenPolicy, poolDatum.LPTokenName),
+		Protocol: p.Protocol(),
+		AssetX: common.AssetAmount{
+			Class:  poolDatum.QuoteAsset(),
+			Amount: reserveQuote,
+		},
+		AssetY: common.AssetAmount{
+			Class:  poolDatum.BaseAsset(),
+			Amount: reserveBase,
+		},
+		FeeNum:    FeeDenom - poolDatum.PoolFee,
+		FeeDenom:  FeeDenom,
+		Slot:      slot,
+		TxHash:    txHash,
+		TxIndex:   txIndex,
+		Timestamp: timestamp,
+	}, nil
+}
+
+func (p *Parser) extractReservesFromValue(
+	utxoValue []byte,
+	poolDatum PoolDatum,
+) (uint64, uint64, error) {
+	txOut, err := ledger.NewTransactionOutputFromCbor(utxoValue)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to decode UTxO output: %w", err)
+	}
+
+	quoteAmount, err := p.getAssetAmount(
+		txOut,
+		poolDatum.QuotePolicy,
+		poolDatum.QuoteName,
+	)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to get quote reserve: %w", err)
+	}
+
+	baseAmount, err := p.getAssetAmount(
+		txOut,
+		poolDatum.BasePolicy,
+		poolDatum.BaseName,
+	)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to get base reserve: %w", err)
+	}
+
+	return quoteAmount, baseAmount, nil
+}
+
+func (p *Parser) getAssetAmount(
+	txOut lcommon.TransactionOutput,
+	policyID []byte,
+	assetName []byte,
+) (uint64, error) {
+	if len(policyID) == 0 {
+		if len(assetName) != 0 {
+			return 0, fmt.Errorf(
+				"malformed asset: empty policy with non-empty asset name %x",
+				assetName,
+			)
+		}
+		return txOut.Amount().Uint64(), nil
+	}
+
+	assets := txOut.Assets()
+	if assets == nil {
+		return 0, fmt.Errorf(
+			"no native assets in UTxO for policy %x",
+			policyID,
+		)
+	}
+
+	var policyHash lcommon.Blake2b224
+	if len(policyID) != len(policyHash) {
+		return 0, fmt.Errorf(
+			"invalid policy ID length: expected %d, got %d",
+			len(policyHash),
+			len(policyID),
+		)
+	}
+	copy(policyHash[:], policyID)
+
+	for _, policy := range assets.Policies() {
+		if policy != policyHash {
+			continue
+		}
+		for _, name := range assets.Assets(policy) {
+			if bytes.Equal(name, assetName) {
+				return assets.Asset(policy, name).Uint64(), nil
+			}
+		}
+	}
+
+	return 0, fmt.Errorf(
+		"asset not found: policy=%x, name=%x",
+		policyID,
+		assetName,
+	)
+}
+
+// GeneratePoolId generates a deterministic pool ID from the LP token asset.
+func GeneratePoolId(lpPolicy []byte, lpName []byte) string {
+	return fmt.Sprintf(
+		"%s_%s.%s",
+		ProtocolName,
+		hex.EncodeToString(lpPolicy),
+		hex.EncodeToString(lpName),
+	)
+}

--- a/internal/oracle/cswap_test.go
+++ b/internal/oracle/cswap_test.go
@@ -1,0 +1,254 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oracle
+
+import (
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger/babbage"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/mary"
+	cswappkg "github.com/blinklabs-io/shai/internal/oracle/cswap"
+)
+
+func TestNewCSwapParser(t *testing.T) {
+	parser := NewCSwapParser()
+	if parser == nil {
+		t.Fatal("expected non-nil parser")
+	}
+	if parser.Protocol() != "cswap" {
+		t.Fatalf("expected protocol cswap, got %s", parser.Protocol())
+	}
+}
+
+func TestCSwapPoolDatumUnmarshal(t *testing.T) {
+	datum := newCSwapPoolDatum(
+		t,
+		uint64(123456),
+		uint64(30),
+		nil,
+		nil,
+		mustSizedBytes(28, 0x11),
+		[]byte("CSWAP"),
+		mustSizedBytes(28, 0x22),
+		[]byte("LP"),
+	)
+
+	var poolDatum cswappkg.PoolDatum
+	if _, err := cbor.Decode(datum, &poolDatum); err != nil {
+		t.Fatalf("failed to decode pool datum: %v", err)
+	}
+
+	if poolDatum.TotalLpTokens != 123456 {
+		t.Fatalf("expected total LP tokens 123456, got %d", poolDatum.TotalLpTokens)
+	}
+	if poolDatum.PoolFee != 30 {
+		t.Fatalf("expected pool fee 30, got %d", poolDatum.PoolFee)
+	}
+	if string(poolDatum.BaseName) != "CSWAP" {
+		t.Fatalf("expected base asset name CSWAP, got %q", string(poolDatum.BaseName))
+	}
+}
+
+func TestCSwapParserParsePoolDatum(t *testing.T) {
+	quotePolicy := []byte{}
+	quoteName := []byte{}
+	basePolicy := mustSizedBytes(28, 0x11)
+	baseName := []byte("CSWAP")
+	lpPolicy := mustSizedBytes(28, 0x22)
+	lpName := []byte("LP")
+
+	datum := newCSwapPoolDatum(
+		t,
+		uint64(555000),
+		uint64(30),
+		quotePolicy,
+		quoteName,
+		basePolicy,
+		baseName,
+		lpPolicy,
+		lpName,
+	)
+	utxoValue := newBabbageOutputValue(
+		t,
+		75_000_000,
+		[]assetAmount{
+			{policy: basePolicy, name: baseName, amount: 250_000_000},
+			{policy: lpPolicy, name: lpName, amount: 555_000},
+		},
+	)
+
+	parser := NewCSwapParser()
+	state, err := parser.ParsePoolDatum(
+		datum,
+		utxoValue,
+		"abc123",
+		1,
+		12345,
+		time.Unix(1700000000, 0).UTC(),
+	)
+	if err != nil {
+		t.Fatalf("failed to parse CSWAP datum: %v", err)
+	}
+
+	if state.Protocol != "cswap" {
+		t.Fatalf("expected protocol cswap, got %s", state.Protocol)
+	}
+	expectedPoolID := "cswap_22222222222222222222222222222222222222222222222222222222.4c50"
+	if state.PoolId != expectedPoolID {
+		t.Fatalf("expected pool ID %s, got %s", expectedPoolID, state.PoolId)
+	}
+	if state.AssetX.Amount != 75_000_000 {
+		t.Fatalf("expected quote reserve 75000000, got %d", state.AssetX.Amount)
+	}
+	if state.AssetY.Amount != 250_000_000 {
+		t.Fatalf("expected base reserve 250000000, got %d", state.AssetY.Amount)
+	}
+	if state.FeeNum != 9970 {
+		t.Fatalf("expected effective fee numerator 9970, got %d", state.FeeNum)
+	}
+	if state.FeeDenom != 10000 {
+		t.Fatalf("expected fee denominator 10000, got %d", state.FeeDenom)
+	}
+	if got := state.PriceXY(); got != (250_000_000.0 / 75_000_000.0) {
+		t.Fatalf("unexpected priceXY %f", got)
+	}
+}
+
+func TestCSwapParserRejectsMalformedLovelaceAsset(t *testing.T) {
+	datum := newCSwapPoolDatum(
+		t,
+		uint64(1),
+		uint64(30),
+		nil,
+		[]byte("bad"),
+		mustSizedBytes(28, 0x11),
+		[]byte("CSWAP"),
+		mustSizedBytes(28, 0x22),
+		[]byte("LP"),
+	)
+	utxoValue := newBabbageOutputValue(
+		t,
+		1_000_000,
+		[]assetAmount{
+			{policy: mustSizedBytes(28, 0x11), name: []byte("CSWAP"), amount: 1},
+		},
+	)
+
+	parser := NewCSwapParser()
+	_, err := parser.ParsePoolDatum(
+		datum,
+		utxoValue,
+		"abc123",
+		0,
+		1,
+		time.Now(),
+	)
+	if err == nil {
+		t.Fatal("expected malformed lovelace asset error")
+	}
+}
+
+type assetAmount struct {
+	policy []byte
+	name   []byte
+	amount uint64
+}
+
+func newCSwapPoolDatum(
+	t *testing.T,
+	totalLP uint64,
+	poolFee uint64,
+	quotePolicy []byte,
+	quoteName []byte,
+	basePolicy []byte,
+	baseName []byte,
+	lpPolicy []byte,
+	lpName []byte,
+) []byte {
+	t.Helper()
+
+	datum := cbor.NewConstructor(0, cbor.IndefLengthList{
+		totalLP,
+		poolFee,
+		quotePolicy,
+		quoteName,
+		basePolicy,
+		baseName,
+		lpPolicy,
+		lpName,
+	})
+	data, err := cbor.Encode(&datum)
+	if err != nil {
+		t.Fatalf("failed to encode pool datum: %v", err)
+	}
+	return data
+}
+
+func newBabbageOutputValue(
+	t *testing.T,
+	lovelace uint64,
+	assets []assetAmount,
+) []byte {
+	t.Helper()
+
+	address, err := lcommon.NewAddressFromParts(
+		lcommon.AddressTypeKeyNone,
+		lcommon.AddressNetworkMainnet,
+		mustSizedBytes(28, 0x99),
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("failed to build test address: %v", err)
+	}
+
+	var multiAsset *lcommon.MultiAsset[lcommon.MultiAssetTypeOutput]
+	if len(assets) > 0 {
+		multiAssetData := make(map[lcommon.Blake2b224]map[cbor.ByteString]*big.Int)
+		for _, asset := range assets {
+			policy := lcommon.NewBlake2b224(asset.policy)
+			if _, ok := multiAssetData[policy]; !ok {
+				multiAssetData[policy] = make(map[cbor.ByteString]*big.Int)
+			}
+			multiAssetData[policy][cbor.NewByteString(asset.name)] = new(big.Int).SetUint64(asset.amount)
+		}
+		tmp := lcommon.NewMultiAsset[lcommon.MultiAssetTypeOutput](multiAssetData)
+		multiAsset = &tmp
+	}
+
+	txOut := babbage.BabbageTransactionOutput{
+		OutputAddress: address,
+		OutputAmount: mary.MaryTransactionOutputValue{
+			Amount: lovelace,
+			Assets: multiAsset,
+		},
+	}
+	data, err := cbor.Encode(&txOut)
+	if err != nil {
+		t.Fatalf("failed to encode output value: %v", err)
+	}
+	return data
+}
+
+func mustSizedBytes(size int, fill byte) []byte {
+	ret := make([]byte, size)
+	for i := range ret {
+		ret[i] = fill
+	}
+	return ret
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add CSWAP DEX support to the oracle so Shai can track CSWAP liquidity pools on mainnet. Enable it by adding the `cswap` profile; it's wired to the verified pool script and uses CRFA/CSWAP registry data.

- **New Features**
  - Implemented `cswap` parser and models: decodes pool datum, extracts reserves from UTxO, generates deterministic pool IDs, fee denominator 10000.
  - Added mainnet `cswap` oracle profile (intercept slot/hash + verified pool script address) and wired parser selection in `cmd/shai/main.go`.
  - Updated README with `cswap` usage and data source notes; added tests for datum parsing, reserve extraction (including malformed lovelace cases), and mainnet profile wiring.

<sup>Written for commit 375d6bfea58537fd03acc2c0383de8158be071ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CSWAP oracle profile support, wired to a verified mainnet DEX pool

* **Documentation**
  * Updated supported oracle profiles documentation to include CSWAP

* **Tests**
  * Added unit tests verifying CSWAP profile wiring and parser behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->