### PR TITLE
feat: mempool state tracking

### DIFF
--- a/internal/oracle/mempool.go
+++ b/internal/oracle/mempool.go
@@ -1,0 +1,387 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Mempool state tracking with per-transaction granularity.
+//
+// This module tracks the effect of each mempool transaction individually,
+// enabling analysis scenarios such as price-impact estimation and selective
+// transaction ordering. Each pending transaction is recorded as a discrete
+// effect (the delta it would apply to the confirmed pool state), preserving
+// the order in which transactions were observed.
+
+package oracle
+
+import (
+	"math"
+	"sync"
+	"time"
+)
+
+// MempoolTxEffect represents the effect of a single mempool transaction on a
+// pool. It captures the signed delta (change) relative to the confirmed state,
+// allowing for selective application of transactions in any order.
+type MempoolTxEffect struct {
+	TxHash    string    `json:"txHash"`
+	PoolId    string    `json:"poolId"`
+	Protocol  string    `json:"protocol"`
+	Timestamp time.Time `json:"timestamp"`
+
+	// Delta values are signed to allow for both additions and subtractions.
+	// They represent the CHANGE from the confirmed state, not absolute values.
+	DeltaX int64 `json:"deltaX"`
+	DeltaY int64 `json:"deltaY"`
+
+	// ResultingPriceXY is the price of X in terms of Y if this transaction
+	// were applied alone to the confirmed state.
+	ResultingPriceXY float64 `json:"resultingPriceXY"`
+}
+
+// PriceImpact returns the price change percentage this transaction causes
+// relative to the given confirmed price. Returns 0 when confirmedPrice is 0.
+func (e *MempoolTxEffect) PriceImpact(confirmedPrice float64) float64 {
+	if confirmedPrice == 0 {
+		return 0
+	}
+	return (e.ResultingPriceXY - confirmedPrice) / confirmedPrice * 100
+}
+
+// MempoolPoolState tracks the confirmed state and all pending mempool effects
+// for a single pool. It is safe for concurrent use.
+type MempoolPoolState struct {
+	mu sync.RWMutex
+
+	poolId   string
+	protocol string
+
+	// confirmedState is the last confirmed on-chain state.
+	confirmedState *PoolState
+
+	// pendingTxs holds per-transaction effects, indexed by tx hash.
+	pendingTxs map[string]*MempoolTxEffect
+
+	// txOrder preserves the order in which transactions were observed.
+	txOrder []string
+}
+
+// NewMempoolPoolState creates a new mempool state tracker for a pool.
+func NewMempoolPoolState(
+	poolId, protocol string,
+	confirmed *PoolState,
+) *MempoolPoolState {
+	return &MempoolPoolState{
+		poolId:         poolId,
+		protocol:       protocol,
+		confirmedState: clonePoolState(confirmed),
+		pendingTxs:     make(map[string]*MempoolTxEffect),
+		txOrder:        make([]string, 0),
+	}
+}
+
+// AddPendingTx records the effect of a pending mempool transaction relative to
+// the confirmed state. If a transaction with the same hash already exists, the
+// existing effect is returned unchanged. The returned effect is a copy; nil
+// newState inputs are ignored and return nil.
+func (m *MempoolPoolState) AddPendingTx(
+	txHash string,
+	newState *PoolState,
+) *MempoolTxEffect {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if existing, ok := m.pendingTxs[txHash]; ok {
+		return cloneMempoolTxEffect(existing)
+	}
+	if newState == nil {
+		return nil
+	}
+
+	effect := &MempoolTxEffect{
+		TxHash:           txHash,
+		PoolId:           m.poolId,
+		Protocol:         m.protocol,
+		Timestamp:        time.Now(),
+		ResultingPriceXY: newState.PriceXY(),
+	}
+	oldX, oldY := poolReserves(m.confirmedState)
+	effect.DeltaX = reserveDelta(newState.AssetX.Amount, oldX)
+	effect.DeltaY = reserveDelta(newState.AssetY.Amount, oldY)
+
+	m.pendingTxs[txHash] = effect
+	m.txOrder = append(m.txOrder, txHash)
+	return cloneMempoolTxEffect(effect)
+}
+
+// RemovePendingTx removes a pending transaction by hash. Removing a hash that
+// does not exist is a no-op.
+func (m *MempoolPoolState) RemovePendingTx(txHash string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.removePendingTxLocked(txHash)
+}
+
+// removePendingTxLocked removes a pending transaction. Caller must hold m.mu.
+func (m *MempoolPoolState) removePendingTxLocked(txHash string) {
+	if _, ok := m.pendingTxs[txHash]; !ok {
+		return
+	}
+	delete(m.pendingTxs, txHash)
+	for i, h := range m.txOrder {
+		if h == txHash {
+			m.txOrder = append(m.txOrder[:i], m.txOrder[i+1:]...)
+			break
+		}
+	}
+}
+
+// PendingCount returns the number of pending transactions tracked for the pool.
+func (m *MempoolPoolState) PendingCount() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return len(m.pendingTxs)
+}
+
+// SetConfirmedState updates the confirmed on-chain state and drops any pending
+// transaction whose hash now matches the confirmed transaction. Remaining
+// pending effects are rebased so their deltas stay relative to the new
+// confirmed state.
+func (m *MempoolPoolState) SetConfirmedState(newConfirmed *PoolState) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	oldX, oldY := poolReserves(m.confirmedState)
+	newX, newY := poolReserves(newConfirmed)
+
+	m.confirmedState = clonePoolState(newConfirmed)
+	if newConfirmed != nil {
+		m.removePendingTxLocked(newConfirmed.TxHash)
+	}
+
+	// A pending effect's absolute resulting reserves are fixed at
+	// (oldConfirmed + oldDelta). Shifting each delta by (old - new) keeps those
+	// resulting reserves constant while making the delta reflect the change from
+	// the new confirmed state instead of the stale previous one.
+	shiftX := reserveDelta(oldX, newX)
+	shiftY := reserveDelta(oldY, newY)
+	if shiftX == 0 && shiftY == 0 {
+		return
+	}
+	for _, effect := range m.pendingTxs {
+		effect.DeltaX = addDeltaSaturating(effect.DeltaX, shiftX)
+		effect.DeltaY = addDeltaSaturating(effect.DeltaY, shiftY)
+	}
+}
+
+// poolReserves returns the X and Y reserve amounts of a pool state, treating a
+// nil state as empty (zero) reserves.
+func poolReserves(state *PoolState) (x, y uint64) {
+	if state == nil {
+		return 0, 0
+	}
+	return state.AssetX.Amount, state.AssetY.Amount
+}
+
+// reserveDelta returns newAmount - oldAmount as a signed int64. The true
+// difference between two uint64 reserves can fall outside the int64 range, so
+// rather than letting a uint64->int64 cast silently flip the sign, the result
+// saturates at the int64 bounds.
+func reserveDelta(newAmount, oldAmount uint64) int64 {
+	if newAmount >= oldAmount {
+		if diff := newAmount - oldAmount; diff <= math.MaxInt64 {
+			return int64(diff)
+		}
+		return math.MaxInt64
+	}
+	if diff := oldAmount - newAmount; diff <= math.MaxInt64 {
+		return -int64(diff)
+	}
+	return math.MinInt64
+}
+
+// addDeltaSaturating returns a + b clamped to the int64 range so that rebasing
+// an already-saturated delta cannot itself silently overflow.
+func addDeltaSaturating(a, b int64) int64 {
+	sum := a + b
+	switch {
+	case a > 0 && b > 0 && sum < 0:
+		return math.MaxInt64
+	case a < 0 && b < 0 && sum >= 0:
+		return math.MinInt64
+	default:
+		return sum
+	}
+}
+
+// GetConfirmedState returns a copy of the current confirmed on-chain state.
+func (m *MempoolPoolState) GetConfirmedState() *PoolState {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return clonePoolState(m.confirmedState)
+}
+
+// GetPendingTxs returns copies of the pending transaction effects in insertion
+// order.
+func (m *MempoolPoolState) GetPendingTxs() []*MempoolTxEffect {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	effects := make([]*MempoolTxEffect, 0, len(m.txOrder))
+	for _, h := range m.txOrder {
+		if effect, ok := m.pendingTxs[h]; ok {
+			effects = append(effects, cloneMempoolTxEffect(effect))
+		}
+	}
+	return effects
+}
+
+func cloneMempoolTxEffect(effect *MempoolTxEffect) *MempoolTxEffect {
+	if effect == nil {
+		return nil
+	}
+	clone := *effect
+	return &clone
+}
+
+// MempoolStateManager tracks mempool state across all pools. It is safe for
+// concurrent use.
+type MempoolStateManager struct {
+	mu    sync.RWMutex
+	pools map[string]*MempoolPoolState
+}
+
+// NewMempoolStateManager creates an empty mempool state manager.
+func NewMempoolStateManager() *MempoolStateManager {
+	return &MempoolStateManager{
+		pools: make(map[string]*MempoolPoolState),
+	}
+}
+
+// GetOrCreatePoolState returns the existing mempool state for a pool, creating
+// one seeded with the given confirmed state if it does not yet exist.
+func (mgr *MempoolStateManager) GetOrCreatePoolState(
+	poolId, protocol string,
+	confirmed *PoolState,
+) *MempoolPoolState {
+	mgr.mu.Lock()
+	defer mgr.mu.Unlock()
+
+	if ps, ok := mgr.pools[poolId]; ok {
+		return ps
+	}
+	ps := NewMempoolPoolState(poolId, protocol, confirmed)
+	mgr.pools[poolId] = ps
+	return ps
+}
+
+// GetPoolState returns the mempool state for a pool, if tracked.
+func (mgr *MempoolStateManager) GetPoolState(
+	poolId string,
+) (*MempoolPoolState, bool) {
+	mgr.mu.RLock()
+	defer mgr.mu.RUnlock()
+	ps, ok := mgr.pools[poolId]
+	if !ok || ps == nil {
+		return nil, false
+	}
+	return ps, ok
+}
+
+// PoolCount returns the number of pools currently tracked.
+func (mgr *MempoolStateManager) PoolCount() int {
+	mgr.mu.RLock()
+	defer mgr.mu.RUnlock()
+	return len(mgr.pools)
+}
+
+// AddPendingTx records a pending transaction's effect for the given pool,
+// creating the pool's mempool state if necessary.
+func (mgr *MempoolStateManager) AddPendingTx(
+	poolId, protocol, txHash string,
+	newState *PoolState,
+) *MempoolTxEffect {
+	if newState == nil {
+		mgr.mu.RLock()
+		ps, ok := mgr.pools[poolId]
+		mgr.mu.RUnlock()
+		if !ok {
+			return nil
+		}
+		return ps.AddPendingTx(txHash, nil)
+	}
+	ps := mgr.GetOrCreatePoolState(poolId, protocol, nil)
+	return ps.AddPendingTx(txHash, newState)
+}
+
+// RemovePendingTx removes a pending transaction by hash from every pool that
+// tracks it.
+func (mgr *MempoolStateManager) RemovePendingTx(txHash string) {
+	mgr.mu.RLock()
+	defer mgr.mu.RUnlock()
+	for _, ps := range mgr.pools {
+		ps.RemovePendingTx(txHash)
+	}
+}
+
+// TotalPendingTxs returns the total number of pending transactions across all
+// pools.
+func (mgr *MempoolStateManager) TotalPendingTxs() int {
+	mgr.mu.RLock()
+	defer mgr.mu.RUnlock()
+	total := 0
+	for _, ps := range mgr.pools {
+		total += ps.PendingCount()
+	}
+	return total
+}
+
+// GetPoolsAffectedByTx returns the IDs of pools that have the given
+// transaction hash pending.
+func (mgr *MempoolStateManager) GetPoolsAffectedByTx(txHash string) []string {
+	mgr.mu.RLock()
+	defer mgr.mu.RUnlock()
+
+	var affected []string
+	for poolId, ps := range mgr.pools {
+		ps.mu.RLock()
+		_, ok := ps.pendingTxs[txHash]
+		ps.mu.RUnlock()
+		if ok {
+			affected = append(affected, poolId)
+		}
+	}
+	return affected
+}
+
+// RemovePoolState removes all mempool tracking for a pool, including its
+// confirmed state and any pending transaction effects. Removing a pool that is
+// not tracked is a no-op. This is used on rollback to discard reorged state so
+// it is neither served to consumers nor used to seed future pending-tx deltas.
+func (mgr *MempoolStateManager) RemovePoolState(poolId string) {
+	mgr.mu.Lock()
+	defer mgr.mu.Unlock()
+	delete(mgr.pools, poolId)
+}
+
+// UpdateConfirmedState updates the confirmed state for a pool, creating the
+// pool's mempool state if necessary. Any pending transaction matching the
+// confirmed transaction hash is dropped.
+func (mgr *MempoolStateManager) UpdateConfirmedState(
+	poolId string,
+	state *PoolState,
+) {
+	if state == nil {
+		return
+	}
+	ps := mgr.GetOrCreatePoolState(poolId, state.Protocol, state)
+	ps.SetConfirmedState(state)
+}

--- a/internal/oracle/mempool_test.go
+++ b/internal/oracle/mempool_test.go
@@ -1,0 +1,429 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oracle
+
+import (
+	"math"
+	"testing"
+
+	"github.com/blinklabs-io/shai/internal/common"
+)
+
+func TestMempoolPoolState_AddPendingTx(t *testing.T) {
+	confirmed := &PoolState{
+		PoolId:   "pool1",
+		Protocol: "test",
+		AssetX:   common.AssetAmount{Amount: 1000},
+		AssetY:   common.AssetAmount{Amount: 2000},
+	}
+	mps := NewMempoolPoolState("pool1", "test", confirmed)
+	newState := &PoolState{
+		PoolId:   "pool1",
+		Protocol: "test",
+		TxHash:   "tx1",
+		AssetX:   common.AssetAmount{Amount: 1100},
+		AssetY:   common.AssetAmount{Amount: 1900},
+	}
+	effect := mps.AddPendingTx("tx1", newState)
+	if effect == nil {
+		t.Fatal("expected non-nil effect")
+	}
+	if effect.DeltaX != 100 {
+		t.Errorf("expected deltaX=100, got %d", effect.DeltaX)
+	}
+	if effect.DeltaY != -100 {
+		t.Errorf("expected deltaY=-100, got %d", effect.DeltaY)
+	}
+	if mps.PendingCount() != 1 {
+		t.Errorf("expected 1 pending, got %d", mps.PendingCount())
+	}
+}
+
+func TestMempoolPoolState_DuplicateTx(t *testing.T) {
+	mps := NewMempoolPoolState("pool1", "test", &PoolState{})
+	state := &PoolState{TxHash: "tx1"}
+	effect1 := mps.AddPendingTx("tx1", state)
+	effect2 := mps.AddPendingTx("tx1", state)
+	if effect1 == nil || effect2 == nil {
+		t.Fatal("expected non-nil effects")
+	}
+	if effect1 == effect2 {
+		t.Error("expected duplicate tx result to be returned as a copy")
+	}
+	if effect1.TxHash != effect2.TxHash ||
+		effect1.Timestamp != effect2.Timestamp ||
+		effect1.DeltaX != effect2.DeltaX ||
+		effect1.DeltaY != effect2.DeltaY {
+		t.Error("expected duplicate tx to return the existing effect values")
+	}
+	if mps.PendingCount() != 1 {
+		t.Errorf("expected 1 pending, got %d", mps.PendingCount())
+	}
+}
+
+func TestMempoolPoolState_AddPendingTxNilState(t *testing.T) {
+	mps := NewMempoolPoolState("pool1", "test", &PoolState{})
+	if effect := mps.AddPendingTx("tx1", nil); effect != nil {
+		t.Fatalf("expected nil effect for nil state, got %#v", effect)
+	}
+	if mps.PendingCount() != 0 {
+		t.Fatalf("expected no pending tx for nil state, got %d", mps.PendingCount())
+	}
+}
+
+func TestMempoolStateManager_AddPendingTxNilStateDoesNotCreatePool(
+	t *testing.T,
+) {
+	mgr := NewMempoolStateManager()
+	if effect := mgr.AddPendingTx("pool1", "test", "tx1", nil); effect != nil {
+		t.Fatalf("expected nil effect for nil state, got %#v", effect)
+	}
+	if mgr.PoolCount() != 0 {
+		t.Fatalf("expected no tracked pool for nil state, got %d", mgr.PoolCount())
+	}
+}
+
+func TestMempoolPoolState_RemovePendingTx(t *testing.T) {
+	mps := NewMempoolPoolState("pool1", "test", &PoolState{})
+	mps.AddPendingTx("tx1", &PoolState{TxHash: "tx1"})
+	mps.AddPendingTx("tx2", &PoolState{TxHash: "tx2"})
+	mps.RemovePendingTx("tx1")
+	if mps.PendingCount() != 1 {
+		t.Errorf("expected 1 pending after remove, got %d", mps.PendingCount())
+	}
+	mps.RemovePendingTx("nonexistent")
+}
+
+func TestMempoolPoolState_SetConfirmedState(t *testing.T) {
+	confirmed := &PoolState{TxHash: "confirmed1"}
+	mps := NewMempoolPoolState("pool1", "test", confirmed)
+	mps.AddPendingTx("tx1", &PoolState{TxHash: "tx1"})
+	newConfirmed := &PoolState{TxHash: "tx1"}
+	mps.SetConfirmedState(newConfirmed)
+	if mps.PendingCount() != 0 {
+		t.Errorf("expected 0 pending after confirm, got %d", mps.PendingCount())
+	}
+	confirmedState := mps.GetConfirmedState()
+	if confirmedState == nil {
+		t.Fatal("expected confirmed state")
+	}
+	if confirmedState == newConfirmed {
+		t.Error("expected confirmed state to be returned as a copy")
+	}
+	if confirmedState.TxHash != newConfirmed.TxHash {
+		t.Error("confirmed state not updated")
+	}
+}
+
+func TestMempoolPoolState_GetConfirmedStateReturnsCopy(t *testing.T) {
+	confirmed := &PoolState{
+		TxHash: "confirmed1",
+		AssetX: common.AssetAmount{
+			Class:  common.AssetClass{PolicyId: []byte{0x01}},
+			Amount: 1000,
+		},
+		AssetY: common.AssetAmount{
+			Class:  common.AssetClass{Name: []byte{0x02}},
+			Amount: 2000,
+		},
+	}
+	mps := NewMempoolPoolState("pool1", "test", confirmed)
+
+	confirmed.AssetX.Amount = 9999
+	confirmed.AssetX.Class.PolicyId[0] = 0xff
+
+	got := mps.GetConfirmedState()
+	if got == nil {
+		t.Fatal("expected confirmed state")
+	}
+	if got.AssetX.Amount != 1000 {
+		t.Fatalf("expected stored amount 1000, got %d", got.AssetX.Amount)
+	}
+	if got.AssetX.Class.PolicyId[0] != 0x01 {
+		t.Fatalf(
+			"expected stored policy id byte 0x01, got 0x%02x",
+			got.AssetX.Class.PolicyId[0],
+		)
+	}
+
+	got.AssetX.Amount = 42
+	got.AssetX.Class.PolicyId[0] = 0xee
+	gotAgain := mps.GetConfirmedState()
+	if gotAgain.AssetX.Amount != 1000 {
+		t.Fatalf(
+			"expected returned mutation not to change stored amount, got %d",
+			gotAgain.AssetX.Amount,
+		)
+	}
+	if gotAgain.AssetX.Class.PolicyId[0] != 0x01 {
+		t.Fatalf(
+			"expected returned mutation not to change stored policy id, got 0x%02x",
+			gotAgain.AssetX.Class.PolicyId[0],
+		)
+	}
+}
+
+func TestMempoolPoolState_SetConfirmedStateRebasesPendingDeltas(t *testing.T) {
+	confirmed := &PoolState{
+		TxHash: "confirmed0",
+		AssetX: common.AssetAmount{Amount: 1000},
+		AssetY: common.AssetAmount{Amount: 2000},
+	}
+	mps := NewMempoolPoolState("pool1", "test", confirmed)
+
+	// A pending tx whose resulting pool reserves would be X=1100, Y=1900.
+	pending := &PoolState{
+		TxHash: "txA",
+		AssetX: common.AssetAmount{Amount: 1100},
+		AssetY: common.AssetAmount{Amount: 1900},
+	}
+	effect := mps.AddPendingTx("txA", pending)
+	if effect == nil {
+		t.Fatal("expected pending effect")
+	}
+	if effect.DeltaX != 100 || effect.DeltaY != -100 {
+		t.Fatalf(
+			"baseline deltas wrong: got DeltaX=%d DeltaY=%d",
+			effect.DeltaX,
+			effect.DeltaY,
+		)
+	}
+	priceBefore := effect.ResultingPriceXY
+
+	// A *different* transaction confirms, moving the pool to X=1050, Y=1950.
+	newConfirmed := &PoolState{
+		TxHash: "confirmedB",
+		AssetX: common.AssetAmount{Amount: 1050},
+		AssetY: common.AssetAmount{Amount: 1950},
+	}
+	mps.SetConfirmedState(newConfirmed)
+
+	// txA is not the confirmed tx, so it must remain pending.
+	if mps.PendingCount() != 1 {
+		t.Fatalf("expected txA to remain pending, got %d", mps.PendingCount())
+	}
+
+	got := mps.GetPendingTxs()[0]
+	// Deltas must now be relative to the *new* confirmed state:
+	// 1100-1050 = 50, 1900-1950 = -50.
+	if got.DeltaX != 50 {
+		t.Errorf("expected rebased DeltaX=50, got %d", got.DeltaX)
+	}
+	if got.DeltaY != -50 {
+		t.Errorf("expected rebased DeltaY=-50, got %d", got.DeltaY)
+	}
+	// The tx's resulting reserves are fixed, so its absolute resulting price
+	// must be unchanged by a confirmed-state update.
+	if got.ResultingPriceXY != priceBefore {
+		t.Errorf(
+			"expected ResultingPriceXY unchanged (%v), got %v",
+			priceBefore,
+			got.ResultingPriceXY,
+		)
+	}
+	// Sanity: new confirmed reserves + rebased delta == original resulting
+	// reserves (X=1100).
+	if int64(newConfirmed.AssetX.Amount)+got.DeltaX != 1100 {
+		t.Errorf("rebased DeltaX inconsistent with resulting reserves")
+	}
+}
+
+func TestMempoolPoolState_AddPendingTxNoOverflowNilConfirmed(t *testing.T) {
+	// With no confirmed state, the delta is the absolute reserve. A reserve
+	// above math.MaxInt64 must not sign-flip via a uint64->int64 cast; it
+	// saturates to MaxInt64 instead.
+	mps := NewMempoolPoolState("pool1", "test", nil)
+	newState := &PoolState{
+		TxHash: "tx1",
+		AssetX: common.AssetAmount{Amount: math.MaxUint64},
+		AssetY: common.AssetAmount{Amount: uint64(math.MaxInt64) + 1},
+	}
+	effect := mps.AddPendingTx("tx1", newState)
+	if effect == nil {
+		t.Fatal("expected non-nil effect")
+	}
+	if effect.DeltaX != math.MaxInt64 {
+		t.Errorf("expected DeltaX saturated to MaxInt64, got %d", effect.DeltaX)
+	}
+	if effect.DeltaY != math.MaxInt64 {
+		t.Errorf("expected DeltaY saturated to MaxInt64, got %d", effect.DeltaY)
+	}
+}
+
+func TestMempoolPoolState_AddPendingTxNoOverflowLargeDelta(t *testing.T) {
+	confirmed := &PoolState{
+		AssetX: common.AssetAmount{Amount: 0},
+		AssetY: common.AssetAmount{Amount: math.MaxUint64},
+	}
+	mps := NewMempoolPoolState("pool1", "test", confirmed)
+	newState := &PoolState{
+		TxHash: "tx1",
+		// X grows from 0 to MaxUint64: a positive delta beyond int64 range.
+		AssetX: common.AssetAmount{Amount: math.MaxUint64},
+		// Y drains from MaxUint64 to 0: a negative delta beyond int64 range.
+		AssetY: common.AssetAmount{Amount: 0},
+	}
+	effect := mps.AddPendingTx("tx1", newState)
+	if effect == nil {
+		t.Fatal("expected non-nil effect")
+	}
+	if effect.DeltaX != math.MaxInt64 {
+		t.Errorf(
+			"expected DeltaX saturated to MaxInt64 (positive), got %d",
+			effect.DeltaX,
+		)
+	}
+	if effect.DeltaY != math.MinInt64 {
+		t.Errorf(
+			"expected DeltaY saturated to MinInt64 (negative), got %d",
+			effect.DeltaY,
+		)
+	}
+}
+
+func TestMempoolPoolState_SetConfirmedStateNoOverflowOnLargeShift(
+	t *testing.T,
+) {
+	confirmed := &PoolState{
+		TxHash: "c0",
+		AssetX: common.AssetAmount{Amount: math.MaxUint64},
+		AssetY: common.AssetAmount{Amount: 1000},
+	}
+	mps := NewMempoolPoolState("pool1", "test", confirmed)
+	// A pending tx that leaves X unchanged (delta 0) relative to confirmed.
+	mps.AddPendingTx("txA", &PoolState{
+		TxHash: "txA",
+		AssetX: common.AssetAmount{Amount: math.MaxUint64},
+		AssetY: common.AssetAmount{Amount: 1000},
+	})
+
+	// A different tx confirms, draining X from MaxUint64 down to 0. The shift
+	// (old - new) is a large positive value beyond int64 range. The rebased
+	// delta must move positive, never sign-flip negative.
+	mps.SetConfirmedState(&PoolState{
+		TxHash: "cB",
+		AssetX: common.AssetAmount{Amount: 0},
+		AssetY: common.AssetAmount{Amount: 1000},
+	})
+
+	got := mps.GetPendingTxs()
+	if len(got) != 1 {
+		t.Fatalf("expected 1 pending tx, got %d", len(got))
+	}
+	if got[0].DeltaX <= 0 {
+		t.Errorf(
+			"expected positive rebased DeltaX after large shift, got %d",
+			got[0].DeltaX,
+		)
+	}
+}
+
+func TestMempoolTxEffect_PriceImpact(t *testing.T) {
+	effect := &MempoolTxEffect{ResultingPriceXY: 1.1}
+	impact := effect.PriceImpact(1.0)
+	if impact < 9.9 || impact > 10.1 {
+		t.Errorf("expected ~10%% impact, got %.2f%%", impact)
+	}
+	if impact = effect.PriceImpact(0); impact != 0 {
+		t.Errorf("expected 0 impact for zero price, got %.2f", impact)
+	}
+}
+
+func TestMempoolPoolState_GetPendingTxsReturnsCopies(t *testing.T) {
+	mps := NewMempoolPoolState("pool1", "test", &PoolState{})
+	effect := mps.AddPendingTx("tx1", &PoolState{TxHash: "tx1"})
+	if effect == nil {
+		t.Fatal("expected effect")
+	}
+	effect.DeltaX = 12345
+
+	txs := mps.GetPendingTxs()
+	if len(txs) != 1 {
+		t.Fatalf("expected 1 pending tx, got %d", len(txs))
+	}
+	if txs[0].DeltaX == 12345 {
+		t.Fatal("AddPendingTx returned mutable internal effect")
+	}
+
+	txs[0].DeltaX = 999
+	txsAgain := mps.GetPendingTxs()
+	if len(txsAgain) != 1 {
+		t.Fatalf("expected 1 pending tx, got %d", len(txsAgain))
+	}
+	if txsAgain[0].DeltaX == 999 {
+		t.Fatal("GetPendingTxs returned mutable internal effect")
+	}
+}
+
+func TestMempoolStateManager_Basic(t *testing.T) {
+	mgr := NewMempoolStateManager()
+	confirmed := &PoolState{
+		PoolId:   "pool1",
+		Protocol: "test",
+		AssetX:   common.AssetAmount{Amount: 1000},
+		AssetY:   common.AssetAmount{Amount: 2000},
+	}
+	ps := mgr.GetOrCreatePoolState("pool1", "test", confirmed)
+	if ps == nil {
+		t.Fatal("expected non-nil pool state")
+	}
+	if mgr.PoolCount() != 1 {
+		t.Errorf("expected 1 pool, got %d", mgr.PoolCount())
+	}
+	newState := &PoolState{
+		PoolId:   "pool1",
+		Protocol: "test",
+		TxHash:   "tx1",
+		AssetX:   common.AssetAmount{Amount: 1100},
+		AssetY:   common.AssetAmount{Amount: 1900},
+	}
+	mgr.AddPendingTx("pool1", "test", "tx1", newState)
+	if mgr.TotalPendingTxs() != 1 {
+		t.Errorf("expected 1 pending tx, got %d", mgr.TotalPendingTxs())
+	}
+	affected := mgr.GetPoolsAffectedByTx("tx1")
+	if len(affected) != 1 || affected[0] != "pool1" {
+		t.Errorf("expected [pool1], got %v", affected)
+	}
+	mgr.RemovePendingTx("tx1")
+	if mgr.TotalPendingTxs() != 0 {
+		t.Errorf("expected 0 pending txs, got %d", mgr.TotalPendingTxs())
+	}
+}
+
+func TestMempoolStateManager_GetPendingTxOrder(t *testing.T) {
+	mgr := NewMempoolStateManager()
+	_ = mgr.GetOrCreatePoolState("pool1", "test", &PoolState{})
+	mgr.AddPendingTx("pool1", "test", "tx-a", &PoolState{TxHash: "tx-a"})
+	mgr.AddPendingTx("pool1", "test", "tx-b", &PoolState{TxHash: "tx-b"})
+	mgr.AddPendingTx("pool1", "test", "tx-c", &PoolState{TxHash: "tx-c"})
+	ps, ok := mgr.GetPoolState("pool1")
+	if !ok || ps == nil {
+		t.Fatal("expected pool1 to be tracked")
+	}
+	txs := ps.GetPendingTxs()
+	if len(txs) != 3 {
+		t.Fatalf("expected 3 pending txs, got %d", len(txs))
+	}
+	if txs[0].TxHash != "tx-a" || txs[1].TxHash != "tx-b" ||
+		txs[2].TxHash != "tx-c" {
+		t.Errorf(
+			"expected order [tx-a, tx-b, tx-c], got [%s, %s, %s]",
+			txs[0].TxHash,
+			txs[1].TxHash,
+			txs[2].TxHash,
+		)
+	}
+}

--- a/internal/oracle/models.go
+++ b/internal/oracle/models.go
@@ -40,6 +40,34 @@ type PoolState struct {
 	FromMempool bool               `json:"fromMempool"` // True if state is from mempool (unconfirmed)
 }
 
+func clonePoolState(state *PoolState) *PoolState {
+	if state == nil {
+		return nil
+	}
+	clone := *state
+	clone.AssetX = cloneAssetAmount(state.AssetX)
+	clone.AssetY = cloneAssetAmount(state.AssetY)
+	return &clone
+}
+
+func cloneAssetAmount(amount common.AssetAmount) common.AssetAmount {
+	amount.Class.PolicyId = cloneBytes(amount.Class.PolicyId)
+	amount.Class.Name = cloneBytes(amount.Class.Name)
+	return amount
+}
+
+func cloneBytes(src []byte) []byte {
+	if src == nil {
+		return nil
+	}
+	// Use make+copy rather than append([]byte(nil), src...): appending zero
+	// elements to a nil slice returns nil, which would normalize an empty
+	// (non-nil) slice to nil and change the serialized asset class.
+	dst := make([]byte, len(src))
+	copy(dst, src)
+	return dst
+}
+
 // PriceXY returns the price of X in terms of Y (Y per X)
 func (p *PoolState) PriceXY() float64 {
 	if p.AssetX.Amount == 0 {

--- a/internal/oracle/models_test.go
+++ b/internal/oracle/models_test.go
@@ -15,6 +15,7 @@
 package oracle
 
 import (
+	"bytes"
 	"encoding/json"
 	"testing"
 
@@ -88,6 +89,64 @@ func TestPoolStateKey(t *testing.T) {
 	expected := "mainnet:spectrum:pool123"
 	if state.Key() != expected {
 		t.Errorf("expected key %s, got %s", expected, state.Key())
+	}
+}
+
+func TestClonePoolStatePreservesEmptyAssetSlices(t *testing.T) {
+	state := &PoolState{
+		// Empty but non-nil slices (e.g. lovelace via NewAssetClass("", "")).
+		AssetX: common.AssetAmount{
+			Class: common.AssetClass{PolicyId: []byte{}, Name: []byte{}},
+		},
+		// Nil slices (e.g. lovelace via the zero-value AssetClass).
+		AssetY: common.AssetAmount{
+			Class: common.AssetClass{PolicyId: nil, Name: nil},
+		},
+	}
+
+	clone := clonePoolState(state)
+
+	if clone.AssetX.Class.PolicyId == nil {
+		t.Error("expected empty (non-nil) PolicyId to stay non-nil after clone")
+	}
+	if clone.AssetX.Class.Name == nil {
+		t.Error("expected empty (non-nil) Name to stay non-nil after clone")
+	}
+	if clone.AssetY.Class.PolicyId != nil {
+		t.Error("expected nil PolicyId to stay nil after clone")
+	}
+	if clone.AssetY.Class.Name != nil {
+		t.Error("expected nil Name to stay nil after clone")
+	}
+}
+
+func TestClonePoolStatePreservesSerializedState(t *testing.T) {
+	state := &PoolState{
+		PoolId: "pool1",
+		AssetX: common.AssetAmount{
+			Class:  common.AssetClass{PolicyId: []byte{}, Name: []byte{}},
+			Amount: 1000,
+		},
+		AssetY: common.AssetAmount{
+			Class:  common.AssetClass{PolicyId: []byte{}, Name: []byte{}},
+			Amount: 2000,
+		},
+	}
+
+	before, err := json.Marshal(state)
+	if err != nil {
+		t.Fatalf("marshal original: %v", err)
+	}
+	after, err := json.Marshal(clonePoolState(state))
+	if err != nil {
+		t.Fatalf("marshal clone: %v", err)
+	}
+	if !bytes.Equal(before, after) {
+		t.Errorf(
+			"clone changed serialized state:\n before: %s\n after:  %s",
+			before,
+			after,
+		)
 	}
 }
 

--- a/internal/oracle/oracle.go
+++ b/internal/oracle/oracle.go
@@ -46,6 +46,7 @@ type Oracle struct {
 	subMu         sync.RWMutex
 	stopped       bool
 	dropCount     atomic.Uint64
+	mempoolMgr    *MempoolStateManager
 }
 
 // New creates a new Oracle instance
@@ -61,6 +62,7 @@ func New(
 		pools:         make(map[string]*PoolState),
 		poolAddresses: make(map[string]struct{}),
 		stopChan:      make(chan struct{}),
+		mempoolMgr:    NewMempoolStateManager(),
 	}
 
 	// Extract pool addresses from profile config
@@ -287,6 +289,9 @@ func (o *Oracle) handleTransaction(
 		// Notify subscribers of price update
 		o.notifySubscribers(state, prevPrice)
 
+		// Update mempool manager's confirmed state for this pool
+		o.mempoolMgr.UpdateConfirmedState(state.PoolId, state)
+
 		// Persist to storage
 		if err := o.storage.SavePoolState(state); err != nil {
 			logger.Error(
@@ -332,6 +337,13 @@ func (o *Oracle) handleRollback(evt event.RollbackEvent) error {
 		delete(o.pools, state.PoolId)
 	}
 	o.poolsMu.Unlock()
+
+	// Invalidate mempool tracking for rolled-back pools. Otherwise the reorged
+	// confirmed state stays visible to consumers and seeds future pending-tx
+	// delta calculations with stale data.
+	for _, state := range toDelete {
+		o.mempoolMgr.RemovePoolState(state.PoolId)
+	}
 
 	// Delete from persistent storage
 	var errs []error
@@ -383,6 +395,13 @@ func (o *Oracle) loadPersistedStates() error {
 	}
 	o.poolsMu.Unlock()
 
+	if o.mempoolMgr == nil {
+		o.mempoolMgr = NewMempoolStateManager()
+	}
+	for _, state := range states {
+		o.mempoolMgr.UpdateConfirmedState(state.PoolId, state)
+	}
+
 	logger := logging.GetLogger()
 	logger.Info("loaded persisted pool states", "count", len(states))
 
@@ -416,6 +435,9 @@ func (o *Oracle) PoolCount() int {
 	defer o.poolsMu.RUnlock()
 	return len(o.pools)
 }
+
+// GetMempoolManager returns the mempool state manager.
+func (o *Oracle) GetMempoolManager() *MempoolStateManager { return o.mempoolMgr }
 
 // GetPrice returns the price of assetX in terms of assetY for a pool
 func (o *Oracle) GetPrice(poolId string) (float64, bool) {

--- a/internal/oracle/oracle_test.go
+++ b/internal/oracle/oracle_test.go
@@ -19,8 +19,130 @@ import (
 	"testing"
 	"time"
 
+	"github.com/blinklabs-io/adder/event"
 	"github.com/blinklabs-io/shai/internal/common"
 )
+
+func TestOracleRollbackClearsMempoolState(t *testing.T) {
+	o := &Oracle{
+		pools:      make(map[string]*PoolState),
+		stopChan:   make(chan struct{}),
+		storage:    newTestOracleStorage(t),
+		mempoolMgr: NewMempoolStateManager(),
+	}
+
+	// A confirmed pool state at slot 100, tracked in o.pools, storage, and the
+	// mempool manager (as handleTransaction would have done).
+	state := &PoolState{
+		PoolId:   "pool1",
+		Network:  "mainnet",
+		Protocol: "test",
+		TxHash:   "tx100",
+		Slot:     100,
+		AssetX:   common.AssetAmount{Amount: 1000},
+		AssetY:   common.AssetAmount{Amount: 2000},
+	}
+	o.pools[state.PoolId] = state
+	if err := o.storage.SavePoolState(state); err != nil {
+		t.Fatalf("failed to save pool state: %v", err)
+	}
+	o.mempoolMgr.UpdateConfirmedState(state.PoolId, state)
+	if o.mempoolMgr.PoolCount() != 1 {
+		t.Fatalf(
+			"expected mempool manager to track the pool, got %d",
+			o.mempoolMgr.PoolCount(),
+		)
+	}
+
+	// Roll back to slot 50 (< 100): the pool's state is reorged away.
+	if err := o.handleRollback(
+		event.RollbackEvent{SlotNumber: 50, BlockHash: "abc"},
+	); err != nil {
+		t.Fatalf("handleRollback returned error: %v", err)
+	}
+
+	// Existing behavior: removed from the in-memory map.
+	if _, ok := o.GetPoolState("pool1"); ok {
+		t.Error("expected pool removed from o.pools after rollback")
+	}
+	// Fix: the mempool manager must not keep the reorged confirmed state.
+	if _, ok := o.mempoolMgr.GetPoolState("pool1"); ok {
+		t.Error("expected mempool manager to drop reorged pool state")
+	}
+	if o.mempoolMgr.PoolCount() != 0 {
+		t.Errorf(
+			"expected 0 tracked pools in mempool manager, got %d",
+			o.mempoolMgr.PoolCount(),
+		)
+	}
+}
+
+func TestOracleLoadPersistedStatesSeedsMempoolManager(t *testing.T) {
+	o := &Oracle{
+		pools:      make(map[string]*PoolState),
+		stopChan:   make(chan struct{}),
+		storage:    newTestOracleStorage(t),
+		mempoolMgr: NewMempoolStateManager(),
+	}
+	state := &PoolState{
+		PoolId:   "pool1",
+		Network:  "mainnet",
+		Protocol: "test",
+		TxHash:   "tx100",
+		AssetX:   common.AssetAmount{Amount: 1000},
+		AssetY:   common.AssetAmount{Amount: 2000},
+	}
+	if err := o.storage.SavePoolState(state); err != nil {
+		t.Fatalf("failed to save pool state: %v", err)
+	}
+
+	if err := o.loadPersistedStates(); err != nil {
+		t.Fatalf("failed to load persisted states: %v", err)
+	}
+
+	if o.PoolCount() != 1 {
+		t.Fatalf("expected 1 loaded pool, got %d", o.PoolCount())
+	}
+	ps, ok := o.mempoolMgr.GetPoolState("pool1")
+	if !ok || ps == nil {
+		t.Fatal("expected mempool manager to track loaded pool")
+	}
+	confirmed := ps.GetConfirmedState()
+	if confirmed == nil {
+		t.Fatal("expected loaded confirmed state in mempool manager")
+	}
+	if confirmed.AssetX.Amount != 1000 || confirmed.AssetY.Amount != 2000 {
+		t.Fatalf(
+			"expected restored reserves 1000/2000, got %d/%d",
+			confirmed.AssetX.Amount,
+			confirmed.AssetY.Amount,
+		)
+	}
+
+	pending := &PoolState{
+		PoolId:   "pool1",
+		Protocol: "test",
+		TxHash:   "tx-pending",
+		AssetX:   common.AssetAmount{Amount: 1100},
+		AssetY:   common.AssetAmount{Amount: 1900},
+	}
+	effect := o.mempoolMgr.AddPendingTx(
+		"pool1",
+		"test",
+		"tx-pending",
+		pending,
+	)
+	if effect == nil {
+		t.Fatal("expected pending effect")
+	}
+	if effect.DeltaX != 100 || effect.DeltaY != -100 {
+		t.Fatalf(
+			"expected deltas against restored reserves 100/-100, got %d/%d",
+			effect.DeltaX,
+			effect.DeltaY,
+		)
+	}
+}
 
 func TestOracleSubscribeNotifyUnsubscribe(t *testing.T) {
 	o := &Oracle{


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add per-transaction mempool state tracking with deltas and price impact, integrated with the oracle to keep confirmed and pending states in sync and handle rollbacks cleanly. This enables selective ordering and analysis of pending swaps across pools.

- **New Features**
  - `MempoolStateManager` and `MempoolPoolState` for thread-safe, per-pool tracking; per-tx effects (`DeltaX`, `DeltaY`, `ResultingPriceXY`) in insertion order, plus `PriceImpact`.
  - Manager APIs: add/remove/list pending txs; get affected pools; pool/total counts; update confirmed state (drop matching tx; rebase remaining deltas); remove pool state on rollback.
  - Oracle integration: owns the manager, updates on each confirmed tx, clears reorged pools on rollback, seeds from persisted states at startup, and exposes `GetMempoolManager()`.
  - Safety and tests: deep-copy helpers for `PoolState`/assets that preserve empty vs nil slices; getters return copies; saturating arithmetic for deltas to avoid overflow; tests cover ordering, dedup, price impact, delta rebasing, rollback clearing, immutability, serialization stability, and persisted-state seeding.

<sup>Written for commit a213511c777e713221f5bbbd6748fbbc0948bb03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/shai/pull/307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

