### PR TITLE
fix(spectrum): underflow protection and sanity checks

### DIFF
--- a/internal/spectrum/pool.go
+++ b/internal/spectrum/pool.go
@@ -16,6 +16,7 @@ package spectrum
 
 import (
 	"errors"
+	"fmt"
 	"math/big"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -175,7 +176,7 @@ func (p *Pool) Asset(asset AssetClass) AssetAmount {
 func (p *Pool) CalculateReturnToPool(
 	inputAsset AssetAmount,
 	rewardAsset AssetAmount,
-) (uint64, []AssetAmount) {
+) (uint64, []AssetAmount, error) {
 	var retAda uint64
 	retUnits := []AssetAmount{
 		{
@@ -187,6 +188,15 @@ func (p *Pool) CalculateReturnToPool(
 	inAsset := p.Asset(inputAsset.Class)
 	inAsset.Amount += inputAsset.Amount
 	outAsset := p.Asset(rewardAsset.Class)
+	// Guard against uint64 underflow: the pool cannot pay out more of the
+	// output asset than it holds in reserve.
+	if outAsset.Amount < rewardAsset.Amount {
+		return 0, nil, fmt.Errorf(
+			"pool underflow: outAsset amount (%d) < reward amount (%d)",
+			outAsset.Amount,
+			rewardAsset.Amount,
+		)
+	}
 	outAsset.Amount -= rewardAsset.Amount
 	if inAsset.IsLovelace() {
 		retAda = inAsset.Amount
@@ -195,5 +205,5 @@ func (p *Pool) CalculateReturnToPool(
 		retAda = outAsset.Amount
 		retUnits = append(retUnits, inAsset)
 	}
-	return retAda, retUnits
+	return retAda, retUnits, nil
 }

--- a/internal/spectrum/pool_test.go
+++ b/internal/spectrum/pool_test.go
@@ -1,0 +1,153 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spectrum_test
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/shai/internal/spectrum"
+)
+
+// adaClass is the ADA / lovelace asset class (empty policy id and name).
+var adaClass = spectrum.AssetClass{
+	PolicyId: []byte{},
+	Name:     []byte{},
+}
+
+// tokenClass is a non-ADA asset class used for the Y side of test pools.
+var tokenClass = spectrum.AssetClass{
+	PolicyId: testModelsDecodeHex(
+		"f66d78b4a3cb3d37afa0ec36461e51ecbde00f26c8f0a68f94b69880",
+	),
+	Name: []byte("iBTC"),
+}
+
+var lqClass = spectrum.AssetClass{
+	PolicyId: testModelsDecodeHex(
+		"475362a850bf8d1f037794432cdea9fdbbf8d048a7c5115feeb7e91d",
+	),
+	Name: []byte("ibtc_ADA_LQ"),
+}
+
+var nftClass = spectrum.AssetClass{
+	PolicyId: testModelsDecodeHex(
+		"d8beceb1ac736c92df8e1210fb39803508533ae9573cffeb2b24a839",
+	),
+	Name: []byte("ibtc_ADA_NFT"),
+}
+
+// newTestPool builds a Pool with ADA on the X side and a token on the Y side.
+func newTestPool(adaReserve, tokenReserve uint64) *spectrum.Pool {
+	return &spectrum.Pool{
+		Id: nftClass,
+		X: spectrum.AssetAmount{
+			Class:  adaClass,
+			Amount: adaReserve,
+		},
+		Y: spectrum.AssetAmount{
+			Class:  tokenClass,
+			Amount: tokenReserve,
+		},
+		Lq: spectrum.AssetAmount{
+			Class:  lqClass,
+			Amount: 1_000_000,
+		},
+		FeeNum: 997,
+	}
+}
+
+// TestCalculateReturnToPoolHappyPath verifies the existing correct behavior is
+// preserved: a token-for-ADA swap returns the reduced ADA reserve plus the
+// increased token reserve, with a nil error.
+func TestCalculateReturnToPoolHappyPath(t *testing.T) {
+	adaReserve := uint64(15_000_000_000)
+	tokenReserve := uint64(150_000)
+	pool := newTestPool(adaReserve, tokenReserve)
+
+	// Trader sends tokens in (input), receives ADA out (reward).
+	inputAsset := spectrum.AssetAmount{Class: tokenClass, Amount: 100}
+	rewardAsset := spectrum.AssetAmount{Class: adaClass, Amount: 9_000_000}
+
+	retAda, retUnits, err := pool.CalculateReturnToPool(
+		inputAsset,
+		rewardAsset,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	// ADA reserve is the output asset, reduced by the reward amount.
+	wantAda := adaReserve - rewardAsset.Amount
+	if retAda != wantAda {
+		t.Fatalf("expected retAda %d, got %d", wantAda, retAda)
+	}
+	// retUnits should always lead with the pool NFT and the LQ token.
+	if len(retUnits) < 3 {
+		t.Fatalf("expected at least 3 return units, got %d", len(retUnits))
+	}
+	if retUnits[0].Amount != 1 || !retUnits[0].IsAsset(nftClass) {
+		t.Fatalf("expected first unit to be pool NFT, got %+v", retUnits[0])
+	}
+	// The LQ token must follow the NFT, with its reserve passed through
+	// unchanged (the swap does not mint or burn LQ tokens).
+	if !retUnits[1].IsAsset(lqClass) || retUnits[1].Amount != 1_000_000 {
+		t.Fatalf(
+			"expected second unit to be LQ token (amount 1000000), got %+v",
+			retUnits[1],
+		)
+	}
+	// The token side reserve should be increased by the input amount.
+	var foundToken bool
+	for _, u := range retUnits {
+		if u.IsAsset(tokenClass) {
+			foundToken = true
+			wantToken := tokenReserve + inputAsset.Amount
+			if u.Amount != wantToken {
+				t.Fatalf(
+					"expected token reserve %d, got %d",
+					wantToken,
+					u.Amount,
+				)
+			}
+		}
+	}
+	if !foundToken {
+		t.Fatalf("token asset not found in return units: %+v", retUnits)
+	}
+}
+
+// TestCalculateReturnToPoolUnderflow verifies that a reward larger than the
+// pool's reserve of the output asset produces an error instead of underflowing
+// the uint64 subtraction.
+func TestCalculateReturnToPoolUnderflow(t *testing.T) {
+	adaReserve := uint64(5_000_000)
+	tokenReserve := uint64(150_000)
+	pool := newTestPool(adaReserve, tokenReserve)
+
+	inputAsset := spectrum.AssetAmount{Class: tokenClass, Amount: 100}
+	// Reward exceeds the ADA reserve -> would underflow.
+	rewardAsset := spectrum.AssetAmount{
+		Class:  adaClass,
+		Amount: adaReserve + 1,
+	}
+
+	_, _, err := pool.CalculateReturnToPool(inputAsset, rewardAsset)
+	if err == nil {
+		t.Fatalf(
+			"expected underflow error when reward (%d) > reserve (%d), got nil",
+			rewardAsset.Amount,
+			adaReserve,
+		)
+	}
+}

--- a/internal/spectrum/tx.go
+++ b/internal/spectrum/tx.go
@@ -2,6 +2,7 @@ package spectrum
 
 import (
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"math/big"
 	"time"
@@ -356,14 +357,25 @@ func (s *Spectrum) createSwapTx(opts createSwapTxOpts) ([]byte, error) {
 		)
 	}
 
+	// Reward amount must be non-zero, otherwise the swap order is malformed
+	// and there is nothing to pay out to the trader.
+	if rewardAsset.Amount == 0 {
+		return nil, errors.New(
+			"calculated reward amount is zero for swap order",
+		)
+	}
+
 	// Calculate lovelace and assets to return to pool
-	poolReturnLovelace, poolReturnAssets := opts.pool.CalculateReturnToPool(
+	poolReturnLovelace, poolReturnAssets, err := opts.pool.CalculateReturnToPool(
 		AssetAmount{
 			Class:  opts.swapConfig.Base,
 			Amount: opts.swapConfig.BaseAmount,
 		},
 		rewardAsset,
 	)
+	if err != nil {
+		return nil, fmt.Errorf("pool return calculation failed: %w", err)
+	}
 	poolReturnUnits := []apollo.Unit{}
 	for _, asset := range poolReturnAssets {
 		poolReturnUnits = append(
@@ -373,6 +385,21 @@ func (s *Spectrum) createSwapTx(opts createSwapTxOpts) ([]byte, error) {
 				string(asset.Class.Name),
 				int(asset.Amount),
 			),
+		)
+	}
+
+	// Guard against a nil numerator, which would panic in big.Float.SetInt
+	// during the matcher fee calculation below.
+	if opts.swapConfig.FeePerTokenNum == nil {
+		return nil, errors.New(
+			"FeePerTokenNum is nil for swap order",
+		)
+	}
+	// Guard against division-by-zero in the matcher fee calculation below.
+	if opts.swapConfig.FeePerTokenDen == nil ||
+		opts.swapConfig.FeePerTokenDen.Sign() == 0 {
+		return nil, errors.New(
+			"FeePerTokenDen is zero for swap order",
 		)
 	}
 
@@ -390,13 +417,40 @@ func (s *Spectrum) createSwapTx(opts createSwapTxOpts) ([]byte, error) {
 	).Uint64()
 
 	// Calculate leftover lovelace from swap order UTxO for return with reward
-	leftoverSwapLovelace := uint64(
-		swapUtxo.Output.GetAmount().GetCoin(),
-	) - matcherFee
+	swapUtxoCoin := uint64(swapUtxo.Output.GetAmount().GetCoin())
+	// Guard against uint64 underflow: the swap UTxO must hold at least the
+	// matcher fee.
+	if swapUtxoCoin < matcherFee {
+		return nil, fmt.Errorf(
+			"swap UTxO coin (%d) is less than matcher fee (%d)",
+			swapUtxoCoin,
+			matcherFee,
+		)
+	}
+	leftoverSwapLovelace := swapUtxoCoin - matcherFee
 	if len(opts.swapConfig.Base.PolicyId) == 0 {
+		// Guard against uint64 underflow: for ADA-base swaps the leftover
+		// lovelace must cover the base amount being sent to the pool.
+		if leftoverSwapLovelace < opts.swapConfig.BaseAmount {
+			return nil, fmt.Errorf(
+				"leftover swap lovelace (%d) is less than base amount (%d)",
+				leftoverSwapLovelace,
+				opts.swapConfig.BaseAmount,
+			)
+		}
 		leftoverSwapLovelace -= opts.swapConfig.BaseAmount
 	}
 	rewardLovelace += leftoverSwapLovelace
+
+	// Guard against a non-positive change output: the matcher fee must exceed
+	// the transaction fee, otherwise the change output below would underflow.
+	if matcherFee <= swapTxFee {
+		return nil, fmt.Errorf(
+			"matcher fee (%d) does not exceed tx fee (%d)",
+			matcherFee,
+			swapTxFee,
+		)
+	}
 
 	// Generate addresses
 	tmpRewardAddr := addressFromKeys(


### PR DESCRIPTION
Closes #48 

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add underflow protection and sanity checks to Spectrum pool and swap logic to prevent negative balances and malformed orders. Adds clear errors and tests for edge cases; `CalculateReturnToPool` now returns an error.

- **Bug Fixes**
  - Harden `(*Pool).CalculateReturnToPool`: block payouts larger than pool reserves; change return to `(uint64, []AssetAmount, error)` and propagate errors.
  - Harden `createSwapTx`: reject zero reward; reject nil `FeePerTokenNum`; reject nil or zero `FeePerTokenDen`; guard underflows (swap UTxO coin < matcher fee, ADA-base leftover < base amount, matcher fee ≤ tx fee); handle pool return errors.
  - Add `internal/spectrum/pool_test.go` with happy-path and underflow tests.

- **Migration**
  - Update callers to handle the new `error` return from `(*Pool).CalculateReturnToPool`.

<sup>Written for commit 31a60bc7a92622139531403db70aeb2fc2738d9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/shai/pull/308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent pool underflow errors during liquidity return calculations.
  * Enhanced swap transaction processing with improved safety checks and error handling.
  * Added stricter validation for fee calculations to prevent underflow conditions.

* **Tests**
  * Added comprehensive test coverage for liquidity pool operations, verifying success and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->