### PR TITLE
fix: logging race

### DIFF
--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -3,14 +3,49 @@ package logging
 import (
 	"log/slog"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/blinklabs-io/shai/internal/config"
 )
 
-var globalLogger *slog.Logger
+var (
+	mu           sync.RWMutex
+	globalLogger *slog.Logger
+)
 
+// Configure builds the global logger from the current configuration, replacing
+// any previously configured logger. It is safe for concurrent use.
 func Configure() {
+	logger := buildLogger()
+	mu.Lock()
+	globalLogger = logger
+	mu.Unlock()
+}
+
+// GetLogger returns the global logger, configuring it on first use. It is safe
+// for concurrent use.
+func GetLogger() *slog.Logger {
+	mu.RLock()
+	logger := globalLogger
+	mu.RUnlock()
+	if logger != nil {
+		return logger
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	// Re-check under the write lock: another goroutine may have configured the
+	// logger between releasing the read lock and acquiring the write lock.
+	if globalLogger == nil {
+		globalLogger = buildLogger()
+	}
+	return globalLogger
+}
+
+// buildLogger constructs a logger from the current configuration. It touches no
+// shared state, so it runs outside the lock.
+func buildLogger() *slog.Logger {
 	cfg := config.GetConfig()
 	var level slog.Level
 	switch cfg.Logging.Level {
@@ -40,13 +75,5 @@ func Configure() {
 		},
 		Level: level,
 	})
-	globalLogger = slog.New(handler).With("component", "main")
-
-}
-
-func GetLogger() *slog.Logger {
-	if globalLogger == nil {
-		Configure()
-	}
-	return globalLogger
+	return slog.New(handler).With("component", "main")
 }

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -1,0 +1,33 @@
+package logging
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestConcurrentGetLoggerAndConfigureRaceFree hammers the global logger from
+// many goroutines at once, mixing lazy initialization (GetLogger) with explicit
+// reconfiguration (Configure). Run with -race, it fails if access to the global
+// logger is unsynchronized.
+func TestConcurrentGetLoggerAndConfigureRaceFree(t *testing.T) {
+	// Force the lazy-initialization path so first-use is exercised too. This is
+	// sequenced before the goroutines below, so it does not itself race.
+	globalLogger = nil
+
+	const goroutines = 64
+	var wg sync.WaitGroup
+	wg.Add(goroutines * 2)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			if GetLogger() == nil {
+				t.Error("GetLogger returned nil")
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			Configure()
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a data race in the global logger by making `GetLogger` and `Configure` thread-safe with a read/write lock. Adds a concurrency test to prevent regressions under `-race`.

- **Bug Fixes**
  - Protect the global `*slog.Logger` with `sync.RWMutex`; `GetLogger` uses double-checked locking to reduce contention.
  - Extract `buildLogger()` to construct the logger from config without touching shared state.
  - Add `TestConcurrentGetLoggerAndConfigureRaceFree` to hammer `GetLogger` and `Configure` concurrently and fail if access is unsynchronized.

<sup>Written for commit babe67678355607723c183790851807fc4a30310. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/shai/pull/310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

