### PR TITLE
ci: configure gha workflow permissions

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -5,6 +5,9 @@ on:
     branches: ['main']
     paths: ['Dockerfile','*.go','go.*','.github/workflows/ci-docker.yml']
 
+permissions:
+  contents: read
+
 env:
   GHCR_IMAGE_NAME: ghcr.io/blinklabs-io/shai
 

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -6,12 +6,15 @@ name: Conventional Commits
 on:
   pull_request:
 
+permissions: {}
+
 jobs:
   build:
     name: Conventional Commits
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: webiny/action-conventional-commits@d13e2e7762992979ec06e9b5b7c7d24af1d7d7fd # v1.4.2

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -8,6 +8,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   go-test:
     name: go-test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,8 @@ on:
 
 concurrency: ${{ github.ref }}
 
+permissions: {}
+
 jobs:
   create-draft-release:
     runs-on: ubuntu-latest
@@ -46,6 +48,8 @@ jobs:
         os: [linux]
         arch: [amd64, arm64]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     needs: [create-draft-release]
     steps:
       - run: "echo \"RELEASE_TAG=${GITHUB_REF#refs/tags/}\" >> $GITHUB_ENV"
@@ -71,6 +75,9 @@ jobs:
 
   build-images:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     needs: [create-draft-release]
     steps:
       - run: "echo \"RELEASE_TAG=${GITHUB_REF#refs/tags/}\" >> $GITHUB_ENV"


### PR DESCRIPTION
Closes: #261 

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Set explicit, least-privilege permissions across GitHub Actions workflows. Improves CI security and ensures publish jobs have the write scopes they need.

- **Refactors**
  - `ci-docker.yml` and `go-test.yml`: set `permissions: { contents: read }` at workflow level.
  - `conventional-commits.yml`: set `permissions: {}` at workflow level; job now has `contents: read` and `pull-requests: read`.
  - `publish.yml`: set `permissions: {}` at workflow level; grant `contents: write` to the release artifacts job; grant `contents: read` and `packages: write` to the image build job.

<sup>Written for commit ee4b25352cc1fffa0082efe2f5ef565e7f4c24d3. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/shai/pull/295?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

