### PR TITLE
fix: switch mk-script-address to slog

### DIFF
--- a/cmd/mk-script-address/main.go
+++ b/cmd/mk-script-address/main.go
@@ -4,7 +4,7 @@ import (
 	"encoding/hex"
 	"flag"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 
 	ouroboros "github.com/blinklabs-io/gouroboros"
@@ -89,7 +89,8 @@ func main() {
 
 	hash, err := blake2b.New(28, nil)
 	if err != nil {
-		log.Fatalf("failed to create blake2b hash: %s", err)
+		slog.Error("failed to create blake2b hash", "error", err)
+		os.Exit(1)
 	}
 	hash.Write([]byte{byte(cmdlineFlags.plutusVersion)})
 	//hash.Write(innerScriptData[:])


### PR DESCRIPTION
Replaces the last remaining stdlib `log` usage (`log.Fatalf` in `cmd/mk-script-address`) with `slog.Error` + `os.Exit(1)`, matching the slog idiom used in `cmd/shai`. No stdlib `log` imports remain in the repo.

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the last stdlib `log` usage in `cmd/mk-script-address` with `log/slog`, using `slog.Error` + `os.Exit(1)` for error handling. This standardizes structured logging to match `cmd/shai` and removes all stdlib `log` imports from the repo.

<sup>Written for commit 552ea26645f31dc017803252734a2a2567a8086c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/shai/pull/326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

