### PR TITLE
feat: indexer watch system for TX ID and UTxO tracking

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/blinklabs-io/bursa v0.16.0
 	github.com/blinklabs-io/dingo v0.50.2
 	github.com/blinklabs-io/gouroboros v0.179.0
+	github.com/blinklabs-io/ouroboros-mock v0.12.0
 	github.com/dgraph-io/badger/v4 v4.9.1
 	github.com/gorilla/websocket v1.5.3
 	github.com/kelseyhightower/envconfig v1.4.0

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/blinklabs-io/adder/event"
@@ -37,20 +38,28 @@ const (
 )
 
 type Indexer struct {
-	pipeline     *pipeline.Pipeline
+	pipeline *pipeline.Pipeline
+	// mu guards the catch-up sync log timer and the cached cursor/tip fields,
+	// which are touched by the chainsync status goroutine, the sync log timer
+	// goroutine, and Stop.
+	mu           sync.Mutex
 	cursorSlot   uint64
 	cursorHash   string
 	tipSlot      uint64
 	tipHash      string
 	tipReached   bool
 	syncLogTimer *time.Timer
+	syncLogDone  bool
 	eventFuncs   []EventFunc
+	Watches      *WatchManager
 }
 
 type EventFunc func(event.Event) error
 
 func New() *Indexer {
-	return &Indexer{}
+	return &Indexer{
+		Watches: NewWatchManager(),
+	}
 }
 
 func (i *Indexer) Start() error {
@@ -165,15 +174,45 @@ func (i *Indexer) Start() error {
 	return nil
 }
 
+// Stop halts the indexer's background workers: the watch manager's expiration
+// goroutine and the catch-up sync log timer. It is safe to call even if the
+// indexer was never started and may be called more than once.
+func (i *Indexer) Stop() {
+	if i.Watches != nil {
+		i.Watches.Stop()
+	}
+	i.mu.Lock()
+	i.stopSyncLogTimerLocked()
+	i.mu.Unlock()
+}
+
+// stopSyncLogTimerLocked stops the catch-up sync log timer and prevents it from
+// being rescheduled. The caller must hold i.mu.
+func (i *Indexer) stopSyncLogTimerLocked() {
+	i.syncLogDone = true
+	if i.syncLogTimer != nil {
+		i.syncLogTimer.Stop()
+	}
+}
+
 func (i *Indexer) AddEventFunc(eventFunc EventFunc) {
 	i.eventFuncs = append(i.eventFuncs, eventFunc)
 }
 
 func (i *Indexer) handleEvent(evt event.Event) error {
+	// Notify any registered watches about this event
+	if i.Watches != nil {
+		i.Watches.CheckEvent(evt)
+	}
 	switch evt.Payload.(type) {
 	case event.TransactionEvent:
-		bursa := wallet.GetWallet()
 		eventTx := evt.Payload.(event.TransactionEvent)
+		// A TransactionEvent may carry a nil Transaction; there is nothing to
+		// reconcile in that case, so skip rather than dereferencing it.
+		if eventTx.Transaction == nil {
+			return nil
+		}
+		bursa := wallet.GetWallet()
 		eventCtx := evt.Context.(event.TransactionContext)
 		// Delete used UTXOs
 		for _, txInput := range eventTx.Transaction.Consumed() {
@@ -202,34 +241,60 @@ func (i *Indexer) handleEvent(evt event.Event) error {
 }
 
 func (i *Indexer) scheduleSyncStatusLog() {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.scheduleSyncStatusLogLocked()
+}
+
+// scheduleSyncStatusLogLocked arms the catch-up sync log timer unless logging
+// has been stopped. The caller must hold i.mu.
+func (i *Indexer) scheduleSyncStatusLogLocked() {
+	if i.syncLogDone {
+		return
+	}
+	if i.syncLogTimer != nil {
+		i.syncLogTimer.Stop()
+	}
 	i.syncLogTimer = time.AfterFunc(syncStatusLogInterval, i.syncStatusLog)
 }
 
 func (i *Indexer) syncStatusLog() {
-	logger := logging.GetLogger()
-	logger.Info(fmt.Sprintf(
+	// Snapshot the cursor fields under the lock, then log and reschedule
+	// without holding it.
+	i.mu.Lock()
+	cursorSlot := i.cursorSlot
+	cursorHash := i.cursorHash
+	tipSlot := i.tipSlot
+	i.mu.Unlock()
+
+	logging.GetLogger().Info(fmt.Sprintf(
 		"catch-up sync in progress: at %d.%s (current tip slot is %d)",
-		i.cursorSlot,
-		i.cursorHash,
-		i.tipSlot),
+		cursorSlot,
+		cursorHash,
+		tipSlot),
 	)
 	i.scheduleSyncStatusLog()
 }
 
 func (i *Indexer) updateStatus(status input_chainsync.ChainSyncStatus) {
-	logger := logging.GetLogger()
+	i.applyStatus(status)
+	if err := storage.GetStorage().UpdateCursor(status.SlotNumber, status.BlockHash); err != nil {
+		logging.GetLogger().Error("failed to update cursor:", "error", err)
+	}
+}
+
+// applyStatus updates the cached cursor/tip fields from a chainsync status
+// update and stops the catch-up sync log timer once the chain tip is reached.
+func (i *Indexer) applyStatus(status input_chainsync.ChainSyncStatus) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
 	// Check if we've hit chain tip
 	if !i.tipReached && status.TipReached {
-		if i.syncLogTimer != nil {
-			i.syncLogTimer.Stop()
-		}
+		i.stopSyncLogTimerLocked()
 		i.tipReached = true
 	}
 	i.cursorSlot = status.SlotNumber
 	i.cursorHash = status.BlockHash
 	i.tipSlot = status.TipSlotNumber
 	i.tipHash = status.TipBlockHash
-	if err := storage.GetStorage().UpdateCursor(status.SlotNumber, status.BlockHash); err != nil {
-		logger.Error("failed to update cursor:", "error", err)
-	}
 }

--- a/internal/indexer/indexer_test.go
+++ b/internal/indexer/indexer_test.go
@@ -1,0 +1,90 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package indexer
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	input_chainsync "github.com/blinklabs-io/adder/input/chainsync"
+)
+
+func TestIndexerStopHaltsWatchManager(t *testing.T) {
+	idx := New()
+	if idx.Watches == nil {
+		t.Fatal("expected non-nil WatchManager")
+	}
+
+	// Stop must halt the WatchManager's background expiration goroutine.
+	idx.Stop()
+	if !idx.Watches.stopped {
+		t.Error("expected WatchManager to be stopped after Indexer.Stop()")
+	}
+
+	// Stop must be idempotent and safe to call more than once.
+	idx.Stop()
+}
+
+func TestIndexerSyncStatusLogConcurrent(t *testing.T) {
+	idx := New()
+	defer idx.Stop()
+
+	// Status updates arrive on the chainsync goroutine while the catch-up sync
+	// log timer reschedules itself from its own goroutine. Both touch the
+	// cursor/tip fields and the timer; with -race this must stay clean.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 500; i++ {
+			idx.applyStatus(input_chainsync.ChainSyncStatus{
+				SlotNumber:    uint64(i),
+				BlockHash:     "hash",
+				TipSlotNumber: uint64(i),
+			})
+		}
+	}()
+	for g := 0; g < 3; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 500; j++ {
+				idx.syncStatusLog()
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestIndexerStopHaltsSyncLogTimer(t *testing.T) {
+	idx := New()
+
+	// Simulate a running catch-up sync timer (normally created by Start).
+	fired := make(chan struct{}, 1)
+	idx.syncLogTimer = time.AfterFunc(50*time.Millisecond, func() {
+		fired <- struct{}{}
+	})
+
+	// Stop must halt the sync log timer so it never fires after shutdown.
+	idx.Stop()
+
+	select {
+	case <-fired:
+		t.Error("syncLogTimer fired after Indexer.Stop()")
+	case <-time.After(150 * time.Millisecond):
+		// Timer was stopped before it could fire.
+	}
+}

--- a/internal/indexer/watches.go
+++ b/internal/indexer/watches.go
@@ -1,0 +1,337 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package indexer
+
+import (
+	"fmt"
+	"runtime/debug"
+	"sync"
+	"time"
+
+	"github.com/blinklabs-io/adder/event"
+	"github.com/blinklabs-io/shai/internal/logging"
+)
+
+const (
+	// watchExpirationInterval is how often the background loop scans for
+	// expired watches.
+	watchExpirationInterval = 10 * time.Second
+)
+
+// WatchType represents the type of watch
+type WatchType int
+
+const (
+	// WatchTypeTxId watches for a specific transaction ID appearing on-chain
+	WatchTypeTxId WatchType = iota
+	// WatchTypeUTxO watches for a specific UTxO being spent (consumed) on-chain
+	WatchTypeUTxO
+)
+
+// WatchCallback is called when a watch is triggered. It receives the id of
+// the watch that fired and the event that triggered it.
+type WatchCallback func(watchId string, evt event.Event)
+
+// Watch represents a registered watch
+type Watch struct {
+	Id   string
+	Type WatchType
+	// Pattern is the lookup key: the txHash for a WatchTypeTxId watch, or
+	// "txHash#index" for a WatchTypeUTxO watch.
+	Pattern   string
+	Callback  WatchCallback
+	TTL       time.Duration
+	CreatedAt time.Time
+}
+
+// WatchManager manages watches for transaction IDs and UTxOs. It provides
+// O(1) indexed lookups for incoming events and TTL-based expiration via a
+// background loop.
+type WatchManager struct {
+	sync.RWMutex
+	watches   map[string]*Watch
+	txIdIndex map[string][]string // txHash -> watchIds
+	utxoIndex map[string][]string // "txHash#index" -> watchIds
+	nextId    uint64
+	stopChan  chan struct{}
+	stopped   bool
+}
+
+// utxoPattern builds the lookup key used for UTxO watches.
+func utxoPattern(txId string, index uint32) string {
+	return fmt.Sprintf("%s#%d", txId, index)
+}
+
+// NewWatchManager creates a new WatchManager and starts its background
+// expiration loop.
+func NewWatchManager() *WatchManager {
+	wm := &WatchManager{
+		watches:   make(map[string]*Watch),
+		txIdIndex: make(map[string][]string),
+		utxoIndex: make(map[string][]string),
+		stopChan:  make(chan struct{}),
+	}
+	go wm.expirationLoop()
+	return wm
+}
+
+// RegisterTxWatch registers a watch for a specific transaction ID. A TTL of
+// 0 means the watch never expires. It returns the generated watch id.
+func (wm *WatchManager) RegisterTxWatch(
+	txId string,
+	ttl time.Duration,
+	callback WatchCallback,
+) string {
+	wm.Lock()
+	defer wm.Unlock()
+
+	if wm.stopped {
+		return ""
+	}
+
+	wm.nextId++
+	watchId := fmt.Sprintf("tx-%d", wm.nextId)
+
+	watch := &Watch{
+		Id:        watchId,
+		Type:      WatchTypeTxId,
+		Pattern:   txId,
+		Callback:  callback,
+		TTL:       ttl,
+		CreatedAt: time.Now(),
+	}
+
+	wm.watches[watchId] = watch
+	wm.txIdIndex[txId] = append(wm.txIdIndex[txId], watchId)
+
+	logging.GetLogger().Debug(
+		"registered TX watch",
+		"watchId", watchId,
+		"txId", txId,
+		"ttl", ttl,
+	)
+
+	return watchId
+}
+
+// RegisterUTxOWatch registers a watch for a specific UTxO (txId#index) being
+// consumed. A TTL of 0 means the watch never expires. It returns the
+// generated watch id.
+func (wm *WatchManager) RegisterUTxOWatch(
+	txId string,
+	index uint32,
+	ttl time.Duration,
+	callback WatchCallback,
+) string {
+	wm.Lock()
+	defer wm.Unlock()
+
+	if wm.stopped {
+		return ""
+	}
+
+	wm.nextId++
+	watchId := fmt.Sprintf("utxo-%d", wm.nextId)
+	pattern := utxoPattern(txId, index)
+
+	watch := &Watch{
+		Id:        watchId,
+		Type:      WatchTypeUTxO,
+		Pattern:   pattern,
+		Callback:  callback,
+		TTL:       ttl,
+		CreatedAt: time.Now(),
+	}
+
+	wm.watches[watchId] = watch
+	wm.utxoIndex[pattern] = append(wm.utxoIndex[pattern], watchId)
+
+	logging.GetLogger().Debug(
+		"registered UTxO watch",
+		"watchId", watchId,
+		"txId", txId,
+		"index", index,
+		"ttl", ttl,
+	)
+
+	return watchId
+}
+
+// Unregister removes a watch by its id. It is safe to call on an unknown id
+// or to call more than once for the same id.
+func (wm *WatchManager) Unregister(watchId string) {
+	wm.Lock()
+	defer wm.Unlock()
+	wm.unregisterLocked(watchId)
+}
+
+// unregisterLocked removes a watch. The caller must hold the write lock.
+func (wm *WatchManager) unregisterLocked(watchId string) {
+	watch, ok := wm.watches[watchId]
+	if !ok {
+		return
+	}
+
+	switch watch.Type {
+	case WatchTypeTxId:
+		wm.removeFromIndex(wm.txIdIndex, watch.Pattern, watchId)
+	case WatchTypeUTxO:
+		wm.removeFromIndex(wm.utxoIndex, watch.Pattern, watchId)
+	}
+
+	delete(wm.watches, watchId)
+
+	logging.GetLogger().Debug("unregistered watch", "watchId", watchId)
+}
+
+// removeFromIndex removes a single watchId from the slice stored under key,
+// deleting the key entirely when no watches remain.
+func (wm *WatchManager) removeFromIndex(
+	index map[string][]string,
+	key string,
+	watchId string,
+) {
+	watchIds := index[key]
+	for i, id := range watchIds {
+		if id == watchId {
+			index[key] = append(watchIds[:i], watchIds[i+1:]...)
+			break
+		}
+	}
+	if len(index[key]) == 0 {
+		delete(index, key)
+	}
+}
+
+// CheckEvent matches an incoming event against all registered watches and
+// fires the callbacks of any that match. Callbacks are invoked in their own
+// goroutines so a slow callback cannot block the event loop or hold the lock.
+func (wm *WatchManager) CheckEvent(evt event.Event) {
+	wm.RLock()
+	defer wm.RUnlock()
+
+	// Once stopped, deliver no further callbacks. The watch tables are also
+	// cleared on Stop, but gating here prevents an in-flight event from firing
+	// a callback after the caller has torn the manager down.
+	if wm.stopped {
+		return
+	}
+
+	payload, ok := evt.Payload.(event.TransactionEvent)
+	if !ok {
+		return
+	}
+
+	// TX ID watches keyed on the transaction hash from the context.
+	if ctx, ok := evt.Context.(event.TransactionContext); ok {
+		wm.fireWatches(wm.txIdIndex[ctx.TransactionHash], evt)
+	}
+
+	// UTxO watches keyed on each consumed input (txHash#index). A nil
+	// Transaction has no inputs to match, so skip the lookup rather than
+	// dereferencing it.
+	if payload.Transaction != nil {
+		for _, txInput := range payload.Transaction.Consumed() {
+			pattern := utxoPattern(txInput.Id().String(), txInput.Index())
+			wm.fireWatches(wm.utxoIndex[pattern], evt)
+		}
+	}
+}
+
+// fireWatches invokes the callback for each of the given watch ids, each in
+// its own goroutine so a slow callback cannot block the event loop or hold the
+// lock. Watches with a nil callback are skipped so a registration that omitted
+// a callback cannot panic the process. A panic from within a callback is
+// recovered and logged so a misbehaving watch cannot crash the process. The
+// caller must hold the lock.
+func (wm *WatchManager) fireWatches(watchIds []string, evt event.Event) {
+	for _, watchId := range watchIds {
+		watch, ok := wm.watches[watchId]
+		if !ok || watch.Callback == nil {
+			continue
+		}
+		go func(id string, callback WatchCallback) {
+			defer func() {
+				if r := recover(); r != nil {
+					logging.GetLogger().Error(
+						"watch callback panicked",
+						"watchId", id,
+						"panic", r,
+						"stack", string(debug.Stack()),
+					)
+				}
+			}()
+			callback(id, evt)
+		}(watchId, watch.Callback)
+	}
+}
+
+// expireWatches removes any watch whose TTL has elapsed. A TTL of 0 means the
+// watch never expires.
+func (wm *WatchManager) expireWatches() {
+	wm.Lock()
+	defer wm.Unlock()
+
+	now := time.Now()
+	var expiredIds []string
+	for watchId, watch := range wm.watches {
+		if watch.TTL > 0 && now.Sub(watch.CreatedAt) > watch.TTL {
+			expiredIds = append(expiredIds, watchId)
+		}
+	}
+
+	for _, watchId := range expiredIds {
+		wm.unregisterLocked(watchId)
+		logging.GetLogger().Debug("watch expired", "watchId", watchId)
+	}
+}
+
+// expirationLoop periodically scans for expired watches until Stop is called.
+func (wm *WatchManager) expirationLoop() {
+	ticker := time.NewTicker(watchExpirationInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			wm.expireWatches()
+		case <-wm.stopChan:
+			return
+		}
+	}
+}
+
+// Stop halts the background expiration loop and clears all registered watches.
+// After Stop, CheckEvent delivers no further callbacks and Register* calls are
+// rejected. It is idempotent and safe to call multiple times.
+func (wm *WatchManager) Stop() {
+	wm.Lock()
+	defer wm.Unlock()
+	if wm.stopped {
+		return
+	}
+	wm.stopped = true
+	close(wm.stopChan)
+	wm.watches = make(map[string]*Watch)
+	wm.txIdIndex = make(map[string][]string)
+	wm.utxoIndex = make(map[string][]string)
+}
+
+// WatchCount returns the number of active watches.
+func (wm *WatchManager) WatchCount() int {
+	wm.RLock()
+	defer wm.RUnlock()
+	return len(wm.watches)
+}

--- a/internal/indexer/watches_test.go
+++ b/internal/indexer/watches_test.go
@@ -1,0 +1,356 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package indexer
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/adder/event"
+	mockledger "github.com/blinklabs-io/ouroboros-mock/ledger"
+)
+
+func TestNewWatchManager(t *testing.T) {
+	wm := NewWatchManager()
+	defer wm.Stop()
+
+	if wm == nil {
+		t.Fatal("expected non-nil WatchManager")
+	}
+	if wm.WatchCount() != 0 {
+		t.Errorf("expected 0 watches, got %d", wm.WatchCount())
+	}
+}
+
+func TestRegisterTxWatch(t *testing.T) {
+	wm := NewWatchManager()
+	defer wm.Stop()
+
+	txId := "abc123def456"
+	var called bool
+	var mu sync.Mutex
+
+	watchId := wm.RegisterTxWatch(
+		txId,
+		time.Hour,
+		func(id string, evt event.Event) {
+			mu.Lock()
+			called = true
+			mu.Unlock()
+		},
+	)
+
+	if watchId == "" {
+		t.Fatal("expected non-empty watchId")
+	}
+	if wm.WatchCount() != 1 {
+		t.Errorf("expected 1 watch, got %d", wm.WatchCount())
+	}
+
+	mu.Lock()
+	if called {
+		t.Error("callback should not have been called yet")
+	}
+	mu.Unlock()
+}
+
+func TestRegisterUTxOWatch(t *testing.T) {
+	wm := NewWatchManager()
+	defer wm.Stop()
+
+	txId := "abc123def456"
+	index := uint32(0)
+
+	watchId := wm.RegisterUTxOWatch(
+		txId,
+		index,
+		time.Hour,
+		func(id string, evt event.Event) {},
+	)
+
+	if watchId == "" {
+		t.Fatal("expected non-empty watchId")
+	}
+	if wm.WatchCount() != 1 {
+		t.Errorf("expected 1 watch, got %d", wm.WatchCount())
+	}
+}
+
+func TestUnregisterWatch(t *testing.T) {
+	wm := NewWatchManager()
+	defer wm.Stop()
+
+	txId := "abc123def456"
+	watchId := wm.RegisterTxWatch(
+		txId,
+		time.Hour,
+		func(id string, evt event.Event) {},
+	)
+
+	if wm.WatchCount() != 1 {
+		t.Errorf("expected 1 watch, got %d", wm.WatchCount())
+	}
+
+	wm.Unregister(watchId)
+
+	if wm.WatchCount() != 0 {
+		t.Errorf("expected 0 watches after unregister, got %d", wm.WatchCount())
+	}
+
+	// Unregistering again should not panic
+	wm.Unregister(watchId)
+	wm.Unregister("nonexistent")
+}
+
+func TestMultipleWatches(t *testing.T) {
+	wm := NewWatchManager()
+	defer wm.Stop()
+
+	// Register multiple watches
+	wm.RegisterTxWatch("tx1", time.Hour, func(id string, evt event.Event) {})
+	wm.RegisterTxWatch("tx2", time.Hour, func(id string, evt event.Event) {})
+	wm.RegisterUTxOWatch(
+		"utxo1",
+		0,
+		time.Hour,
+		func(id string, evt event.Event) {},
+	)
+	wm.RegisterUTxOWatch(
+		"utxo1",
+		1,
+		time.Hour,
+		func(id string, evt event.Event) {},
+	)
+
+	if wm.WatchCount() != 4 {
+		t.Errorf("expected 4 watches, got %d", wm.WatchCount())
+	}
+}
+
+func TestWatchExpiration(t *testing.T) {
+	wm := NewWatchManager()
+	defer wm.Stop()
+
+	// Register a watch with a very short TTL
+	wm.RegisterTxWatch(
+		"tx1",
+		50*time.Millisecond,
+		func(id string, evt event.Event) {},
+	)
+
+	if wm.WatchCount() != 1 {
+		t.Errorf("expected 1 watch, got %d", wm.WatchCount())
+	}
+
+	// Wait for expiration
+	time.Sleep(100 * time.Millisecond)
+	wm.expireWatches()
+
+	if wm.WatchCount() != 0 {
+		t.Errorf("expected 0 watches after expiration, got %d", wm.WatchCount())
+	}
+}
+
+func TestWatchNoExpiration(t *testing.T) {
+	wm := NewWatchManager()
+	defer wm.Stop()
+
+	// Register a watch with TTL of 0 (no expiration)
+	wm.RegisterTxWatch("tx1", 0, func(id string, evt event.Event) {})
+
+	if wm.WatchCount() != 1 {
+		t.Errorf("expected 1 watch, got %d", wm.WatchCount())
+	}
+
+	// Call expireWatches - should not remove watch with TTL 0
+	wm.expireWatches()
+
+	if wm.WatchCount() != 1 {
+		t.Errorf("expected 1 watch (no expiration), got %d", wm.WatchCount())
+	}
+}
+
+func TestMultipleWatchesSamePattern(t *testing.T) {
+	wm := NewWatchManager()
+	defer wm.Stop()
+
+	txId := "same-tx-id"
+
+	// Register multiple watches for the same transaction
+	watchId1 := wm.RegisterTxWatch(
+		txId,
+		time.Hour,
+		func(id string, evt event.Event) {},
+	)
+	watchId2 := wm.RegisterTxWatch(
+		txId,
+		time.Hour,
+		func(id string, evt event.Event) {},
+	)
+
+	if wm.WatchCount() != 2 {
+		t.Errorf("expected 2 watches, got %d", wm.WatchCount())
+	}
+
+	// Unregister one - the other must remain (independent lifecycle)
+	wm.Unregister(watchId1)
+	if wm.WatchCount() != 1 {
+		t.Errorf("expected 1 watch after unregister, got %d", wm.WatchCount())
+	}
+
+	// Unregister the other
+	wm.Unregister(watchId2)
+	if wm.WatchCount() != 0 {
+		t.Errorf("expected 0 watches after unregister, got %d", wm.WatchCount())
+	}
+}
+
+func TestStopIdempotent(t *testing.T) {
+	wm := NewWatchManager()
+	// Stopping multiple times must not panic
+	wm.Stop()
+	wm.Stop()
+}
+
+func TestCheckEventNilTxCallbackDoesNotPanic(t *testing.T) {
+	wm := NewWatchManager()
+	defer wm.Stop()
+
+	txHash := "abc123def456"
+	// A watch registered with a nil callback must not crash the process when
+	// a matching transaction event arrives.
+	wm.RegisterTxWatch(txHash, time.Hour, nil)
+
+	// Transaction with no consumed inputs, so only the TX ID watch can match.
+	tx := mockledger.NewTransactionBuilder()
+	evt := event.Event{
+		Type:    "chainsync.transaction",
+		Payload: event.TransactionEvent{Transaction: tx},
+		Context: event.TransactionContext{TransactionHash: txHash},
+	}
+
+	wm.CheckEvent(evt)
+	// Callbacks run in their own goroutines; allow them to execute so a
+	// nil-callback panic would surface before the test returns.
+	time.Sleep(50 * time.Millisecond)
+}
+
+func TestCheckEventFiresMatchingCallback(t *testing.T) {
+	wm := NewWatchManager()
+	defer wm.Stop()
+
+	txHash := "abc123def456"
+	fired := make(chan string, 1)
+	watchId := wm.RegisterTxWatch(
+		txHash,
+		time.Hour,
+		func(id string, evt event.Event) {
+			fired <- id
+		},
+	)
+
+	tx := mockledger.NewTransactionBuilder()
+	evt := event.Event{
+		Type:    "chainsync.transaction",
+		Payload: event.TransactionEvent{Transaction: tx},
+		Context: event.TransactionContext{TransactionHash: txHash},
+	}
+	wm.CheckEvent(evt)
+
+	select {
+	case id := <-fired:
+		if id != watchId {
+			t.Errorf("expected callback for %q, got %q", watchId, id)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected matching TX watch callback to fire")
+	}
+}
+
+func TestCheckEventNilTransactionDoesNotPanic(t *testing.T) {
+	wm := NewWatchManager()
+	defer wm.Stop()
+
+	txHash := "abc123def456"
+	fired := make(chan string, 1)
+	wm.RegisterTxWatch(
+		txHash,
+		time.Hour,
+		func(id string, evt event.Event) {
+			fired <- id
+		},
+	)
+
+	// A TransactionEvent with a nil Transaction must not panic CheckEvent. The
+	// TX ID path needs only the context, so it must still fire.
+	evt := event.Event{
+		Type:    "chainsync.transaction",
+		Payload: event.TransactionEvent{Transaction: nil},
+		Context: event.TransactionContext{TransactionHash: txHash},
+	}
+	wm.CheckEvent(evt)
+
+	select {
+	case <-fired:
+	case <-time.After(time.Second):
+		t.Fatal("expected TX watch callback to fire even with nil Transaction")
+	}
+}
+
+func TestCheckEventNilUTxOCallbackDoesNotPanic(t *testing.T) {
+	wm := NewWatchManager()
+	defer wm.Stop()
+
+	input, err := mockledger.NewSimpleTransactionInput([]byte("watched-utxo"), 0)
+	if err != nil {
+		t.Fatalf("failed to build mock input: %v", err)
+	}
+
+	// A watch registered with a nil callback must not crash the process when
+	// the watched UTxO is consumed.
+	wm.RegisterUTxOWatch(input.Id().String(), input.Index(), time.Hour, nil)
+
+	// A watch with a real callback for the same UTxO must still fire, proving
+	// the nil-callback guard does not suppress legitimate callbacks.
+	fired := make(chan string, 1)
+	watchId := wm.RegisterUTxOWatch(
+		input.Id().String(),
+		input.Index(),
+		time.Hour,
+		func(id string, evt event.Event) {
+			fired <- id
+		},
+	)
+
+	tx := mockledger.NewTransactionBuilder()
+	tx.WithInputs(input)
+	evt := event.Event{
+		Type:    "chainsync.transaction",
+		Payload: event.TransactionEvent{Transaction: tx},
+		Context: event.TransactionContext{TransactionHash: "unrelated"},
+	}
+
+	wm.CheckEvent(evt)
+
+	select {
+	case id := <-fired:
+		if id != watchId {
+			t.Errorf("expected callback for %q, got %q", watchId, id)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected matching UTxO watch callback to fire")
+	}
+}

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -1,3 +1,17 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package logging
 
 import (
@@ -27,6 +41,24 @@ func TestConcurrentGetLoggerAndConfigureRaceFree(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			Configure()
+		}()
+	}
+	wg.Wait()
+}
+
+func TestGetLoggerConcurrent(t *testing.T) {
+	// Force the lazy-initialization path that GetLogger takes before Configure
+	// has run. Concurrent callers must not race on the global logger.
+	globalLogger = nil
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if GetLogger() == nil {
+				t.Error("GetLogger returned nil")
+			}
 		}()
 	}
 	wg.Wait()


### PR DESCRIPTION
Closes #49 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a watch system to track TX IDs and UTxOs and trigger callbacks when they appear or are consumed. Integrates with the indexer with safe, idempotent shutdown and race-free sync status logging.

- **New Features**
  - `WatchManager` with O(1) lookups, TTL expiry (0 = never), 10s cleanup, and panic-safe, nil-tolerant callbacks.
  - `RegisterTxWatch`/`RegisterUTxOWatch`; callbacks run in goroutines; supports `Unregister` and idempotent `Stop`.
  - Indexer integration: `New()` initializes `Watches`; `handleEvent` checks watches and skips nil transactions; `Indexer.Stop()` halts watches and the catch-up sync log timer without races; sync-status logging snapshots fields and stops at tip.
  - Added tests for watches, timer shutdown, and concurrent logging; introduced `github.com/blinklabs-io/ouroboros-mock` for mocks.

<sup>Written for commit 069ed7514d16a49f05e988e1d8702551ac7df6a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/shai/pull/309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a watch management system enabling users to register and monitor transaction and UTxO consumption events with automatic expiration support

* **Improvements**
  * Enhanced indexer with graceful shutdown capability and improved concurrency-safe operations

* **Tests**
  * Added comprehensive test coverage for watch management and indexer lifecycle operations, including concurrency scenarios

* **Chores**
  * Updated dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->