### PR TITLE
feat: sundae v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Shai is a Cardano Multi-DEX oracle and matcher bot. It monitors the blockchain f
 ## Features
 
 - DEX Oracle: Real-time pool state tracking from on-chain data
-- Multi-DEX Support: Minswap v1/v2, SundaeSwap v3, Splash v1, WingRiders v2, VyFi, CSWAP
+- Multi-DEX Support: Minswap v1/v2, SundaeSwap v1/v3, Splash v1, WingRiders v2, VyFi, CSWAP
 - Spectrum Batching: Matcher bot for Spectrum-compatible DEXs
 - Mempool Monitoring: Track pending transactions for faster matching
 - Cardano Node: Acts as both NtN (Node-to-Node) and NtC (Node-to-Client) peer
@@ -63,6 +63,7 @@ network: mainnet
 profiles:
   - minswap-v1
   - minswap-v2
+  - sundaeswap-v1
   - sundaeswap-v3
   - splash-v1
   - wingriders-v2
@@ -90,6 +91,7 @@ wallet:
 Oracle profiles (price tracking):
 - `minswap-v1` - Minswap V1 pools (legacy)
 - `minswap-v2` - Minswap V2 pools
+- `sundaeswap-v1` - SundaeSwap V1 pools (legacy)
 - `sundaeswap-v3` - SundaeSwap V3 pools
 - `splash-v1` - Splash (formerly Spectrum) pools
 - `wingriders-v2` - WingRiders V2 pools
@@ -119,7 +121,7 @@ Track pool prices across multiple DEXs:
 
 ```bash
 export NETWORK=mainnet
-export PROFILES=minswap-v1,minswap-v2,sundaeswap-v3,splash-v1,wingriders-v2,vyfi,cswap
+export PROFILES=minswap-v1,minswap-v2,sundaeswap-v1,sundaeswap-v3,splash-v1,wingriders-v2,vyfi,cswap
 export INDEXER_TCP_ADDRESS=localhost:3001
 ./shai
 ```

--- a/cmd/shai/main.go
+++ b/cmd/shai/main.go
@@ -208,6 +208,8 @@ func getOracleParser(protocol string) oracle.PoolParser {
 		return oracle.NewMinswapV1Parser()
 	case "minswap-v2", "minswap":
 		return oracle.NewMinswapV2Parser()
+	case "sundaeswap-v1":
+		return oracle.NewSundaeSwapV1Parser()
 	case "sundaeswap-v3", "sundaeswap":
 		return oracle.NewSundaeSwapV3Parser()
 	case "splash-v1", "splash":

--- a/internal/config/profiles.go
+++ b/internal/config/profiles.go
@@ -140,6 +140,22 @@ var Profiles = map[string]map[string]Profile{
 				},
 			},
 		},
+		"sundaeswap-v1": {
+			Name:          "sundaeswap-v1",
+			Type:          ProfileTypeOracle,
+			InterceptSlot: 51337110, // First block at/after the V1 launch slot 51337095
+			InterceptHash: "d1423d7eb6fc87d7ad1a54e44dd8cb70483370877346f3178dd507d7609046c8",
+			Config: OracleProfileConfig{
+				Protocol: "sundaeswap-v1",
+				PoolAddresses: []ProfileConfigAddress{
+					// SundaeSwap V1 pool script address (mainnet)
+					{
+						Address: "addr1wyx22z2s4kasd3w976pnjf9xdty88epjqfvgkmfnfpsdacqe7utc8",
+					},
+				},
+				InputRefs: []ProfileConfigInputRef{},
+			},
+		},
 		"sundaeswap-v3": {
 			Name:          "sundaeswap-v3",
 			Type:          ProfileTypeOracle,

--- a/internal/config/profiles_test.go
+++ b/internal/config/profiles_test.go
@@ -48,3 +48,45 @@ func TestMainnetCSwapProfileIsWired(t *testing.T) {
 		}
 	}
 }
+
+func TestMainnetSundaeSwapV1ProfileIsWired(t *testing.T) {
+	t.Parallel()
+
+	mainnetProfiles, ok := Profiles["mainnet"]
+	if !ok {
+		t.Fatal("missing mainnet profiles")
+	}
+
+	profile, ok := mainnetProfiles["sundaeswap-v1"]
+	if !ok {
+		t.Fatal("missing sundaeswap-v1 profile")
+	}
+
+	if profile.Type != ProfileTypeOracle {
+		t.Fatalf("unexpected profile type: got %v want %v", profile.Type, ProfileTypeOracle)
+	}
+	if profile.InterceptSlot != 51337110 {
+		t.Fatalf("unexpected intercept slot: got %d want %d", profile.InterceptSlot, 51337110)
+	}
+	if profile.InterceptHash != "d1423d7eb6fc87d7ad1a54e44dd8cb70483370877346f3178dd507d7609046c8" {
+		t.Fatalf("unexpected intercept hash: got %q", profile.InterceptHash)
+	}
+
+	oracleCfg, ok := profile.Config.(OracleProfileConfig)
+	if !ok {
+		t.Fatalf("unexpected config type: %T", profile.Config)
+	}
+	if oracleCfg.Protocol != "sundaeswap-v1" {
+		t.Fatalf(
+			"unexpected protocol: got %q want %q",
+			oracleCfg.Protocol,
+			"sundaeswap-v1",
+		)
+	}
+	if len(oracleCfg.PoolAddresses) != 1 {
+		t.Fatalf("unexpected pool address count: got %d want 1", len(oracleCfg.PoolAddresses))
+	}
+	if !strings.HasPrefix(oracleCfg.PoolAddresses[0].Address, "addr1") {
+		t.Fatalf("pool address has unexpected format: %q", oracleCfg.PoolAddresses[0].Address)
+	}
+}

--- a/internal/oracle/sundaeswap.go
+++ b/internal/oracle/sundaeswap.go
@@ -25,6 +25,11 @@ type SundaeSwapParser struct {
 	parser *sundaeswap.Parser
 }
 
+// NewSundaeSwapV1Parser creates a parser for SundaeSwap V1 pools
+func NewSundaeSwapV1Parser() *SundaeSwapParser {
+	return &SundaeSwapParser{parser: sundaeswap.NewV1Parser()}
+}
+
 // NewSundaeSwapV3Parser creates a parser for SundaeSwap V3 pools
 func NewSundaeSwapV3Parser() *SundaeSwapParser {
 	return &SundaeSwapParser{parser: sundaeswap.NewV3Parser()}

--- a/internal/oracle/sundaeswap/models.go
+++ b/internal/oracle/sundaeswap/models.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package sundaeswap provides datum types and parsing for SundaeSwap V3 DEX protocol.
+// Package sundaeswap provides datum types and parsing for SundaeSwap DEX protocols.
 package sundaeswap
 
 import (
@@ -26,7 +26,87 @@ import (
 const (
 	ProtocolName = "sundaeswap"
 	FeeDenom     = 10000
+
+	// V1DefaultFee is the default SundaeSwap V1 pool fee in basis points.
+	V1DefaultFee = 30
+
+	// V1PoolIdentLength is the byte length of a SundaeSwap V1 pool identifier.
+	V1PoolIdentLength = 28
 )
+
+// V1PoolDatum represents the SundaeSwap V1 pool datum structure.
+type V1PoolDatum struct {
+	cbor.StructAsArray
+	cbor.DecodeStoreCbor
+	Ident         []byte
+	AssetA        V1AssetClass
+	AssetB        V1AssetClass
+	CirculatingLp uint64
+	FeeNumerator  uint64
+}
+
+func (d *V1PoolDatum) UnmarshalCBOR(cborData []byte) error {
+	var tmpConstr cbor.ConstructorDecoder
+	if _, err := cbor.Decode(cborData, &tmpConstr); err != nil {
+		return err
+	}
+	if tmpConstr.Tag() != 0 {
+		return fmt.Errorf(
+			"expected constructor 0, got %d",
+			tmpConstr.Tag(),
+		)
+	}
+
+	type tV1PoolDatum V1PoolDatum
+	var tmp tV1PoolDatum
+	if _, err := cbor.Decode(tmpConstr.Fields(), &tmp); err != nil {
+		return err
+	}
+	*d = V1PoolDatum(tmp)
+	d.SetCbor(cborData)
+	return nil
+}
+
+// V1AssetClass represents a constructor-wrapped asset class in V1 datums.
+type V1AssetClass struct {
+	cbor.StructAsArray
+	PolicyId  []byte
+	AssetName []byte
+}
+
+func (a *V1AssetClass) UnmarshalCBOR(cborData []byte) error {
+	var tmpConstr cbor.ConstructorDecoder
+	if _, err := cbor.Decode(cborData, &tmpConstr); err != nil {
+		return err
+	}
+	if tmpConstr.Tag() != 0 {
+		return fmt.Errorf(
+			"expected constructor 0, got %d",
+			tmpConstr.Tag(),
+		)
+	}
+
+	type tV1AssetClass V1AssetClass
+	var tmp tV1AssetClass
+	if _, err := cbor.Decode(tmpConstr.Fields(), &tmp); err != nil {
+		return err
+	}
+	*a = V1AssetClass(tmp)
+	return nil
+}
+
+// ToCommonAssetClass converts to common.AssetClass.
+func (a V1AssetClass) ToCommonAssetClass() common.AssetClass {
+	return common.AssetClass{
+		PolicyId: a.PolicyId,
+		Name:     a.AssetName,
+	}
+}
+
+// GetPoolIdent returns the pool identifier as hex string.
+func (d *V1PoolDatum) GetPoolIdent() string {
+	return fmt.Sprintf("%x", d.Ident)
+}
 
 // V3PoolDatum represents the SundaeSwap V3 pool datum structure
 type V3PoolDatum struct {

--- a/internal/oracle/sundaeswap/parser.go
+++ b/internal/oracle/sundaeswap/parser.go
@@ -40,21 +40,107 @@ type PoolState struct {
 	Timestamp time.Time
 }
 
-// Parser implements pool parsing for SundaeSwap V3
-type Parser struct{}
+// Parser implements pool parsing for SundaeSwap
+type Parser struct {
+	version int
+}
+
+// NewV1Parser creates a parser for SundaeSwap V1 pools
+func NewV1Parser() *Parser {
+	return &Parser{version: 1}
+}
 
 // NewV3Parser creates a parser for SundaeSwap V3 pools
 func NewV3Parser() *Parser {
-	return &Parser{}
+	return &Parser{version: 3}
 }
 
 // Protocol returns the protocol name
 func (p *Parser) Protocol() string {
-	return ProtocolName + "-v3"
+	return fmt.Sprintf("%s-v%d", ProtocolName, p.version)
 }
 
-// ParsePoolDatum parses a SundaeSwap V3 pool datum
+// ParsePoolDatum parses a SundaeSwap pool datum
 func (p *Parser) ParsePoolDatum(
+	datum []byte,
+	utxoValue []byte,
+	txHash string,
+	txIndex uint32,
+	slot uint64,
+	timestamp time.Time,
+) (*PoolState, error) {
+	switch p.version {
+	case 1:
+		return p.parseV1Datum(datum, utxoValue, txHash, txIndex, slot, timestamp)
+	case 3:
+		return p.parseV3Datum(datum, utxoValue, txHash, txIndex, slot, timestamp)
+	default:
+		return nil, fmt.Errorf("unsupported SundaeSwap version: %d", p.version)
+	}
+}
+
+func (p *Parser) parseV1Datum(
+	datum []byte,
+	utxoValue []byte,
+	txHash string,
+	txIndex uint32,
+	slot uint64,
+	timestamp time.Time,
+) (*PoolState, error) {
+	var poolDatum V1PoolDatum
+	if _, err := cbor.Decode(datum, &poolDatum); err != nil {
+		return nil, fmt.Errorf("failed to decode SundaeSwap V1 datum: %w", err)
+	}
+
+	poolId, err := GeneratePoolIdentId(poolDatum.Ident)
+	if err != nil {
+		return nil, fmt.Errorf("invalid SundaeSwap V1 pool identifier: %w", err)
+	}
+
+	feeNum := poolDatum.FeeNumerator
+	if feeNum == 0 {
+		feeNum = V1DefaultFee
+	}
+	if feeNum > FeeDenom {
+		return nil, fmt.Errorf(
+			"invalid fee: fee numerator %d exceeds denominator %d",
+			feeNum,
+			FeeDenom,
+		)
+	}
+
+	assetA := poolDatum.AssetA.ToCommonAssetClass()
+	assetB := poolDatum.AssetB.ToCommonAssetClass()
+	reserveA, reserveB, err := p.extractReservesFromValue(
+		utxoValue,
+		assetA,
+		assetB,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract V1 reserves: %w", err)
+	}
+
+	return &PoolState{
+		PoolId:   poolId,
+		Protocol: p.Protocol(),
+		AssetX: common.AssetAmount{
+			Class:  assetA,
+			Amount: reserveA,
+		},
+		AssetY: common.AssetAmount{
+			Class:  assetB,
+			Amount: reserveB,
+		},
+		FeeNum:    FeeDenom - feeNum,
+		FeeDenom:  FeeDenom,
+		Slot:      slot,
+		TxHash:    txHash,
+		TxIndex:   txIndex,
+		Timestamp: timestamp,
+	}, nil
+}
+
+func (p *Parser) parseV3Datum(
 	datum []byte,
 	utxoValue []byte,
 	txHash string,
@@ -127,8 +213,13 @@ func (p *Parser) ParsePoolDatum(
 		)
 	}
 
-	// Parse the UTXO value to extract token amounts
-	reserveA, reserveB, err := p.extractReservesFromValue(utxoValue, poolDatum)
+	assetA := poolDatum.Assets.AssetA.ToCommonAssetClass()
+	assetB := poolDatum.Assets.AssetB.ToCommonAssetClass()
+	reserveA, reserveB, err := p.extractReservesFromValue(
+		utxoValue,
+		assetA,
+		assetB,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to extract reserves: %w", err)
 	}
@@ -137,11 +228,11 @@ func (p *Parser) ParsePoolDatum(
 		PoolId:   poolId,
 		Protocol: p.Protocol(),
 		AssetX: common.AssetAmount{
-			Class:  poolDatum.Assets.AssetA.ToCommonAssetClass(),
+			Class:  assetA,
 			Amount: reserveA,
 		},
 		AssetY: common.AssetAmount{
-			Class:  poolDatum.Assets.AssetB.ToCommonAssetClass(),
+			Class:  assetB,
 			Amount: reserveB,
 		},
 		FeeNum:    effectiveFeeNum,
@@ -156,7 +247,8 @@ func (p *Parser) ParsePoolDatum(
 // extractReservesFromValue extracts the reserve amounts for AssetA and AssetB from the UTXO value
 func (p *Parser) extractReservesFromValue(
 	utxoValue []byte,
-	poolDatum V3PoolDatum,
+	assetA common.AssetClass,
+	assetB common.AssetClass,
 ) (uint64, uint64, error) {
 	// Parse the UTXO output CBOR using the generic decoder
 	// This handles all eras (Mary, Alonzo, Babbage, Conway)
@@ -168,8 +260,8 @@ func (p *Parser) extractReservesFromValue(
 	// Extract reserve for AssetA
 	reserveA, err := p.getAssetAmount(
 		txOut,
-		poolDatum.Assets.AssetA.PolicyId,
-		poolDatum.Assets.AssetA.AssetName,
+		assetA.PolicyId,
+		assetA.Name,
 	)
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to get AssetA amount: %w", err)
@@ -178,8 +270,8 @@ func (p *Parser) extractReservesFromValue(
 	// Extract reserve for AssetB
 	reserveB, err := p.getAssetAmount(
 		txOut,
-		poolDatum.Assets.AssetB.PolicyId,
-		poolDatum.Assets.AssetB.AssetName,
+		assetB.PolicyId,
+		assetB.Name,
 	)
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to get AssetB amount: %w", err)
@@ -194,8 +286,14 @@ func (p *Parser) getAssetAmount(
 	policyId []byte,
 	assetName []byte,
 ) (uint64, error) {
-	// Check if this is ADA (empty policy ID)
+	// Check if this is ADA (empty policy ID and empty asset name)
 	if len(policyId) == 0 {
+		if len(assetName) != 0 {
+			return 0, fmt.Errorf(
+				"malformed asset: empty policyId with non-empty assetName %x",
+				assetName,
+			)
+		}
 		amount := txOut.Amount()
 		return amount.Uint64(), nil
 	}
@@ -238,6 +336,18 @@ func (p *Parser) getAssetAmount(
 		policyId,
 		assetName,
 	)
+}
+
+// GeneratePoolIdentId generates a unique pool ID from a pool identifier
+func GeneratePoolIdentId(identifier []byte) (string, error) {
+	if len(identifier) != V1PoolIdentLength {
+		return "", fmt.Errorf(
+			"expected %d-byte identifier, got %d bytes",
+			V1PoolIdentLength,
+			len(identifier),
+		)
+	}
+	return fmt.Sprintf("sundaeswap_%s", hex.EncodeToString(identifier)), nil
 }
 
 // GeneratePoolId generates a unique pool ID from asset pair

--- a/internal/oracle/sundaeswap/sundaeswap_test.go
+++ b/internal/oracle/sundaeswap/sundaeswap_test.go
@@ -16,6 +16,7 @@ package sundaeswap
 
 import (
 	"testing"
+	"time"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
 	"github.com/blinklabs-io/shai/internal/common"
@@ -28,9 +29,34 @@ func TestNewV3Parser(t *testing.T) {
 	require.NotNil(t, parser, "NewV3Parser returned nil")
 }
 
+func TestNewV1Parser(t *testing.T) {
+	parser := NewV1Parser()
+	require.NotNil(t, parser, "NewV1Parser returned nil")
+}
+
 func TestParser_Protocol(t *testing.T) {
-	parser := NewV3Parser()
-	assert.Equal(t, "sundaeswap-v3", parser.Protocol())
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{
+			name: "V1",
+			got:  NewV1Parser().Protocol(),
+			want: "sundaeswap-v1",
+		},
+		{
+			name: "V3",
+			got:  NewV3Parser().Protocol(),
+			want: "sundaeswap-v3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.got)
+		})
+	}
 }
 
 func TestGeneratePoolId(t *testing.T) {
@@ -45,6 +71,22 @@ func TestGeneratePoolId(t *testing.T) {
 
 func TestAssetClass_ToCommonAssetClass(t *testing.T) {
 	asset := AssetClass{
+		PolicyId:  []byte{0x01, 0x02, 0x03},
+		AssetName: []byte{0x04, 0x05},
+	}
+
+	expected := common.AssetClass{
+		PolicyId: []byte{0x01, 0x02, 0x03},
+		Name:     []byte{0x04, 0x05},
+	}
+
+	result := asset.ToCommonAssetClass()
+	assert.Equal(t, expected.PolicyId, result.PolicyId)
+	assert.Equal(t, expected.Name, result.Name)
+}
+
+func TestV1AssetClass_ToCommonAssetClass(t *testing.T) {
+	asset := V1AssetClass{
 		PolicyId:  []byte{0x01, 0x02, 0x03},
 		AssetName: []byte{0x04, 0x05},
 	}
@@ -233,6 +275,79 @@ func TestV3PoolDatumUnmarshal(t *testing.T) {
 	assert.Equal(t, "SUNDAE", string(poolDatum.Assets.AssetB.AssetName))
 }
 
+func TestV1PoolDatumUnmarshal(t *testing.T) {
+	ident := make([]byte, 28)
+	for i := range ident {
+		ident[i] = byte(i + 1)
+	}
+
+	assetA := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		[]byte{},
+		[]byte{},
+	})
+
+	assetB := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		[]byte{0xab, 0xcd, 0xef},
+		[]byte("SUNDAE"),
+	})
+
+	datum := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		ident,
+		assetA,
+		assetB,
+		uint64(1000000000),
+		uint64(30),
+	})
+
+	cborData, err := cbor.Encode(&datum)
+	require.NoError(t, err, "failed to encode datum")
+
+	var poolDatum V1PoolDatum
+	_, err = cbor.Decode(cborData, &poolDatum)
+	require.NoError(t, err, "failed to decode datum")
+
+	assert.Equal(t, ident, poolDatum.Ident)
+	assert.Equal(t, uint64(1000000000), poolDatum.CirculatingLp)
+	assert.Equal(t, uint64(30), poolDatum.FeeNumerator)
+	assert.Empty(t, poolDatum.AssetA.PolicyId, "expected AssetA to be ADA")
+	assert.Equal(t, "SUNDAE", string(poolDatum.AssetB.AssetName))
+	assert.Equal(t, "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c", poolDatum.GetPoolIdent())
+}
+
+func TestV1ParserRejectsInvalidPoolIdentBeforeReserves(t *testing.T) {
+	assetA := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		[]byte{},
+		[]byte{},
+	})
+	assetB := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		[]byte{0xab, 0xcd, 0xef},
+		[]byte("SUNDAE"),
+	})
+	datum := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		[]byte{},
+		assetA,
+		assetB,
+		uint64(1000000000),
+		uint64(30),
+	})
+
+	cborData, err := cbor.Encode(&datum)
+	require.NoError(t, err, "failed to encode datum")
+
+	_, err = NewV1Parser().ParsePoolDatum(
+		cborData,
+		[]byte("not a transaction output"),
+		"abc123",
+		2,
+		12345,
+		time.Time{},
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid SundaeSwap V1 pool identifier")
+	assert.Contains(t, err.Error(), "expected 28-byte identifier, got 0 bytes")
+	assert.NotContains(t, err.Error(), "failed to decode UTXO output")
+}
+
 func TestGeneratePoolIdWithADA(t *testing.T) {
 	// Test pool ID generation with ADA (empty policy/name)
 	// Empty bytes encode to empty strings, so format is: sundaeswap_._abcd.544f4b454e
@@ -244,4 +359,51 @@ func TestGeneratePoolIdWithADA(t *testing.T) {
 	)
 
 	assert.Equal(t, "sundaeswap_._abcd.544f4b454e", poolId)
+}
+
+func TestGeneratePoolIdentId(t *testing.T) {
+	identifier := make([]byte, V1PoolIdentLength)
+	for i := range identifier {
+		identifier[i] = byte(i)
+	}
+
+	poolId, err := GeneratePoolIdentId(identifier)
+	require.NoError(t, err)
+	assert.Equal(
+		t,
+		"sundaeswap_000102030405060708090a0b0c0d0e0f101112131415161718191a1b",
+		poolId,
+	)
+}
+
+func TestGeneratePoolIdentIdRejectsInvalidLength(t *testing.T) {
+	tests := []struct {
+		name       string
+		identifier []byte
+	}{
+		{
+			name:       "nil",
+			identifier: nil,
+		},
+		{
+			name:       "empty",
+			identifier: []byte{},
+		},
+		{
+			name:       "short",
+			identifier: []byte{0xab, 0xcd, 0xef},
+		},
+		{
+			name:       "long",
+			identifier: make([]byte, V1PoolIdentLength+1),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := GeneratePoolIdentId(tt.identifier)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "expected 28-byte identifier")
+		})
+	}
 }

--- a/internal/oracle/sundaeswap_test.go
+++ b/internal/oracle/sundaeswap_test.go
@@ -1,0 +1,117 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oracle
+
+import (
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+)
+
+func TestNewSundaeSwapV1Parser(t *testing.T) {
+	parser := NewSundaeSwapV1Parser()
+	if parser == nil {
+		t.Fatal("expected non-nil parser")
+	}
+	if parser.Protocol() != "sundaeswap-v1" {
+		t.Errorf("expected protocol 'sundaeswap-v1', got %s", parser.Protocol())
+	}
+
+	var _ PoolParser = parser
+}
+
+func TestSundaeSwapV1ParserParsePoolDatum(t *testing.T) {
+	ident := make([]byte, 28)
+	for i := range ident {
+		ident[i] = byte(i)
+	}
+
+	tokenPolicy := make([]byte, 28)
+	for i := range tokenPolicy {
+		tokenPolicy[i] = 0xab
+	}
+
+	assetA := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		[]byte{},
+		[]byte{},
+	})
+	assetB := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		tokenPolicy,
+		[]byte("SUNDAE"),
+	})
+	datum := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		ident,
+		assetA,
+		assetB,
+		uint64(500000000),
+		uint64(30),
+	})
+	cborData, err := cbor.Encode(&datum)
+	if err != nil {
+		t.Fatalf("failed to encode datum: %v", err)
+	}
+
+	utxoValue, err := buildMaryOutputCbor(
+		100000000,
+		tokenPolicy,
+		[]byte("SUNDAE"),
+		250000000,
+	)
+	if err != nil {
+		t.Fatalf("failed to build UTxO output: %v", err)
+	}
+
+	parser := NewSundaeSwapV1Parser()
+	state, err := parser.ParsePoolDatum(
+		cborData,
+		utxoValue,
+		"abc123",
+		2,
+		12345,
+		time.Now(),
+	)
+	if err != nil {
+		t.Fatalf("failed to parse datum: %v", err)
+	}
+
+	if state.PoolId != "sundaeswap_000102030405060708090a0b0c0d0e0f101112131415161718191a1b" {
+		t.Errorf("unexpected pool ID: %s", state.PoolId)
+	}
+	if state.Protocol != "sundaeswap-v1" {
+		t.Errorf("expected protocol 'sundaeswap-v1', got %s", state.Protocol)
+	}
+	if state.Slot != 12345 {
+		t.Errorf("expected slot 12345, got %d", state.Slot)
+	}
+	if state.TxHash != "abc123" {
+		t.Errorf("expected txHash 'abc123', got %s", state.TxHash)
+	}
+	if state.TxIndex != 2 {
+		t.Errorf("expected txIndex 2, got %d", state.TxIndex)
+	}
+	if state.AssetX.Amount != 100000000 {
+		t.Errorf("expected assetX amount 100000000, got %d", state.AssetX.Amount)
+	}
+	if state.AssetY.Amount != 250000000 {
+		t.Errorf("expected assetY amount 250000000, got %d", state.AssetY.Amount)
+	}
+	if state.FeeNum != 9970 {
+		t.Errorf("expected feeNum 9970, got %d", state.FeeNum)
+	}
+	if state.FeeDenom != 10000 {
+		t.Errorf("expected feeDenom 10000, got %d", state.FeeDenom)
+	}
+}


### PR DESCRIPTION
Closes #311 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SundaeSwap v1 oracle support for legacy mainnet pools. Includes a versioned parser with V1 datum decoding, ident-based pool IDs, and mainnet profile/CLI wiring.

- **New Features**
  - Added `sundaeswap-v1` parser: V1 datum types, ADA/token asset decoding, ident-based pool IDs, and 30 bp default fee fallback.
  - Versioned parser now reports `sundaeswap-v1`/`sundaeswap-v3`; reserve extraction generalized to common asset classes with stricter ADA checks.
  - New mainnet profile `sundaeswap-v1` (intercept slot/hash, V1 script address) and CLI support via `getOracleParser`.
  - README updated to list `sundaeswap-v1` and example `PROFILES`; tests added for profile wiring, V1 decoding, pool parsing, and ID helpers.

<sup>Written for commit 312bfb970f57ee7be5c224997b346432b3d75592. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/shai/pull/327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for SundaeSwap V1 DEX protocol as an available oracle profile

* **Documentation**
  * Updated README and configuration examples to include SundaeSwap V1 and reflect the current available profiles

<!-- end of auto-generated comment: release notes by coderabbit.ai -->