### PR TITLE
feat: GeniusYield oracle parser

### DIFF
--- a/cmd/shai/main.go
+++ b/cmd/shai/main.go
@@ -332,6 +332,8 @@ func getOracleParser(protocol string) oracle.PoolParser {
 		return oracle.NewVyFiParser()
 	case "cswap":
 		return oracle.NewCSwapParser()
+	case "geniusyield":
+		return oracle.NewGeniusYieldParser()
 	default:
 		return nil
 	}

--- a/dex/geniusyield.go
+++ b/dex/geniusyield.go
@@ -1,0 +1,159 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dex
+
+import (
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/blinklabs-io/shai/common"
+	"github.com/blinklabs-io/shai/dex/geniusyield"
+)
+
+// Re-export constants for backward compatibility
+const (
+	GeniusYieldProtocolName    = geniusyield.ProtocolName
+	GeniusYieldOrderScriptHash = geniusyield.OrderScriptHash
+	GeniusYieldOrderNFTPolicy  = geniusyield.OrderNFTPolicy
+)
+
+// Re-export types for backward compatibility
+type (
+	GeniusYieldPartialOrderDatum = geniusyield.PartialOrderDatum
+	GeniusYieldOrderState        = geniusyield.OrderState
+	GeniusYieldAsset             = geniusyield.Asset
+	GeniusYieldAddress           = geniusyield.Address
+	GeniusYieldCredential        = geniusyield.Credential
+	GeniusYieldRational          = geniusyield.Rational
+	GeniusYieldOptionalPOSIX     = geniusyield.OptionalPOSIX
+	GeniusYieldContainedFee      = geniusyield.ContainedFee
+)
+
+// GeniusYieldParser wraps geniusyield.Parser for backward compatibility
+type GeniusYieldParser struct {
+	parser *geniusyield.Parser
+}
+
+// NewGeniusYieldParser creates a parser for Genius Yield orders
+func NewGeniusYieldParser() *GeniusYieldParser {
+	return &GeniusYieldParser{parser: geniusyield.NewParser()}
+}
+
+// Protocol returns the protocol name
+func (p *GeniusYieldParser) Protocol() string {
+	return p.parser.Protocol()
+}
+
+// PoolAddresses returns the mainnet script addresses holding this protocol's
+// order UTxOs. Query your node for UTxOs at these addresses, then feed each
+// output's datum and value CBOR to ParsePoolDatum.
+func (p *GeniusYieldParser) PoolAddresses() []string {
+	return PoolAddresses(p.Protocol())
+}
+
+// ParseOrderDatum parses a Genius Yield order datum
+func (p *GeniusYieldParser) ParseOrderDatum(
+	datum []byte,
+	txHash string,
+	txIndex uint32,
+	slot uint64,
+	timestamp time.Time,
+) (*geniusyield.OrderState, error) {
+	return p.parser.ParseOrderDatum(datum, txHash, txIndex, slot, timestamp)
+}
+
+// ParsePoolDatum adapts an order-book order into the generic oracle PoolState.
+func (p *GeniusYieldParser) ParsePoolDatum(
+	datum []byte,
+	utxoValue []byte,
+	txHash string,
+	txIndex uint32,
+	slot uint64,
+	timestamp time.Time,
+) (*PoolState, error) {
+	order, err := p.ParseOrderDatum(datum, txHash, txIndex, slot, timestamp)
+	if err != nil {
+		return nil, err
+	}
+	if order == nil || !order.IsActive {
+		return nil, nil
+	}
+
+	askedAmount, err := geniusYieldAskedAmount(order)
+	if err != nil {
+		return nil, err
+	}
+
+	return &PoolState{
+		PoolId:   order.OrderId,
+		Protocol: order.Protocol,
+		AssetX:   order.OfferedAsset,
+		AssetY: common.AssetAmount{
+			Class:  order.AskedAsset,
+			Amount: askedAmount,
+		},
+		FeeNum:    1,
+		FeeDenom:  1,
+		Slot:      order.Slot,
+		TxHash:    order.TxHash,
+		TxIndex:   order.TxIndex,
+		Timestamp: order.Timestamp,
+	}, nil
+}
+
+func geniusYieldAskedAmount(order *geniusyield.OrderState) (uint64, error) {
+	if order.PriceNum <= 0 || order.PriceDenom <= 0 {
+		return 0, fmt.Errorf(
+			"invalid Genius Yield price %d/%d",
+			order.PriceNum,
+			order.PriceDenom,
+		)
+	}
+	if order.OfferedAsset.Amount == 0 {
+		return 0, nil
+	}
+
+	offered := new(big.Int).SetUint64(order.OfferedAsset.Amount)
+	num := big.NewInt(order.PriceNum)
+	denom := big.NewInt(order.PriceDenom)
+	asked := new(big.Int).Mul(offered, num)
+	asked.Div(asked, denom)
+	if asked.IsUint64() {
+		return asked.Uint64(), nil
+	}
+	return 0, fmt.Errorf(
+		"asked amount overflows uint64 for Genius Yield order %s",
+		order.OrderId,
+	)
+}
+
+// GenerateGeniusYieldOrderId wraps geniusyield.GenerateOrderId
+func GenerateGeniusYieldOrderId(nftTokenName []byte) string {
+	return geniusyield.GenerateOrderId(nftTokenName)
+}
+
+// GetGeniusYieldOrderAddresses returns mainnet order addresses
+func GetGeniusYieldOrderAddresses() []string {
+	return PoolAddresses(GeniusYieldProtocolName)
+}
+
+// CalculateGeniusYieldFillAmount calculates fill amounts for an order
+func CalculateGeniusYieldFillAmount(
+	order *geniusyield.OrderState,
+	askedAssetAmount uint64,
+) (offeredAmount uint64, remainder uint64) {
+	return geniusyield.CalculateFillAmount(order, askedAssetAmount)
+}

--- a/dex/geniusyield/models.go
+++ b/dex/geniusyield/models.go
@@ -1,0 +1,276 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package geniusyield provides datum types and parsing for Genius Yield
+// order-book DEX protocol.
+package geniusyield
+
+import (
+	"fmt"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/shai/common"
+)
+
+// Protocol constants
+const (
+	ProtocolName = "geniusyield"
+
+	// Mainnet order script hash
+	// Genius Yield order-book DEX contract
+	OrderScriptHash = "f95cab2d4cf78cc5ffa1c6f0bdb17a6f35df9a60e442d59e2d576e32"
+
+	// Mainnet NFT policy ID for order identification
+	OrderNFTPolicy = "2e5f2c41e0a58f5a5a7b1f5c5e5f5e5f5e5f5e5f5e5f5e5f5e5f5e5f"
+)
+
+// PartialOrderDatum represents the Genius Yield order datum structure
+// Based on the Haskell definition:
+//
+//	data PartialOrderDatum = PartialOrderDatum
+//	    { podOwnerKey :: PubKeyHash
+//	    , podOwnerAddr :: Address
+//	    , podOfferedAsset :: AssetClass
+//	    , podOfferedOriginalAmount :: Integer
+//	    , podOfferedAmount :: Integer
+//	    , podAskedAsset :: AssetClass
+//	    , podPrice :: Rational  -- (numerator, denominator)
+//	    , podNFT :: TokenName
+//	    , podStart :: Maybe POSIXTime
+//	    , podEnd :: Maybe POSIXTime
+//	    , podPartialFills :: Integer
+//	    , podMakerLovelaceFlatFee :: Integer
+//	    , podMakerOfferedPercentFee :: Rational
+//	    , podMakerOfferedPercentFeeMax :: Integer
+//	    , podContainedFee :: ContainedFee
+//	    , podContainedPayment :: Integer
+//	    }
+type PartialOrderDatum struct {
+	cbor.StructAsArray
+	cbor.DecodeStoreCbor
+	OwnerKey                  []byte        // PubKeyHash for cancellation
+	OwnerAddr                 Address       // Address for payments
+	OfferedAsset              Asset         // Asset being offered
+	OfferedOriginalAmount     uint64        // Original units offered
+	OfferedAmount             uint64        // Current units offered
+	AskedAsset                Asset         // Asset wanted as payment
+	Price                     Rational      // Price per unit (num/denom)
+	NFT                       []byte        // TokenName identifying this order
+	Start                     OptionalPOSIX // Optional start time
+	End                       OptionalPOSIX // Optional end time
+	PartialFills              uint64        // Number of partial fills
+	MakerLovelaceFlatFee      uint64        // Flat fee in lovelace
+	MakerOfferedPercentFee    Rational      // Percentage fee
+	MakerOfferedPercentFeeMax uint64        // Max percentage fee
+	ContainedFee              ContainedFee  // Fee tracking
+	ContainedPayment          uint64        // Payment tracking
+}
+
+func (d *PartialOrderDatum) UnmarshalCBOR(cborData []byte) error {
+	d.SetCbor(cborData)
+	var tmpConstr cbor.ConstructorDecoder
+	if _, err := cbor.Decode(cborData, &tmpConstr); err != nil {
+		return err
+	}
+	if tmpConstr.Tag() != 0 {
+		return fmt.Errorf(
+			"expected constructor 0, got %d",
+			tmpConstr.Tag(),
+		)
+	}
+	return cbor.DecodeGeneric(tmpConstr.Fields(), d)
+}
+
+// Asset represents an asset (PolicyId, AssetName) tuple
+type Asset struct {
+	cbor.StructAsArray
+	PolicyId  []byte
+	AssetName []byte
+}
+
+func (a *Asset) UnmarshalCBOR(cborData []byte) error {
+	var tmpConstr cbor.ConstructorDecoder
+	if _, err := cbor.Decode(cborData, &tmpConstr); err != nil {
+		return err
+	}
+	return cbor.DecodeGeneric(tmpConstr.Fields(), a)
+}
+
+// ToCommonAssetClass converts to common.AssetClass
+func (a Asset) ToCommonAssetClass() common.AssetClass {
+	return common.AssetClass{
+		PolicyId: a.PolicyId,
+		Name:     a.AssetName,
+	}
+}
+
+// Address represents a Cardano address in datum format
+// Constructor 0: PubKeyHash credential
+// Constructor 1: ScriptHash credential
+type Address struct {
+	cbor.StructAsArray
+	PaymentCredential Credential
+	StakingCredential OptionalCredential
+}
+
+func (a *Address) UnmarshalCBOR(cborData []byte) error {
+	var tmpConstr cbor.ConstructorDecoder
+	if _, err := cbor.Decode(cborData, &tmpConstr); err != nil {
+		return err
+	}
+	return cbor.DecodeGeneric(tmpConstr.Fields(), a)
+}
+
+// Credential represents a payment or staking credential
+type Credential struct {
+	Type int // 0 = PubKeyHash, 1 = ScriptHash
+	Hash []byte
+}
+
+func (c *Credential) UnmarshalCBOR(cborData []byte) error {
+	var tmpConstr cbor.ConstructorDecoder
+	if _, err := cbor.Decode(cborData, &tmpConstr); err != nil {
+		return err
+	}
+	tag := tmpConstr.Tag()
+	switch tag {
+	case 0, 1:
+	default:
+		return fmt.Errorf("unsupported credential constructor %d", tag)
+	}
+	var wrapper struct {
+		cbor.StructAsArray
+		Hash []byte
+	}
+	if err := cbor.DecodeGeneric(tmpConstr.Fields(), &wrapper); err != nil {
+		return err
+	}
+	c.Type = int(tag)
+	c.Hash = wrapper.Hash
+	return nil
+}
+
+// OptionalCredential represents an optional staking credential
+type OptionalCredential struct {
+	IsPresent  bool
+	Credential *Credential
+}
+
+func (o *OptionalCredential) UnmarshalCBOR(cborData []byte) error {
+	var tmpConstr cbor.ConstructorDecoder
+	if _, err := cbor.Decode(cborData, &tmpConstr); err != nil {
+		return err
+	}
+	// Constructor 0 = Some, Constructor 1 = None
+	switch tag := tmpConstr.Tag(); tag {
+	case 0:
+	case 1:
+		o.IsPresent = false
+		o.Credential = nil // Reset to avoid stale data when struct is reused
+		return nil
+	default:
+		return fmt.Errorf("unsupported optional credential constructor %d", tag)
+	}
+	var wrapper struct {
+		cbor.StructAsArray
+		Inner Credential
+	}
+	if err := cbor.DecodeGeneric(tmpConstr.Fields(), &wrapper); err != nil {
+		return err
+	}
+	o.IsPresent = true
+	o.Credential = &wrapper.Inner
+	return nil
+}
+
+// Rational represents a rational number as numerator/denominator pair
+type Rational struct {
+	Numerator   int64
+	Denominator int64
+}
+
+func (r *Rational) UnmarshalCBOR(cborData []byte) error {
+	var tmpConstr cbor.ConstructorDecoder
+	if _, err := cbor.Decode(cborData, &tmpConstr); err != nil {
+		return err
+	}
+	var wrapper struct {
+		cbor.StructAsArray
+		Numerator   int64
+		Denominator int64
+	}
+	if err := cbor.DecodeGeneric(tmpConstr.Fields(), &wrapper); err != nil {
+		return err
+	}
+	r.Numerator = wrapper.Numerator
+	r.Denominator = wrapper.Denominator
+	return nil
+}
+
+// ToFloat64 converts the rational to a float64 value
+func (r Rational) ToFloat64() float64 {
+	if r.Denominator == 0 {
+		return 0
+	}
+	return float64(r.Numerator) / float64(r.Denominator)
+}
+
+// OptionalPOSIX represents an optional POSIX timestamp (in milliseconds)
+type OptionalPOSIX struct {
+	IsPresent bool
+	Time      int64 // POSIX time in milliseconds
+}
+
+func (o *OptionalPOSIX) UnmarshalCBOR(cborData []byte) error {
+	var tmpConstr cbor.ConstructorDecoder
+	if _, err := cbor.Decode(cborData, &tmpConstr); err != nil {
+		return err
+	}
+	// Constructor 0 = Some, Constructor 1 = None
+	switch tag := tmpConstr.Tag(); tag {
+	case 0:
+	case 1:
+		o.IsPresent = false
+		o.Time = 0 // Reset to avoid stale values when struct is reused
+		return nil
+	default:
+		return fmt.Errorf("unsupported optional POSIX constructor %d", tag)
+	}
+	var wrapper struct {
+		cbor.StructAsArray
+		Time int64
+	}
+	if err := cbor.DecodeGeneric(tmpConstr.Fields(), &wrapper); err != nil {
+		return err
+	}
+	o.IsPresent = true
+	o.Time = wrapper.Time
+	return nil
+}
+
+// ContainedFee tracks fee amounts contained in the order
+type ContainedFee struct {
+	cbor.StructAsArray
+	LovelaceFee uint64 // Lovelace fees contained
+	OfferedFee  uint64 // Offered asset fees contained
+	AskedFee    uint64 // Asked asset fees contained
+}
+
+func (c *ContainedFee) UnmarshalCBOR(cborData []byte) error {
+	var tmpConstr cbor.ConstructorDecoder
+	if _, err := cbor.Decode(cborData, &tmpConstr); err != nil {
+		return err
+	}
+	return cbor.DecodeGeneric(tmpConstr.Fields(), c)
+}

--- a/dex/geniusyield/parser.go
+++ b/dex/geniusyield/parser.go
@@ -1,0 +1,273 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package geniusyield
+
+import (
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/shai/common"
+)
+
+// OrderState represents the parsed state of a Genius Yield order
+type OrderState struct {
+	OrderId        string             `json:"orderId"`
+	Protocol       string             `json:"protocol"`
+	Owner          string             `json:"owner"`
+	OfferedAsset   common.AssetAmount `json:"offeredAsset"`
+	OriginalAmount uint64             `json:"originalAmount"`
+	AskedAsset     common.AssetClass  `json:"askedAsset"`
+	Price          float64            `json:"price"`
+	PriceNum       int64              `json:"priceNum"`
+	PriceDenom     int64              `json:"priceDenom"`
+	IsActive       bool               `json:"isActive"`
+	StartTime      *time.Time         `json:"startTime"`
+	EndTime        *time.Time         `json:"endTime"`
+	PartialFills   uint64             `json:"partialFills"`
+	Slot           uint64             `json:"slot"`
+	TxHash         string             `json:"txHash"`
+	TxIndex        uint32             `json:"txIndex"`
+	Timestamp      time.Time          `json:"timestamp"`
+	UpdatedAt      time.Time          `json:"updatedAt"`
+
+	// Fee and datum fields preserved for partial fill updates
+	NFT                  []byte `json:"nft"`
+	MakerLovelaceFlatFee uint64 `json:"makerLovelaceFlatFee"`
+	MakerFeeNum          int64  `json:"makerFeeNum"`
+	MakerFeeDenom        int64  `json:"makerFeeDenom"`
+	MakerFeeMax          uint64 `json:"makerFeeMax"`
+	ContainedLovelaceFee uint64 `json:"containedLovelaceFee"`
+	ContainedOfferedFee  uint64 `json:"containedOfferedFee"`
+	ContainedAskedFee    uint64 `json:"containedAskedFee"`
+	ContainedPayment     uint64 `json:"containedPayment"`
+}
+
+// Key returns a unique identifier for this order state
+func (o *OrderState) Key() string {
+	return fmt.Sprintf("geniusyield:%s", o.OrderId)
+}
+
+// FillPercent returns the percentage of the order that has been filled
+func (o *OrderState) FillPercent() float64 {
+	if o.OriginalAmount == 0 {
+		return 0
+	}
+	// Guard against underflow if OfferedAsset.Amount > OriginalAmount
+	if o.OfferedAsset.Amount >= o.OriginalAmount {
+		return 0
+	}
+	filled := o.OriginalAmount - o.OfferedAsset.Amount
+	return float64(filled) / float64(o.OriginalAmount) * 100
+}
+
+// RemainingValue returns the value of remaining offered assets at current price
+func (o *OrderState) RemainingValue() float64 {
+	return float64(o.OfferedAsset.Amount) * o.Price
+}
+
+// Parser implements order parsing for Genius Yield DEX
+type Parser struct{}
+
+// NewParser creates a new Genius Yield order parser
+func NewParser() *Parser {
+	return &Parser{}
+}
+
+// Protocol returns the protocol name
+func (p *Parser) Protocol() string {
+	return ProtocolName
+}
+
+// ParseOrderDatum parses a Genius Yield order datum
+func (p *Parser) ParseOrderDatum(
+	datum []byte,
+	txHash string,
+	txIndex uint32,
+	slot uint64,
+	timestamp time.Time,
+) (*OrderState, error) {
+	var orderDatum PartialOrderDatum
+	if _, err := cbor.Decode(datum, &orderDatum); err != nil {
+		return nil, fmt.Errorf("failed to decode Genius Yield datum: %w", err)
+	}
+	if orderDatum.Price.Numerator <= 0 || orderDatum.Price.Denominator <= 0 {
+		return nil, fmt.Errorf(
+			"invalid Genius Yield price: numerator=%d denominator=%d",
+			orderDatum.Price.Numerator,
+			orderDatum.Price.Denominator,
+		)
+	}
+
+	// Generate order ID from the NFT token name
+	orderId := GenerateOrderId(orderDatum.NFT)
+
+	// Check if order is active
+	isActive := p.isOrderActive(orderDatum, timestamp)
+
+	// Convert timestamps
+	var startTime, endTime *time.Time
+	if orderDatum.Start.IsPresent {
+		t := time.UnixMilli(orderDatum.Start.Time)
+		startTime = &t
+	}
+	if orderDatum.End.IsPresent {
+		t := time.UnixMilli(orderDatum.End.Time)
+		endTime = &t
+	}
+
+	state := &OrderState{
+		OrderId:  orderId,
+		Protocol: p.Protocol(),
+		Owner:    hex.EncodeToString(orderDatum.OwnerKey),
+		OfferedAsset: common.AssetAmount{
+			Class:  orderDatum.OfferedAsset.ToCommonAssetClass(),
+			Amount: orderDatum.OfferedAmount,
+		},
+		OriginalAmount: orderDatum.OfferedOriginalAmount,
+		AskedAsset:     orderDatum.AskedAsset.ToCommonAssetClass(),
+		Price:          orderDatum.Price.ToFloat64(),
+		PriceNum:       orderDatum.Price.Numerator,
+		PriceDenom:     orderDatum.Price.Denominator,
+		IsActive:       isActive,
+		StartTime:      startTime,
+		EndTime:        endTime,
+		PartialFills:   orderDatum.PartialFills,
+		Slot:           slot,
+		TxHash:         txHash,
+		TxIndex:        txIndex,
+		Timestamp:      timestamp,
+		UpdatedAt:      time.Now(),
+
+		// Preserve fee and datum fields for partial fill reconstruction
+		NFT:                  orderDatum.NFT,
+		MakerLovelaceFlatFee: orderDatum.MakerLovelaceFlatFee,
+		MakerFeeNum:          orderDatum.MakerOfferedPercentFee.Numerator,
+		MakerFeeDenom:        orderDatum.MakerOfferedPercentFee.Denominator,
+		MakerFeeMax:          orderDatum.MakerOfferedPercentFeeMax,
+		ContainedLovelaceFee: orderDatum.ContainedFee.LovelaceFee,
+		ContainedOfferedFee:  orderDatum.ContainedFee.OfferedFee,
+		ContainedAskedFee:    orderDatum.ContainedFee.AskedFee,
+		ContainedPayment:     orderDatum.ContainedPayment,
+	}
+
+	return state, nil
+}
+
+// isOrderActive checks if an order is currently active
+func (p *Parser) isOrderActive(datum PartialOrderDatum, now time.Time) bool {
+	// Order is inactive if no amount remaining
+	if datum.OfferedAmount == 0 {
+		return false
+	}
+
+	nowMs := now.UnixMilli()
+
+	// Check start time constraint
+	if datum.Start.IsPresent && datum.Start.Time > nowMs {
+		return false // Order hasn't started yet
+	}
+
+	// Check end time constraint
+	if datum.End.IsPresent && datum.End.Time < nowMs {
+		return false // Order has expired
+	}
+
+	return true
+}
+
+// GenerateOrderId generates a unique order ID from the NFT token name
+func GenerateOrderId(nftTokenName []byte) string {
+	return fmt.Sprintf("gy_%s", hex.EncodeToString(nftTokenName))
+}
+
+// GetOrderAddresses returns mainnet order contract addresses
+func GetOrderAddresses() []string {
+	return []string{
+		// Genius Yield order-book DEX contract address (mainnet)
+		// The actual address derived from OrderScriptHash
+		"addr1w8lj5fvnqvx8rtp8k6e6kcp7g76twqv2ad2hg7avfqtj7qgc5rquk",
+	}
+}
+
+// CalculateFillAmount calculates how much of an order can be filled
+// given a specific amount of the asked asset.
+// Uses integer arithmetic to avoid float64 precision loss on large amounts.
+func CalculateFillAmount(
+	order *OrderState,
+	askedAssetAmount uint64,
+) (offeredAmount uint64, remainder uint64) {
+	if order.PriceNum <= 0 || order.PriceDenom <= 0 {
+		return 0, askedAssetAmount
+	}
+
+	// Calculate offered amount based on price using big.Int to avoid overflow
+	// offeredAmount = askedAssetAmount * priceDenom / priceNum
+	asked := new(big.Int).SetUint64(askedAssetAmount)
+	denom := new(big.Int).SetInt64(order.PriceDenom)
+	num := new(big.Int).SetInt64(order.PriceNum)
+
+	// maxOffered = asked * denom / num
+	maxOfferedBig := new(big.Int).Mul(asked, denom)
+	maxOfferedBig.Div(maxOfferedBig, num)
+
+	// Cap at uint64 max and available amount
+	maxOffered := uint64(0)
+	if maxOfferedBig.Sign() >= 0 && maxOfferedBig.IsUint64() {
+		maxOffered = maxOfferedBig.Uint64()
+	} else if maxOfferedBig.Sign() > 0 {
+		maxOffered = ^uint64(0) // max uint64 if overflow
+	}
+
+	// Cap at available amount
+	if maxOffered > order.OfferedAsset.Amount {
+		offeredAmount = order.OfferedAsset.Amount
+	} else {
+		offeredAmount = maxOffered
+	}
+
+	// Calculate how much asked asset was actually used for the offered amount
+	// usedAsked = ceil(offeredAmount * priceNum / priceDenom)
+	// This accounts for integer division truncation in both branches
+	offered := new(big.Int).SetUint64(offeredAmount)
+	usedAskedBig := new(big.Int).Mul(offered, num)
+	usedAskedBig = ceilDivPositiveBig(usedAskedBig, denom)
+
+	usedAsked := uint64(0)
+	if usedAskedBig.Sign() >= 0 && usedAskedBig.IsUint64() {
+		usedAsked = usedAskedBig.Uint64()
+	}
+	if usedAsked > askedAssetAmount {
+		remainder = 0
+	} else {
+		remainder = askedAssetAmount - usedAsked
+	}
+
+	return offeredAmount, remainder
+}
+
+func ceilDivPositiveBig(numerator *big.Int, denominator *big.Int) *big.Int {
+	quotient, remainder := new(big.Int).QuoRem(
+		numerator,
+		denominator,
+		new(big.Int),
+	)
+	if remainder.Sign() != 0 {
+		quotient.Add(quotient, big.NewInt(1))
+	}
+	return quotient
+}

--- a/dex/geniusyield_test.go
+++ b/dex/geniusyield_test.go
@@ -1,0 +1,882 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dex
+
+import (
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/shai/dex/geniusyield"
+)
+
+func TestNewGeniusYieldParser(t *testing.T) {
+	parser := NewGeniusYieldParser()
+	if parser == nil {
+		t.Fatal("expected non-nil parser")
+	}
+	var _ PoolParser = parser
+	if parser.Protocol() != "geniusyield" {
+		t.Errorf("expected protocol 'geniusyield', got %s", parser.Protocol())
+	}
+	if len(parser.PoolAddresses()) == 0 {
+		t.Error("expected at least one GeniusYield order address")
+	}
+}
+
+func TestGeniusYieldAssetToCommonAssetClass(t *testing.T) {
+	asset := GeniusYieldAsset{
+		PolicyId:  []byte{0x01, 0x02, 0x03},
+		AssetName: []byte("TEST"),
+	}
+
+	common := asset.ToCommonAssetClass()
+	if string(common.PolicyId) != string(asset.PolicyId) {
+		t.Error("policy ID mismatch")
+	}
+	if string(common.Name) != string(asset.AssetName) {
+		t.Error("asset name mismatch")
+	}
+}
+
+func TestGenerateGeniusYieldOrderId(t *testing.T) {
+	nftName := []byte{
+		0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+		0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+	}
+	orderId := GenerateGeniusYieldOrderId(nftName)
+
+	expected := "gy_0102030405060708090a0b0c0d0e0f10"
+	if orderId != expected {
+		t.Errorf("expected order ID %s, got %s", expected, orderId)
+	}
+}
+
+func TestGeniusYieldRationalToFloat64(t *testing.T) {
+	tests := []struct {
+		name     string
+		num      int64
+		denom    int64
+		expected float64
+	}{
+		{"simple ratio", 1, 2, 0.5},
+		{"whole number", 10, 1, 10.0},
+		{"price ratio", 150, 100, 1.5},
+		{"zero denominator", 1, 0, 0.0},
+		{"zero numerator", 0, 100, 0.0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := GeniusYieldRational{
+				Numerator:   tt.num,
+				Denominator: tt.denom,
+			}
+			result := r.ToFloat64()
+			if result != tt.expected {
+				t.Errorf("expected %f, got %f", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestGeniusYieldOptionalPOSIXUnmarshal(t *testing.T) {
+	// Test None case (Constructor 1)
+	noneConstr := cbor.NewConstructorEncoder(1, cbor.IndefLengthList{})
+	noneData, err := cbor.Encode(&noneConstr)
+	if err != nil {
+		t.Fatalf("failed to encode None: %v", err)
+	}
+
+	var optNone GeniusYieldOptionalPOSIX
+	if _, err := cbor.Decode(noneData, &optNone); err != nil {
+		t.Fatalf("failed to decode None: %v", err)
+	}
+	if optNone.IsPresent {
+		t.Error("expected IsPresent to be false for None")
+	}
+
+	// Test Some case (Constructor 0)
+	timestamp := int64(1704067200000) // 2024-01-01 00:00:00 UTC
+	someConstr := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{timestamp})
+	someData, err := cbor.Encode(&someConstr)
+	if err != nil {
+		t.Fatalf("failed to encode Some: %v", err)
+	}
+
+	var optSome GeniusYieldOptionalPOSIX
+	if _, err := cbor.Decode(someData, &optSome); err != nil {
+		t.Fatalf("failed to decode Some: %v", err)
+	}
+	if !optSome.IsPresent {
+		t.Error("expected IsPresent to be true for Some")
+	}
+	if optSome.Time != timestamp {
+		t.Errorf("expected time %d, got %d", timestamp, optSome.Time)
+	}
+
+	invalidConstr := cbor.NewConstructorEncoder(2, cbor.IndefLengthList{})
+	invalidData, err := cbor.Encode(&invalidConstr)
+	if err != nil {
+		t.Fatalf("failed to encode invalid constructor: %v", err)
+	}
+
+	var optInvalid GeniusYieldOptionalPOSIX
+	if _, err := cbor.Decode(invalidData, &optInvalid); err == nil {
+		t.Fatal("expected unsupported constructor error")
+	}
+}
+
+func TestGeniusYieldContainedFeeUnmarshal(t *testing.T) {
+	feeConstr := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		uint64(1000000), // lovelaceFee
+		uint64(500000),  // offeredFee
+		uint64(250000),  // askedFee
+	})
+
+	cborData, err := cbor.Encode(&feeConstr)
+	if err != nil {
+		t.Fatalf("failed to encode: %v", err)
+	}
+
+	var fee GeniusYieldContainedFee
+	if _, err := cbor.Decode(cborData, &fee); err != nil {
+		t.Fatalf("failed to decode: %v", err)
+	}
+
+	if fee.LovelaceFee != 1000000 {
+		t.Errorf("expected lovelaceFee 1000000, got %d", fee.LovelaceFee)
+	}
+	if fee.OfferedFee != 500000 {
+		t.Errorf("expected offeredFee 500000, got %d", fee.OfferedFee)
+	}
+	if fee.AskedFee != 250000 {
+		t.Errorf("expected askedFee 250000, got %d", fee.AskedFee)
+	}
+}
+
+func TestGeniusYieldCredentialUnmarshal(t *testing.T) {
+	// Test PubKeyHash (Constructor 0)
+	pubKeyHash := []byte{0xab, 0xcd, 0xef, 0x12, 0x34}
+	pkConstr := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{pubKeyHash})
+	pkData, err := cbor.Encode(&pkConstr)
+	if err != nil {
+		t.Fatalf("failed to encode PubKeyHash: %v", err)
+	}
+
+	var pkCred GeniusYieldCredential
+	if _, err := cbor.Decode(pkData, &pkCred); err != nil {
+		t.Fatalf("failed to decode PubKeyHash: %v", err)
+	}
+	if pkCred.Type != 0 {
+		t.Errorf("expected type 0 for PubKeyHash, got %d", pkCred.Type)
+	}
+	if string(pkCred.Hash) != string(pubKeyHash) {
+		t.Error("PubKeyHash mismatch")
+	}
+
+	// Test ScriptHash (Constructor 1)
+	scriptHash := []byte{0x11, 0x22, 0x33, 0x44, 0x55}
+	shConstr := cbor.NewConstructorEncoder(1, cbor.IndefLengthList{scriptHash})
+	shData, err := cbor.Encode(&shConstr)
+	if err != nil {
+		t.Fatalf("failed to encode ScriptHash: %v", err)
+	}
+
+	var shCred GeniusYieldCredential
+	if _, err := cbor.Decode(shData, &shCred); err != nil {
+		t.Fatalf("failed to decode ScriptHash: %v", err)
+	}
+	if shCred.Type != 1 {
+		t.Errorf("expected type 1 for ScriptHash, got %d", shCred.Type)
+	}
+	if string(shCred.Hash) != string(scriptHash) {
+		t.Error("ScriptHash mismatch")
+	}
+
+	invalidConstr := cbor.NewConstructorEncoder(
+		2,
+		cbor.IndefLengthList{scriptHash},
+	)
+	invalidData, err := cbor.Encode(&invalidConstr)
+	if err != nil {
+		t.Fatalf("failed to encode invalid credential: %v", err)
+	}
+
+	var invalidCred GeniusYieldCredential
+	if _, err := cbor.Decode(invalidData, &invalidCred); err == nil {
+		t.Fatal("expected unsupported constructor error")
+	}
+}
+
+func TestGeniusYieldOptionalCredentialUnmarshalRejectsInvalidConstructor(
+	t *testing.T,
+) {
+	invalidConstr := cbor.NewConstructorEncoder(2, cbor.IndefLengthList{})
+	invalidData, err := cbor.Encode(&invalidConstr)
+	if err != nil {
+		t.Fatalf("failed to encode invalid optional credential: %v", err)
+	}
+
+	var optionalCred geniusyield.OptionalCredential
+	if _, err := cbor.Decode(invalidData, &optionalCred); err == nil {
+		t.Fatal("expected unsupported constructor error")
+	}
+}
+
+func TestGeniusYieldOrderStateKey(t *testing.T) {
+	state := &geniusyield.OrderState{
+		OrderId: "gy_abc123",
+	}
+	key := state.Key()
+	expected := "geniusyield:gy_abc123"
+	if key != expected {
+		t.Errorf("expected key %s, got %s", expected, key)
+	}
+}
+
+func TestGeniusYieldOrderStateFillPercent(t *testing.T) {
+	tests := []struct {
+		name         string
+		original     uint64
+		remaining    uint64
+		expectedFill float64
+	}{
+		{"no fill", 1000, 1000, 0.0},
+		{"half filled", 1000, 500, 50.0},
+		{"fully filled", 1000, 0, 100.0},
+		{"quarter filled", 1000, 750, 25.0},
+		{"zero original", 0, 0, 0.0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := &geniusyield.OrderState{
+				OriginalAmount: tt.original,
+			}
+			state.OfferedAsset.Amount = tt.remaining
+			result := state.FillPercent()
+			if result != tt.expectedFill {
+				t.Errorf("expected %f%%, got %f%%", tt.expectedFill, result)
+			}
+		})
+	}
+}
+
+func TestCalculateGeniusYieldFillAmount(t *testing.T) {
+	tests := []struct {
+		name              string
+		offeredAmount     uint64
+		priceNum          int64
+		priceDenom        int64
+		askedAmount       uint64
+		expectedOffered   uint64
+		expectedRemainder uint64
+	}{
+		{
+			name:              "exact fill",
+			offeredAmount:     1000,
+			priceNum:          1,
+			priceDenom:        1,
+			askedAmount:       1000,
+			expectedOffered:   1000,
+			expectedRemainder: 0,
+		},
+		{
+			name:              "partial fill",
+			offeredAmount:     1000,
+			priceNum:          1,
+			priceDenom:        1,
+			askedAmount:       500,
+			expectedOffered:   500,
+			expectedRemainder: 0,
+		},
+		{
+			name:              "overfill capped",
+			offeredAmount:     1000,
+			priceNum:          1,
+			priceDenom:        1,
+			askedAmount:       2000,
+			expectedOffered:   1000,
+			expectedRemainder: 1000,
+		},
+		{
+			name:              "price ratio 2:1",
+			offeredAmount:     1000,
+			priceNum:          2,
+			priceDenom:        1,
+			askedAmount:       1000,
+			expectedOffered:   500,
+			expectedRemainder: 0,
+		},
+		{
+			name:              "non-divisible price rounds used asked up",
+			offeredAmount:     1000,
+			priceNum:          3,
+			priceDenom:        2,
+			askedAmount:       2,
+			expectedOffered:   1,
+			expectedRemainder: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			order := &geniusyield.OrderState{
+				PriceNum:   tt.priceNum,
+				PriceDenom: tt.priceDenom,
+				Price:      float64(tt.priceNum) / float64(tt.priceDenom),
+			}
+			order.OfferedAsset.Amount = tt.offeredAmount
+
+			offered, remainder := CalculateGeniusYieldFillAmount(
+				order,
+				tt.askedAmount,
+			)
+
+			if offered != tt.expectedOffered {
+				t.Errorf(
+					"expected offered %d, got %d",
+					tt.expectedOffered,
+					offered,
+				)
+			}
+			if remainder != tt.expectedRemainder {
+				t.Errorf(
+					"expected remainder %d, got %d",
+					tt.expectedRemainder,
+					remainder,
+				)
+			}
+		})
+	}
+}
+
+func TestGeniusYieldPartialOrderDatumUnmarshal(t *testing.T) {
+	// Build a test PartialOrderDatum
+	// Constructor 0 with all required fields
+
+	ownerKey := make([]byte, 28)
+	for i := range ownerKey {
+		ownerKey[i] = byte(i + 1)
+	}
+
+	// Payment credential (PubKeyHash)
+	paymentCred := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{ownerKey})
+
+	// Staking credential (None)
+	stakingCred := cbor.NewConstructorEncoder(1, cbor.IndefLengthList{})
+
+	// Owner address
+	ownerAddr := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		paymentCred,
+		stakingCred,
+	})
+
+	// Offered asset (ADA)
+	offeredAsset := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		[]byte{},
+		[]byte{},
+	})
+
+	// Asked asset (some token)
+	askedAsset := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		[]byte{0xab, 0xcd, 0xef},
+		[]byte("TOKEN"),
+	})
+
+	// Price rational (1.5 = 3/2)
+	price := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		int64(3),
+		int64(2),
+	})
+
+	// NFT token name
+	nftName := []byte{0x01, 0x02, 0x03, 0x04}
+
+	// Start time (None)
+	startTime := cbor.NewConstructorEncoder(1, cbor.IndefLengthList{})
+
+	// End time (Some timestamp)
+	endTimestamp := int64(1735689600000) // 2025-01-01 00:00:00 UTC
+	endTime := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{endTimestamp})
+
+	// Maker percent fee (0.3% = 3/1000)
+	makerPercentFee := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		int64(3),
+		int64(1000),
+	})
+
+	// Contained fee
+	containedFee := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		uint64(1000000), // lovelaceFee
+		uint64(0),       // offeredFee
+		uint64(0),       // askedFee
+	})
+
+	datum := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		ownerKey,         // podOwnerKey
+		ownerAddr,        // podOwnerAddr
+		offeredAsset,     // podOfferedAsset
+		uint64(10000000), // podOfferedOriginalAmount
+		uint64(5000000),  // podOfferedAmount (partially filled)
+		askedAsset,       // podAskedAsset
+		price,            // podPrice
+		nftName,          // podNFT
+		startTime,        // podStart
+		endTime,          // podEnd
+		uint64(3),        // podPartialFills
+		uint64(2000000),  // podMakerLovelaceFlatFee
+		makerPercentFee,  // podMakerOfferedPercentFee
+		uint64(100000),   // podMakerOfferedPercentFeeMax
+		containedFee,     // podContainedFee
+		uint64(7500000),  // podContainedPayment
+	})
+
+	cborData, err := cbor.Encode(&datum)
+	if err != nil {
+		t.Fatalf("failed to encode test datum: %v", err)
+	}
+
+	var orderDatum GeniusYieldPartialOrderDatum
+	if _, err := cbor.Decode(cborData, &orderDatum); err != nil {
+		t.Fatalf("failed to decode datum: %v", err)
+	}
+
+	// Verify fields
+	if orderDatum.OfferedOriginalAmount != 10000000 {
+		t.Errorf(
+			"expected offeredOriginalAmount 10000000, got %d",
+			orderDatum.OfferedOriginalAmount,
+		)
+	}
+	if orderDatum.OfferedAmount != 5000000 {
+		t.Errorf(
+			"expected offeredAmount 5000000, got %d",
+			orderDatum.OfferedAmount,
+		)
+	}
+	if orderDatum.PartialFills != 3 {
+		t.Errorf(
+			"expected partialFills 3, got %d",
+			orderDatum.PartialFills,
+		)
+	}
+	if orderDatum.Price.Numerator != 3 || orderDatum.Price.Denominator != 2 {
+		t.Errorf(
+			"expected price 3/2, got %d/%d",
+			orderDatum.Price.Numerator,
+			orderDatum.Price.Denominator,
+		)
+	}
+	if orderDatum.Start.IsPresent {
+		t.Error("expected start to be None")
+	}
+	if !orderDatum.End.IsPresent {
+		t.Error("expected end to be Some")
+	}
+	if orderDatum.End.Time != endTimestamp {
+		t.Errorf(
+			"expected end time %d, got %d",
+			endTimestamp,
+			orderDatum.End.Time,
+		)
+	}
+	if orderDatum.ContainedFee.LovelaceFee != 1000000 {
+		t.Errorf(
+			"expected containedFee.lovelaceFee 1000000, got %d",
+			orderDatum.ContainedFee.LovelaceFee,
+		)
+	}
+}
+
+func TestGeniusYieldParserParseOrderDatum(t *testing.T) {
+	// Build test datum
+	ownerKey := make([]byte, 28)
+	for i := range ownerKey {
+		ownerKey[i] = byte(i)
+	}
+
+	paymentCred := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{ownerKey})
+	stakingCred := cbor.NewConstructorEncoder(1, cbor.IndefLengthList{})
+	ownerAddr := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		paymentCred,
+		stakingCred,
+	})
+
+	offeredAsset := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		[]byte{},
+		[]byte{},
+	})
+
+	askedAsset := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		[]byte{0xab, 0xcd},
+		[]byte("TEST"),
+	})
+
+	price := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		int64(15),
+		int64(10),
+	})
+
+	nftName := []byte{0xde, 0xad, 0xbe, 0xef}
+	startTime := cbor.NewConstructorEncoder(1, cbor.IndefLengthList{})
+	endTime := cbor.NewConstructorEncoder(1, cbor.IndefLengthList{})
+	makerPercentFee := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		int64(3),
+		int64(1000),
+	})
+	containedFee := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		uint64(0),
+		uint64(0),
+		uint64(0),
+	})
+
+	datum := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		ownerKey,
+		ownerAddr,
+		offeredAsset,
+		uint64(5000000),
+		uint64(5000000),
+		askedAsset,
+		price,
+		nftName,
+		startTime,
+		endTime,
+		uint64(0),
+		uint64(1000000),
+		makerPercentFee,
+		uint64(50000),
+		containedFee,
+		uint64(0),
+	})
+
+	cborData, err := cbor.Encode(&datum)
+	if err != nil {
+		t.Fatalf("failed to encode: %v", err)
+	}
+
+	parser := NewGeniusYieldParser()
+	state, err := parser.ParseOrderDatum(
+		cborData,
+		"abc123def456",
+		0,
+		12345,
+		time.Now(),
+	)
+	if err != nil {
+		t.Fatalf("failed to parse datum: %v", err)
+	}
+
+	if state.Protocol != "geniusyield" {
+		t.Errorf("expected protocol 'geniusyield', got %s", state.Protocol)
+	}
+	if state.Slot != 12345 {
+		t.Errorf("expected slot 12345, got %d", state.Slot)
+	}
+	if state.TxHash != "abc123def456" {
+		t.Errorf("expected txHash 'abc123def456', got %s", state.TxHash)
+	}
+	if state.Price != 1.5 {
+		t.Errorf("expected price 1.5, got %f", state.Price)
+	}
+	if state.OrderId != "gy_deadbeef" {
+		t.Errorf("expected orderId 'gy_deadbeef', got %s", state.OrderId)
+	}
+	if !state.IsActive {
+		t.Error("expected order to be active")
+	}
+	if state.OriginalAmount != 5000000 {
+		t.Errorf(
+			"expected originalAmount 5000000, got %d",
+			state.OriginalAmount,
+		)
+	}
+}
+
+func TestGeniusYieldParserRejectsNonPositivePrice(t *testing.T) {
+	tests := []struct {
+		name       string
+		priceNum   int64
+		priceDenom int64
+	}{
+		{
+			name:       "zero numerator",
+			priceNum:   0,
+			priceDenom: 1,
+		},
+		{
+			name:       "negative numerator",
+			priceNum:   -1,
+			priceDenom: 1,
+		},
+		{
+			name:       "zero denominator",
+			priceNum:   1,
+			priceDenom: 0,
+		},
+		{
+			name:       "negative denominator",
+			priceNum:   1,
+			priceDenom: -1,
+		},
+	}
+
+	parser := NewGeniusYieldParser()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			datum := newTestGeniusYieldDatum(
+				t,
+				tt.priceNum,
+				tt.priceDenom,
+				1000,
+			)
+			state, err := parser.ParseOrderDatum(
+				datum,
+				"tx",
+				0,
+				0,
+				time.Now(),
+			)
+			if err == nil {
+				t.Fatalf("expected invalid price error, got state %#v", state)
+			}
+		})
+	}
+}
+
+func TestGeniusYieldParsePoolDatumRejectsAskedAmountOverflow(t *testing.T) {
+	parser := NewGeniusYieldParser()
+	datum := newTestGeniusYieldDatum(t, 1<<62, 1, 4)
+
+	state, err := parser.ParsePoolDatum(datum, nil, "tx", 0, 0, time.Now())
+	if err == nil {
+		t.Fatalf("expected asked amount overflow error, got state %#v", state)
+	}
+	if state != nil {
+		t.Fatalf("expected nil state on overflow, got %#v", state)
+	}
+}
+
+func TestGeniusYieldOrderIsActive(t *testing.T) {
+	now := time.Now()
+	past := now.Add(-time.Hour)
+	future := now.Add(time.Hour)
+
+	tests := []struct {
+		name           string
+		offeredAmount  uint64
+		startTime      *time.Time
+		endTime        *time.Time
+		expectedActive bool
+	}{
+		{
+			name:           "active - no time constraints",
+			offeredAmount:  1000,
+			startTime:      nil,
+			endTime:        nil,
+			expectedActive: true,
+		},
+		{
+			name:           "inactive - no amount",
+			offeredAmount:  0,
+			startTime:      nil,
+			endTime:        nil,
+			expectedActive: false,
+		},
+		{
+			name:           "inactive - not started",
+			offeredAmount:  1000,
+			startTime:      &future,
+			endTime:        nil,
+			expectedActive: false,
+		},
+		{
+			name:           "inactive - expired",
+			offeredAmount:  1000,
+			startTime:      nil,
+			endTime:        &past,
+			expectedActive: false,
+		},
+		{
+			name:           "active - within time window",
+			offeredAmount:  1000,
+			startTime:      &past,
+			endTime:        &future,
+			expectedActive: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Build datum
+			ownerKey := make([]byte, 28)
+			paymentCred := cbor.NewConstructorEncoder(
+				0,
+				cbor.IndefLengthList{ownerKey},
+			)
+			stakingCred := cbor.NewConstructorEncoder(1, cbor.IndefLengthList{})
+			ownerAddr := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+				paymentCred,
+				stakingCred,
+			})
+			offeredAsset := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+				[]byte{},
+				[]byte{},
+			})
+			askedAsset := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+				[]byte{0xab},
+				[]byte("T"),
+			})
+			price := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+				int64(1),
+				int64(1),
+			})
+			nftName := []byte{0x01}
+			makerFee := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+				int64(0),
+				int64(1),
+			})
+			containedFee := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+				uint64(0),
+				uint64(0),
+				uint64(0),
+			})
+
+			var startConstr, endConstr interface{}
+			if tt.startTime != nil {
+				startConstr = cbor.NewConstructorEncoder(
+					0,
+					cbor.IndefLengthList{
+						tt.startTime.UnixMilli(),
+					},
+				)
+			} else {
+				startConstr = cbor.NewConstructorEncoder(1, cbor.IndefLengthList{})
+			}
+			if tt.endTime != nil {
+				endConstr = cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+					tt.endTime.UnixMilli(),
+				})
+			} else {
+				endConstr = cbor.NewConstructorEncoder(1, cbor.IndefLengthList{})
+			}
+
+			datum := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+				ownerKey,
+				ownerAddr,
+				offeredAsset,
+				tt.offeredAmount,
+				tt.offeredAmount,
+				askedAsset,
+				price,
+				nftName,
+				startConstr,
+				endConstr,
+				uint64(0),
+				uint64(0),
+				makerFee,
+				uint64(0),
+				containedFee,
+				uint64(0),
+			})
+
+			cborData, err := cbor.Encode(&datum)
+			if err != nil {
+				t.Fatalf("failed to encode: %v", err)
+			}
+
+			parser := NewGeniusYieldParser()
+			state, err := parser.ParseOrderDatum(cborData, "tx", 0, 0, now)
+			if err != nil {
+				t.Fatalf("failed to parse: %v", err)
+			}
+
+			if state.IsActive != tt.expectedActive {
+				t.Errorf(
+					"expected isActive=%v, got %v",
+					tt.expectedActive,
+					state.IsActive,
+				)
+			}
+		})
+	}
+}
+
+func newTestGeniusYieldDatum(
+	t *testing.T,
+	priceNum int64,
+	priceDenom int64,
+	offeredAmount uint64,
+) []byte {
+	t.Helper()
+
+	ownerKey := make([]byte, 28)
+	paymentCred := cbor.NewConstructorEncoder(
+		0,
+		cbor.IndefLengthList{ownerKey},
+	)
+	stakingCred := cbor.NewConstructorEncoder(1, cbor.IndefLengthList{})
+	ownerAddr := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		paymentCred,
+		stakingCred,
+	})
+	offeredAsset := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		[]byte{},
+		[]byte{},
+	})
+	askedAsset := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		[]byte{0xab},
+		[]byte("T"),
+	})
+	price := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		priceNum,
+		priceDenom,
+	})
+	makerFee := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		int64(0),
+		int64(1),
+	})
+	containedFee := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		uint64(0),
+		uint64(0),
+		uint64(0),
+	})
+
+	datum := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		ownerKey,
+		ownerAddr,
+		offeredAsset,
+		offeredAmount,
+		offeredAmount,
+		askedAsset,
+		price,
+		[]byte{0x01},
+		cbor.NewConstructorEncoder(1, cbor.IndefLengthList{}),
+		cbor.NewConstructorEncoder(1, cbor.IndefLengthList{}),
+		uint64(0),
+		uint64(0),
+		makerFee,
+		uint64(0),
+		containedFee,
+		uint64(0),
+	})
+
+	cborData, err := cbor.Encode(&datum)
+	if err != nil {
+		t.Fatalf("failed to encode datum: %v", err)
+	}
+	return cborData
+}

--- a/dex/locator.go
+++ b/dex/locator.go
@@ -101,6 +101,14 @@ var mainnetLocators = map[string]PoolLocator{
 			"addr1z8ke0c9p89rjfwmuh98jpt8ky74uy5mffjft3zlcld9h7ml3lmln3mwk0y3zsh3gs3dzqlwa9rjzrxawkwm4udw9axhs6fuu6e",
 		},
 	},
+	"geniusyield": {
+		Protocol: "geniusyield",
+		Network:  "mainnet",
+		Addresses: []string{
+			"addr1w9zr09hgj7z6vz3d7wnxw0u4x30arsp5k8avlcm84utptls8uqd0z",
+		},
+		PoolNFTPolicy: "fae686ea8f21d567841d703dea4d4221c2af071a6f2b433ff07c0af2",
+	},
 }
 
 // Locator returns the mainnet pool locator for the given protocol identifier

--- a/dex/models_test.go
+++ b/dex/models_test.go
@@ -320,6 +320,7 @@ func TestPoolAddressesLocator(t *testing.T) {
 		NewWingRidersV2Parser(),
 		NewVyFiParser(),
 		NewCSwapParser(),
+		NewGeniusYieldParser(),
 	}
 	for _, p := range parsers {
 		proto := p.Protocol()

--- a/internal/config/profiles.go
+++ b/internal/config/profiles.go
@@ -341,6 +341,17 @@ var Profiles = map[string]map[string]Profile{
 				InputRefs: []ProfileConfigInputRef{},
 			},
 		},
+		"geniusyield": {
+			Name:          "geniusyield",
+			Type:          ProfileTypeOracle,
+			InterceptSlot: 107999998, // ~Nov 9 2023 (epoch 447)
+			InterceptHash: "9ade9e2cbbf075b7653df58c29ebb4d8910119b7ac452c9512ef2f211d25d2ff",
+			Config: OracleProfileConfig{
+			Protocol:      "geniusyield",
+			PoolAddresses: poolAddrs("geniusyield"),
+			InputRefs:     []ProfileConfigInputRef{},
+		},
+		},
 		"spectrum": {
 			Name:          "spectrum",
 			Type:          ProfileTypeSpectrum,

--- a/internal/oracle/dex.go
+++ b/internal/oracle/dex.go
@@ -48,4 +48,5 @@ var (
 	NewWingRidersV2Parser = dex.NewWingRidersV2Parser
 	NewVyFiParser         = dex.NewVyFiParser
 	NewCSwapParser        = dex.NewCSwapParser
+	NewGeniusYieldParser  = dex.NewGeniusYieldParser
 )


### PR DESCRIPTION
Closes #312 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a Genius Yield order-book parser as a dedicated `dex/geniusyield` package and wired it through the CLI and oracle with mainnet addresses. Emits generic `PoolState` for active orders and implements Linear #312.

- **New Features**
  - Added `dex/geniusyield` with datum models, order parser, order ID and fill-amount helpers; wrapper `dex/geniusyield.go` re-exports constants/types and provides `GeniusYieldParser` with `ParseOrderDatum`/`ParsePoolDatum`.
  - Enabled protocol in CLI and oracle (`cmd/shai`, `internal/oracle/dex.go`); added a `geniusyield` profile (intercept slot/hash) and mainnet locator with script address and NFT policy; added tests for decoding, parsing, and math.

- **Bug Fixes**
  - Skip nil/inactive orders; enforce price > 0; use `big.Int` for overflow-safe math; clear optional CBOR fields to avoid stale values.

<sup>Written for commit 39ee45ab2e1e1fee9179f283469e9add5693d21e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/shai/pull/334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new Genius Yield oracle source.
  * Included a new mainnet profile for monitoring Genius Yield orders.

* **Bug Fixes**
  * Improved handling of empty or inactive parsed records so they are skipped instead of continuing through processing.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->