### PR TITLE
fix: indexer watch cleanups

### DIFF
--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -260,8 +260,14 @@ func (i *Indexer) scheduleSyncStatusLogLocked() {
 
 func (i *Indexer) syncStatusLog() {
 	// Snapshot the cursor fields under the lock, then log and reschedule
-	// without holding it.
+	// without holding it. Bail out if logging has been stopped (by Stop or by
+	// reaching the chain tip): a timer callback that was already in flight when
+	// that happened must not emit a stale catch-up message.
 	i.mu.Lock()
+	if i.syncLogDone {
+		i.mu.Unlock()
+		return
+	}
 	cursorSlot := i.cursorSlot
 	cursorHash := i.cursorHash
 	tipSlot := i.tipSlot

--- a/internal/indexer/indexer_test.go
+++ b/internal/indexer/indexer_test.go
@@ -15,12 +15,47 @@
 package indexer
 
 import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	input_chainsync "github.com/blinklabs-io/adder/input/chainsync"
+	"github.com/blinklabs-io/shai/internal/logging"
 )
+
+// captureStdout redirects the global logger's output (os.Stdout) for the
+// duration of fn and returns everything written. The logger is rebuilt to point
+// at the pipe and restored afterwards.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	orig := os.Stdout
+	os.Stdout = w
+	logging.Configure()
+
+	done := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		done <- buf.String()
+	}()
+
+	fn()
+
+	os.Stdout = orig
+	_ = w.Close()
+	out := <-done
+	_ = r.Close()
+	logging.Configure()
+	return out
+}
 
 func TestIndexerStopHaltsWatchManager(t *testing.T) {
 	idx := New()
@@ -67,6 +102,46 @@ func TestIndexerSyncStatusLogConcurrent(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+}
+
+func TestSyncStatusLogSkipsLoggingAfterStop(t *testing.T) {
+	idx := New()
+	defer idx.Stop()
+
+	// Mark the catch-up sync logger as stopped, as Stop and reaching the chain
+	// tip both do. A timer callback that was already in flight at that point
+	// must not emit a stale catch-up message.
+	idx.mu.Lock()
+	idx.syncLogDone = true
+	idx.mu.Unlock()
+
+	out := captureStdout(t, func() {
+		idx.syncStatusLog()
+	})
+
+	if strings.Contains(out, "catch-up sync in progress") {
+		t.Errorf("syncStatusLog logged after shutdown: %q", out)
+	}
+}
+
+func TestSyncStatusLogEmitsWhenActive(t *testing.T) {
+	idx := New()
+	defer idx.Stop()
+
+	// Positive control: while logging is active, syncStatusLog must emit the
+	// catch-up message. This proves the skip test above is meaningful.
+	out := captureStdout(t, func() {
+		idx.syncStatusLog()
+	})
+
+	// syncStatusLog reschedules itself; halt the timer it armed.
+	idx.mu.Lock()
+	idx.stopSyncLogTimerLocked()
+	idx.mu.Unlock()
+
+	if !strings.Contains(out, "catch-up sync in progress") {
+		t.Errorf("expected catch-up message while active, got %q", out)
+	}
 }
 
 func TestIndexerStopHaltsSyncLogTimer(t *testing.T) {

--- a/internal/indexer/watches.go
+++ b/internal/indexer/watches.go
@@ -67,6 +67,9 @@ type WatchManager struct {
 	nextId    uint64
 	stopChan  chan struct{}
 	stopped   bool
+	// callbackWg tracks in-flight callback goroutines spawned by fireWatches so
+	// Stop can wait for them to finish before returning.
+	callbackWg sync.WaitGroup
 }
 
 // utxoPattern builds the lookup key used for UTxO watches.
@@ -252,17 +255,20 @@ func (wm *WatchManager) CheckEvent(evt event.Event) {
 
 // fireWatches invokes the callback for each of the given watch ids, each in
 // its own goroutine so a slow callback cannot block the event loop or hold the
-// lock. Watches with a nil callback are skipped so a registration that omitted
-// a callback cannot panic the process. A panic from within a callback is
-// recovered and logged so a misbehaving watch cannot crash the process. The
-// caller must hold the lock.
+// lock. Each goroutine is tracked on callbackWg so Stop can wait for in-flight
+// callbacks to finish. Watches with a nil callback are skipped so a
+// registration that omitted a callback cannot panic the process. A panic from
+// within a callback is recovered and logged so a misbehaving watch cannot crash
+// the process. The caller must hold the lock.
 func (wm *WatchManager) fireWatches(watchIds []string, evt event.Event) {
 	for _, watchId := range watchIds {
 		watch, ok := wm.watches[watchId]
 		if !ok || watch.Callback == nil {
 			continue
 		}
+		wm.callbackWg.Add(1)
 		go func(id string, callback WatchCallback) {
+			defer wm.callbackWg.Done()
 			defer func() {
 				if r := recover(); r != nil {
 					logging.GetLogger().Error(
@@ -315,11 +321,13 @@ func (wm *WatchManager) expirationLoop() {
 
 // Stop halts the background expiration loop and clears all registered watches.
 // After Stop, CheckEvent delivers no further callbacks and Register* calls are
-// rejected. It is idempotent and safe to call multiple times.
+// rejected. Stop also blocks until any callback goroutines that were already in
+// flight have finished, so no callback runs after Stop returns. It is
+// idempotent and safe to call multiple times.
 func (wm *WatchManager) Stop() {
 	wm.Lock()
-	defer wm.Unlock()
 	if wm.stopped {
+		wm.Unlock()
 		return
 	}
 	wm.stopped = true
@@ -327,6 +335,13 @@ func (wm *WatchManager) Stop() {
 	wm.watches = make(map[string]*Watch)
 	wm.txIdIndex = make(map[string][]string)
 	wm.utxoIndex = make(map[string][]string)
+	wm.Unlock()
+
+	// Wait for in-flight callbacks outside the lock. CheckEvent gates on
+	// stopped under the read lock, so once the write lock above is released no
+	// new callbacks can be spawned; waiting without the lock held lets a
+	// callback that re-enters the manager finish instead of deadlocking.
+	wm.callbackWg.Wait()
 }
 
 // WatchCount returns the number of active watches.

--- a/internal/indexer/watches_test.go
+++ b/internal/indexer/watches_test.go
@@ -16,6 +16,7 @@ package indexer
 
 import (
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -223,6 +224,58 @@ func TestStopIdempotent(t *testing.T) {
 	// Stopping multiple times must not panic
 	wm.Stop()
 	wm.Stop()
+}
+
+func TestStopWaitsForInFlightCallbacks(t *testing.T) {
+	wm := NewWatchManager()
+
+	txHash := "abc123def456"
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var finished atomic.Bool
+
+	// A callback that parks until released, simulating a slow in-flight
+	// callback that is still running when Stop is called.
+	wm.RegisterTxWatch(txHash, time.Hour, func(id string, evt event.Event) {
+		close(started)
+		<-release
+		finished.Store(true)
+	})
+
+	tx := mockledger.NewTransactionBuilder()
+	evt := event.Event{
+		Type:    "chainsync.transaction",
+		Payload: event.TransactionEvent{Transaction: tx},
+		Context: event.TransactionContext{TransactionHash: txHash},
+	}
+	wm.CheckEvent(evt)
+
+	// Ensure the callback goroutine is actually running before we stop.
+	<-started
+
+	stopReturned := make(chan struct{})
+	go func() {
+		wm.Stop()
+		close(stopReturned)
+	}()
+
+	// Stop must not return while the callback is still in flight.
+	select {
+	case <-stopReturned:
+		t.Fatal("Stop returned before in-flight callback finished")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// Release the callback; Stop must return only after it has completed.
+	close(release)
+	select {
+	case <-stopReturned:
+		if !finished.Load() {
+			t.Error("Stop returned before the callback finished running")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Stop did not return after the in-flight callback completed")
+	}
 }
 
 func TestCheckEventNilTxCallbackDoesNotPanic(t *testing.T) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes shutdown races in the indexer. `WatchManager.Stop` now waits for in-flight callbacks, and `Indexer.syncStatusLog` no longer emits stale catch-up logs after stop or at chain tip.

- **Bug Fixes**
  - Track callback goroutines with `callbackWg`; `Stop` waits outside the lock so no callback runs after it returns.
  - `fireWatches` wraps callbacks with Add/Done and keeps panic recovery; nil callbacks are skipped.
  - `syncStatusLog` exits early when `syncLogDone` is set to suppress stale "catch-up" messages.
  - Tests: add coverage for Stop waiting behavior and logging skip/emit, including a `captureStdout` helper.

<sup>Written for commit 6582d98c35f57db853abfeaddebf9e8d4282697c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/shai/pull/325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

