### PR TITLE
feat: extract Indigo oracle parser

### DIFF
--- a/cmd/shai/main.go
+++ b/cmd/shai/main.go
@@ -123,36 +123,36 @@ func main() {
 				)
 				os.Exit(1)
 			}
-			logger.Info(
-				"initializing profile",
-				"name",
-				profile.Name,
-				"type",
-				"Oracle",
-				"protocol",
-				oracleCfg.Protocol,
-			)
-			parser := getOracleParser(oracleCfg.Protocol)
-			if parser == nil {
-				logger.Error(
-					"unknown oracle protocol",
-					"protocol",
+			oracles = append(
+				oracles,
+				startOracleProfile(
+					idx,
+					&profile,
+					getOracleParser(oracleCfg.Protocol),
+					"Oracle",
 					oracleCfg.Protocol,
-				)
-				os.Exit(1)
-			}
-			o := oracle.New(idx, &profile, parser)
-			if err := o.Start(); err != nil {
+				),
+			)
+		case config.ProfileTypeSynthetics:
+			synthCfg, ok := profile.Config.(config.SyntheticsProfileConfig)
+			if !ok {
 				logger.Error(
-					"failed to start oracle",
-					"error",
-					err,
+					"invalid synthetics profile config",
 					"profile",
 					profile.Name,
 				)
 				os.Exit(1)
 			}
-			oracles = append(oracles, o)
+			oracles = append(
+				oracles,
+				startOracleProfile(
+					idx,
+					&profile,
+					getSyntheticsParser(synthCfg.Protocol),
+					"Synthetics",
+					synthCfg.Protocol,
+				),
+			)
 		case config.ProfileTypeNone:
 			logger.Error("profile type none given")
 			os.Exit(1)
@@ -201,6 +201,49 @@ func main() {
 	select {}
 }
 
+func startOracleProfile(
+	idx *indexer.Indexer,
+	profile *config.Profile,
+	parser oracle.PoolParser,
+	profileType string,
+	protocol string,
+) *oracle.Oracle {
+	logger := logging.GetLogger()
+	logger.Info(
+		"initializing profile",
+		"name",
+		profile.Name,
+		"type",
+		profileType,
+		"protocol",
+		protocol,
+	)
+	if parser == nil {
+		logger.Error(
+			"unknown oracle profile protocol",
+			"type",
+			profileType,
+			"protocol",
+			protocol,
+		)
+		os.Exit(1)
+	}
+	o := oracle.New(idx, profile, parser)
+	if err := o.Start(); err != nil {
+		logger.Error(
+			"failed to start oracle profile",
+			"error",
+			err,
+			"profile",
+			profile.Name,
+			"type",
+			profileType,
+		)
+		os.Exit(1)
+	}
+	return o
+}
+
 // getOracleParser returns the appropriate parser for an oracle protocol
 func getOracleParser(protocol string) oracle.PoolParser {
 	switch protocol {
@@ -220,6 +263,16 @@ func getOracleParser(protocol string) oracle.PoolParser {
 		return oracle.NewVyFiParser()
 	case "cswap":
 		return oracle.NewCSwapParser()
+	default:
+		return nil
+	}
+}
+
+// getSyntheticsParser returns the appropriate parser for a synthetics protocol.
+func getSyntheticsParser(protocol string) oracle.PoolParser {
+	switch protocol {
+	case "indigo":
+		return oracle.NewIndigoParser()
 	default:
 		return nil
 	}

--- a/internal/config/profiles.go
+++ b/internal/config/profiles.go
@@ -24,6 +24,7 @@ const (
 	ProfileTypeNone ProfileType = iota
 	ProfileTypeSpectrum
 	ProfileTypeOracle
+	ProfileTypeSynthetics
 )
 
 type Profile struct {
@@ -62,6 +63,12 @@ type OracleProfileConfig struct {
 	Protocol      string                  // Protocol name (e.g., "minswap", "sundaeswap")
 	PoolAddresses []ProfileConfigAddress  // Pool addresses to monitor
 	InputRefs     []ProfileConfigInputRef // Reference inputs if needed
+}
+
+// SyntheticsProfileConfig contains configuration for synthetics protocols.
+type SyntheticsProfileConfig struct {
+	Protocol     string                 // Protocol name (e.g., "indigo")
+	CDPAddresses []ProfileConfigAddress // CDP contract addresses to monitor
 }
 
 func GetProfiles() []Profile {
@@ -277,6 +284,23 @@ var Profiles = map[string]map[string]Profile{
 				Protocol:      "cswap",
 				PoolAddresses: poolAddrs("cswap"),
 				InputRefs:     []ProfileConfigInputRef{},
+			},
+		},
+		"indigo": {
+			Name:          "indigo",
+			Type:          ProfileTypeSynthetics,
+			InterceptSlot: 75599947, // ~Oct 30 2022 (epoch 372)
+			InterceptHash: "5af43c107055e2339c0d8d931c10679adb0b39ae0322cc521d7c327dcc6d816f",
+			Config: SyntheticsProfileConfig{
+				Protocol: "indigo",
+				CDPAddresses: []ProfileConfigAddress{
+					{
+						Address: "addr1z8jd97ct35n4s5ss8lt4sq0zclw0dmf7yak8fj46m0jm3dhzfjvtm0pg7ms9fvw5luec6euwzku8wqjpt5gv0q86052qv9nxuw",
+					},
+					{
+						Address: "addr1w80ptp0qgmcklhmeweesqgeurtlma8fsxsr9dt8au30fzss0czhl9",
+					},
+				},
 			},
 		},
 		"spectrum": {

--- a/internal/oracle/api.go
+++ b/internal/oracle/api.go
@@ -175,6 +175,8 @@ func normalizeHostPort(hostPort, scheme string) string {
 func (a *OracleAPI) RegisterHandlers(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/v1/pools", a.HandleListPools)
 	mux.HandleFunc("GET /api/v1/pools/{poolId}", a.HandleGetPool)
+	mux.HandleFunc("GET /api/v1/cdps", a.HandleListCDPs)
+	mux.HandleFunc("GET /api/v1/cdps/{cdpId}", a.HandleGetCDP)
 	mux.HandleFunc("GET /api/v1/prices", a.HandleListPrices)
 	mux.HandleFunc("/ws/prices", a.HandlePriceStream)
 	a.startBroadcastPriceUpdates()
@@ -241,6 +243,46 @@ func (a *OracleAPI) HandleGetPool(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(pool)
+}
+
+// HandleListCDPs returns all tracked CDPs.
+func (a *OracleAPI) HandleListCDPs(w http.ResponseWriter, r *http.Request) {
+	cdps := a.getAllCDPs()
+
+	protocol := r.URL.Query().Get("protocol")
+	if protocol != "" {
+		filtered := make([]*CDPState, 0)
+		for _, cdp := range cdps {
+			if cdp.Protocol == protocol {
+				filtered = append(filtered, cdp)
+			}
+		}
+		cdps = filtered
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"cdps":  cdps,
+		"count": len(cdps),
+	})
+}
+
+// HandleGetCDP returns a specific CDP by ID.
+func (a *OracleAPI) HandleGetCDP(w http.ResponseWriter, r *http.Request) {
+	cdpId := r.PathValue("cdpId")
+	if cdpId == "" {
+		http.Error(w, "CDP ID required", http.StatusBadRequest)
+		return
+	}
+
+	cdp, ok := a.getCDPState(cdpId)
+	if !ok {
+		http.Error(w, "CDP not found", http.StatusNotFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(cdp)
 }
 
 // HandleListPrices returns current prices for all pools
@@ -436,10 +478,27 @@ func (a *OracleAPI) getAllPools() []*PoolState {
 	return merged
 }
 
+func (a *OracleAPI) getAllCDPs() []*CDPState {
+	var merged []*CDPState
+	for _, o := range a.oracles {
+		merged = append(merged, o.GetAllCDPs()...)
+	}
+	return merged
+}
+
 func (a *OracleAPI) getPoolState(poolId string) (*PoolState, bool) {
 	for _, o := range a.oracles {
 		if pool, ok := o.GetPoolState(poolId); ok {
 			return pool, true
+		}
+	}
+	return nil, false
+}
+
+func (a *OracleAPI) getCDPState(cdpId string) (*CDPState, bool) {
+	for _, o := range a.oracles {
+		if cdp, ok := o.GetCDPState(cdpId); ok {
+			return cdp, true
 		}
 	}
 	return nil, false

--- a/internal/oracle/cdp_test.go
+++ b/internal/oracle/cdp_test.go
@@ -1,0 +1,275 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oracle
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/blinklabs-io/adder/event"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	"github.com/blinklabs-io/shai/internal/config"
+)
+
+func TestOracleIndigoCDPUpdateDeletesSpentState(t *testing.T) {
+	o := newTestIndigoOracle(t)
+	oldHash := strings.Repeat("a", 64)
+	newHash := strings.Repeat("b", 64)
+	oldID := generateIndigoCDPId(oldHash, 0)
+	oldState := &CDPState{
+		CDPId:    oldID,
+		Network:  "mainnet",
+		Protocol: IndigoProtocolName,
+		Slot:     10,
+	}
+	o.cdps[oldID] = oldState
+	if err := o.storage.SaveCDPState(oldState); err != nil {
+		t.Fatalf("failed to save old CDP state: %v", err)
+	}
+
+	err := o.handleTransaction(
+		event.Event{
+			Context: event.TransactionContext{
+				TransactionHash: newHash,
+				SlotNumber:      20,
+			},
+		},
+		event.TransactionEvent{
+			BlockHash: "block-20",
+			Inputs: []ledger.TransactionInput{
+				shelley.NewShelleyTransactionInput(oldHash, 0),
+			},
+			Outputs: []ledger.TransactionOutput{
+				newTestCDPOutput(t, "iUSD", 42_000_000),
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("handleTransaction returned error: %v", err)
+	}
+
+	if _, ok := o.GetCDPState(oldID); ok {
+		t.Fatalf("expected spent CDP %s to be removed", oldID)
+	}
+	if _, err := o.storage.LoadCDPState("mainnet", IndigoProtocolName, oldID); err == nil {
+		t.Fatalf("expected spent CDP %s to be deleted from storage", oldID)
+	}
+
+	newID := generateIndigoCDPId(newHash, 0)
+	newState, ok := o.GetCDPState(newID)
+	if !ok || newState == nil {
+		t.Fatalf("expected replacement CDP %s to be tracked", newID)
+	}
+	if newState.MintedAmount != 42_000_000 {
+		t.Fatalf("expected minted amount 42000000, got %d", newState.MintedAmount)
+	}
+	if newState.BlockHash != "block-20" {
+		t.Fatalf("expected block hash block-20, got %s", newState.BlockHash)
+	}
+	if _, err := o.storage.LoadCDPState("mainnet", IndigoProtocolName, newID); err != nil {
+		t.Fatalf("expected replacement CDP in storage: %v", err)
+	}
+
+	api := NewOracleAPI(o)
+	defer api.Stop()
+	mux := http.NewServeMux()
+	api.RegisterHandlers(mux)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/cdps", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rr.Code)
+	}
+	var response struct {
+		CDPs  []*CDPState `json:"cdps"`
+		Count int         `json:"count"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to decode CDP list: %v", err)
+	}
+	if response.Count != 1 {
+		t.Fatalf("expected one CDP in API response, got %d", response.Count)
+	}
+	if response.CDPs[0].CDPId != newID {
+		t.Fatalf("expected API to return %s, got %s", newID, response.CDPs[0].CDPId)
+	}
+}
+
+func TestOracleIndigoCDPCloseDeletesSpentState(t *testing.T) {
+	o := newTestIndigoOracle(t)
+	oldHash := strings.Repeat("c", 64)
+	oldID := generateIndigoCDPId(oldHash, 1)
+	oldState := &CDPState{
+		CDPId:    oldID,
+		Network:  "mainnet",
+		Protocol: IndigoProtocolName,
+		Slot:     10,
+	}
+	o.cdps[oldID] = oldState
+	if err := o.storage.SaveCDPState(oldState); err != nil {
+		t.Fatalf("failed to save old CDP state: %v", err)
+	}
+
+	err := o.handleTransaction(
+		event.Event{
+			Context: event.TransactionContext{
+				TransactionHash: strings.Repeat("d", 64),
+				SlotNumber:      20,
+			},
+		},
+		event.TransactionEvent{
+			BlockHash: "block-20",
+			Inputs: []ledger.TransactionInput{
+				shelley.NewShelleyTransactionInput(oldHash, 1),
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("handleTransaction returned error: %v", err)
+	}
+
+	if o.CDPCount() != 0 {
+		t.Fatalf("expected no tracked CDPs, got %d", o.CDPCount())
+	}
+	if _, err := o.storage.LoadCDPState("mainnet", IndigoProtocolName, oldID); err == nil {
+		t.Fatalf("expected closed CDP %s to be deleted from storage", oldID)
+	}
+}
+
+func TestOracleStorageCDPStateSaveLoadDelete(t *testing.T) {
+	storage := newTestOracleStorage(t)
+	state := &CDPState{
+		CDPId:        "indigo_cdp_abc#0",
+		Network:      "mainnet",
+		Protocol:     IndigoProtocolName,
+		IAsset:       "69555344",
+		MintedAmount: 1_000_000,
+	}
+	if err := storage.SaveCDPState(state); err != nil {
+		t.Fatalf("failed to save CDP state: %v", err)
+	}
+
+	loaded, err := storage.LoadCDPState("mainnet", IndigoProtocolName, state.CDPId)
+	if err != nil {
+		t.Fatalf("failed to load CDP state: %v", err)
+	}
+	if loaded == nil {
+		t.Fatalf("expected loaded CDP state")
+	}
+	if loaded.CDPId != state.CDPId {
+		t.Fatalf("expected CDP ID %s, got %s", state.CDPId, loaded.CDPId)
+	}
+
+	all, err := storage.LoadAllCDPStates()
+	if err != nil {
+		t.Fatalf("failed to load all CDP states: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("expected 1 CDP state, got %d", len(all))
+	}
+
+	if err := storage.DeleteCDPState("mainnet", IndigoProtocolName, state.CDPId); err != nil {
+		t.Fatalf("failed to delete CDP state: %v", err)
+	}
+	all, err = storage.LoadAllCDPStates()
+	if err != nil {
+		t.Fatalf("failed to load all CDP states after delete: %v", err)
+	}
+	if len(all) != 0 {
+		t.Fatalf("expected 0 CDP states after delete, got %d", len(all))
+	}
+}
+
+func newTestIndigoOracle(t *testing.T) *Oracle {
+	t.Helper()
+	profile := config.Profile{
+		Name: "indigo",
+		Type: config.ProfileTypeSynthetics,
+		Config: config.SyntheticsProfileConfig{
+			Protocol: IndigoProtocolName,
+			CDPAddresses: []config.ProfileConfigAddress{
+				{Address: IndigoCDPContractAddress},
+			},
+		},
+	}
+	o := New(nil, &profile, NewIndigoParser())
+	o.storage = newTestOracleStorage(t)
+	return o
+}
+
+func newTestCDPOutput(
+	t *testing.T,
+	iAsset string,
+	mintedAmount int64,
+) ledger.TransactionOutput {
+	t.Helper()
+	address, err := lcommon.NewAddress(IndigoCDPContractAddress)
+	if err != nil {
+		t.Fatalf("failed to parse Indigo CDP address: %v", err)
+	}
+	outputCbor, err := cbor.Encode(&map[uint64]any{
+		0: address,
+		1: uint64(2_000_000),
+		2: []any{
+			uint64(1),
+			cbor.Tag{
+				Number:  24,
+				Content: testIndigoCDPDatum(t, iAsset, mintedAmount),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to encode test CDP output: %v", err)
+	}
+	output, err := ledger.NewTransactionOutputFromCbor(outputCbor)
+	if err != nil {
+		t.Fatalf("failed to decode test CDP output: %v", err)
+	}
+	if output.Datum() == nil {
+		t.Fatal("expected decoded test CDP output to have inline datum")
+	}
+	return output
+}
+
+func testIndigoCDPDatum(
+	t *testing.T,
+	iAsset string,
+	mintedAmount int64,
+) []byte {
+	t.Helper()
+	owner := cbor.NewConstructorEncoder(1, cbor.IndefLengthList{})
+	accumulatedFees := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		int64(1),
+		int64(0),
+	})
+	inner := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		owner,
+		[]byte(iAsset),
+		mintedAmount,
+		accumulatedFees,
+	})
+	outer := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{inner})
+	cborData, err := cbor.Encode(&outer)
+	if err != nil {
+		t.Fatalf("failed to encode Indigo CDP datum: %v", err)
+	}
+	return cborData
+}

--- a/internal/oracle/indigo.go
+++ b/internal/oracle/indigo.go
@@ -1,0 +1,92 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oracle
+
+import (
+	"time"
+
+	"github.com/blinklabs-io/shai/internal/oracle/indigo"
+)
+
+// Re-export constants for backward compatibility
+const (
+	IndigoProtocolName       = indigo.ProtocolName
+	IndigoCDPContractAddress = indigo.CDPContractAddress
+)
+
+// Re-export types for backward compatibility
+type (
+	IndigoCDPContentDatum = indigo.CDPContentDatum
+	IndigoCDPInner        = indigo.CDPInner
+	IndigoMaybePubKeyHash = indigo.MaybePubKeyHash
+	IndigoAccumulatedFees = indigo.AccumulatedFees
+	IndigoCDPState        = indigo.CDPState
+	CDPState              = indigo.CDPState
+)
+
+// IndigoParser wraps indigo.Parser for backward compatibility
+type IndigoParser struct {
+	parser *indigo.Parser
+}
+
+// NewIndigoParser creates a parser for Indigo protocol
+func NewIndigoParser() *IndigoParser {
+	return &IndigoParser{parser: indigo.NewParser()}
+}
+
+// Protocol returns the protocol name
+func (p *IndigoParser) Protocol() string {
+	return p.parser.Protocol()
+}
+
+// ParseCDPDatum parses an Indigo CDP datum and returns the CDP state
+func (p *IndigoParser) ParseCDPDatum(
+	datum []byte,
+	txHash string,
+	txIndex uint32,
+	slot uint64,
+	timestamp time.Time,
+) (*IndigoCDPState, error) {
+	return p.parser.ParseCDPDatum(datum, txHash, txIndex, slot, timestamp)
+}
+
+// CDPIdForOutput returns the Indigo CDP state key for a UTxO.
+func (p *IndigoParser) CDPIdForOutput(txHash string, txIndex uint32) string {
+	return indigo.GenerateCDPId(txHash, txIndex)
+}
+
+// ParsePoolDatum implements PoolParser interface for compatibility
+// Indigo is a synthetics/CDP protocol, not an AMM, so this returns nil
+func (p *IndigoParser) ParsePoolDatum(
+	datum []byte,
+	utxoValue []byte,
+	txHash string,
+	txIndex uint32,
+	slot uint64,
+	timestamp time.Time,
+) (*PoolState, error) {
+	// Indigo doesn't have AMM pools, return nil
+	return nil, nil
+}
+
+// generateIndigoCDPId wraps indigo.GenerateCDPId for backward compatibility
+func generateIndigoCDPId(txHash string, txIndex uint32) string {
+	return indigo.GenerateCDPId(txHash, txIndex)
+}
+
+// GetIndigoAddresses returns known Indigo contract addresses
+func GetIndigoAddresses() []string {
+	return indigo.GetAddresses()
+}

--- a/internal/oracle/indigo/models.go
+++ b/internal/oracle/indigo/models.go
@@ -1,0 +1,227 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package indigo provides datum types and parsing for Indigo CDP protocol.
+package indigo
+
+import (
+	"fmt"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+)
+
+// Protocol constants
+const (
+	ProtocolName = "indigo"
+
+	// Indigo mainnet CDP contract address
+	// Script hash: e4d2fb0b8d275852103fd75801e2c7dcf6ed3e276c74cabadbe5b8b6
+	CDPContractAddress = "addr1z8jd97ct35n4s5ss8lt4sq0zclw0dmf7yak8fj46m0jm3dhzfjvtm0pg7ms9fvw5luec6euwzku8wqjpt5gv0q86052qv9nxuw"
+
+	// Indigo Stability Pool contract address (mainnet)
+	// Script hash: de1585e046f16fdf79767300233c1affbe9d30340656acfde45e9142
+	StabilityPoolAddress = "addr1w80ptp0qgmcklhmeweesqgeurtlma8fsxsr9dt8au30fzss0czhl9"
+
+	// iAsset minting policy ID - shared by all iAssets (iUSD, iBTC, iETH)
+	IAssetPolicyID = "f66d78b4a3cb3d37afa0ec36461e51ecbde00f26c8f0a68f94b69880"
+
+	// INDY governance token policy ID
+	INDYPolicyID = "533bb94a8850ee3ccbe483106489399112b74c905342cb1792a797a0"
+)
+
+// CDPContentDatum represents the Indigo CDP datum wrapper
+// CDDL: CDPContent = #6.121([#6.121([ owner, iAsset, mintedAmount, accumulatedFees ])])
+// This is a double-wrapped constructor (outer #6.121, inner #6.121)
+type CDPContentDatum struct {
+	cbor.DecodeStoreCbor
+	Inner *CDPInner
+}
+
+func (d *CDPContentDatum) UnmarshalCBOR(cborData []byte) error {
+	d.SetCbor(cborData)
+	d.Inner = nil
+
+	// Parse outer constructor (#6.121)
+	var outerConstr cbor.ConstructorDecoder
+	if _, err := cbor.Decode(cborData, &outerConstr); err != nil {
+		return err
+	}
+
+	// Outer constructor must be 0 (corresponds to #6.121)
+	if outerConstr.Tag() != 0 {
+		return nil // Not a CDP content datum
+	}
+
+	// The outer constructor wraps a single field which is the inner constructor
+	// FieldsCbor() returns the CBOR of the array containing the inner constructor
+	// We need to decode it as a wrapper struct to extract the inner constructor
+	var wrapper struct {
+		cbor.StructAsArray
+		Inner CDPInner
+	}
+	if err := cbor.DecodeGeneric(outerConstr.Fields(), &wrapper); err != nil {
+		return err
+	}
+	d.Inner = &wrapper.Inner
+
+	return nil
+}
+
+// CDPInner represents the inner CDP data
+// CDDL: #6.121([ owner, iAsset, mintedAmount, accumulatedFees ])
+// Fields: owner (MaybePubKeyHash), iAsset (bytes), mintedAmount (int),
+// accumulatedFees (AccumulatedFees)
+type CDPInner struct {
+	cbor.StructAsArray
+	Owner           MaybePubKeyHash
+	IAsset          []byte
+	MintedAmount    int64
+	AccumulatedFees AccumulatedFees
+}
+
+func (c *CDPInner) UnmarshalCBOR(cborData []byte) error {
+	// The inner is wrapped in a constructor (#6.121)
+	var tmpConstr cbor.ConstructorDecoder
+	if _, err := cbor.Decode(cborData, &tmpConstr); err != nil {
+		return err
+	}
+
+	// Inner constructor must be 0 (corresponds to #6.121)
+	if tmpConstr.Tag() != 0 {
+		return fmt.Errorf(
+			"unexpected CDP inner constructor: %d, expected 0",
+			tmpConstr.Tag(),
+		)
+	}
+
+	// Decode the fields array
+	var fields struct {
+		cbor.StructAsArray
+		Owner           MaybePubKeyHash
+		IAsset          []byte
+		MintedAmount    int64
+		AccumulatedFees AccumulatedFees
+	}
+	if err := cbor.DecodeGeneric(tmpConstr.Fields(), &fields); err != nil {
+		return err
+	}
+
+	c.Owner = fields.Owner
+	c.IAsset = fields.IAsset
+	c.MintedAmount = fields.MintedAmount
+	c.AccumulatedFees = fields.AccumulatedFees
+
+	return nil
+}
+
+// MaybePubKeyHash represents an optional public key hash
+// CDDL: MaybePubKeyHash = PubKeyHash / Nothing
+// PubKeyHash = #6.121([bytes])   -> Constructor 0
+// Nothing = #6.122([])           -> Constructor 1
+type MaybePubKeyHash struct {
+	IsJust bool   // true if PubKeyHash, false if Nothing
+	Hash   []byte // Only populated if IsJust is true
+}
+
+func (m *MaybePubKeyHash) UnmarshalCBOR(cborData []byte) error {
+	var tmpConstr cbor.ConstructorDecoder
+	if _, err := cbor.Decode(cborData, &tmpConstr); err != nil {
+		return err
+	}
+
+	switch tmpConstr.Tag() {
+	case 0: // PubKeyHash (#6.121)
+		m.IsJust = true
+		var wrapper struct {
+			cbor.StructAsArray
+			Hash []byte
+		}
+		if err := cbor.DecodeGeneric(tmpConstr.Fields(), &wrapper); err != nil {
+			return err
+		}
+		m.Hash = wrapper.Hash
+	case 1: // Nothing (#6.122)
+		m.IsJust = false
+		m.Hash = nil
+	default:
+		return fmt.Errorf(
+			"unexpected MaybePubKeyHash constructor: %d",
+			tmpConstr.Tag(),
+		)
+	}
+
+	return nil
+}
+
+// AccumulatedFees represents the fees structure
+// CDDL: AccumulatedFees = InterestIAssetAmount / FeesLovelacesAmount
+// InterestIAssetAmount = #6.121([ lastUpdated : int, iAssetAmount : int ])
+// FeesLovelacesAmount = #6.122([ treasury : int, indyStakers : int ])
+type AccumulatedFees struct {
+	Type int // 0 = InterestIAssetAmount, 1 = FeesLovelacesAmount
+
+	// InterestIAssetAmount fields (Type == 0)
+	LastUpdated  int64
+	IAssetAmount int64
+
+	// FeesLovelacesAmount fields (Type == 1)
+	Treasury    int64
+	IndyStakers int64
+}
+
+func (a *AccumulatedFees) UnmarshalCBOR(cborData []byte) error {
+	var tmpConstr cbor.ConstructorDecoder
+	if _, err := cbor.Decode(cborData, &tmpConstr); err != nil {
+		return err
+	}
+
+	a.Type = int(tmpConstr.Tag())
+	a.LastUpdated = 0
+	a.IAssetAmount = 0
+	a.Treasury = 0
+	a.IndyStakers = 0
+
+	switch a.Type {
+	case 0: // InterestIAssetAmount (#6.121)
+		var interest struct {
+			cbor.StructAsArray
+			LastUpdated  int64
+			IAssetAmount int64
+		}
+		if err := cbor.DecodeGeneric(tmpConstr.Fields(), &interest); err != nil {
+			return err
+		}
+		a.LastUpdated = interest.LastUpdated
+		a.IAssetAmount = interest.IAssetAmount
+
+	case 1: // FeesLovelacesAmount (#6.122)
+		var fees struct {
+			cbor.StructAsArray
+			Treasury    int64
+			IndyStakers int64
+		}
+		if err := cbor.DecodeGeneric(tmpConstr.Fields(), &fees); err != nil {
+			return err
+		}
+		a.Treasury = fees.Treasury
+		a.IndyStakers = fees.IndyStakers
+	default:
+		return fmt.Errorf(
+			"unexpected AccumulatedFees constructor: %d",
+			a.Type,
+		)
+	}
+
+	return nil
+}

--- a/internal/oracle/indigo/parser.go
+++ b/internal/oracle/indigo/parser.go
@@ -1,0 +1,172 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package indigo
+
+import (
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+)
+
+// CDPState represents the parsed state of an Indigo CDP position
+type CDPState struct {
+	CDPId        string    // Unique identifier for this CDP
+	Network      string    // Cardano network
+	Protocol     string    // Protocol name
+	Owner        string    // Owner's public key hash (hex) or empty if Nothing
+	HasOwner     bool      // Whether the CDP has an owner set
+	IAsset       string    // The iAsset identifier (hex encoded)
+	MintedAmount int64     // Amount of iAsset minted
+	Slot         uint64    // Slot when this state was observed
+	BlockHash    string    // Block hash when this state was observed
+	TxHash       string    // Transaction hash
+	TxIndex      uint32    // Transaction output index
+	Timestamp    time.Time // Block timestamp
+	UpdatedAt    time.Time // Wall-clock time when this state was updated
+
+	// Accumulated fees information
+	FeesType    int   // 0 = InterestIAssetAmount, 1 = FeesLovelacesAmount
+	LastUpdated int64 // For InterestIAssetAmount: last update time
+	IAssetFees  int64 // For InterestIAssetAmount: accumulated iAsset fees
+	Treasury    int64 // For FeesLovelacesAmount: treasury amount
+	IndyStakers int64 // For FeesLovelacesAmount: INDY stakers amount
+}
+
+// Key returns a unique key for this CDP
+func (c *CDPState) Key() string {
+	return fmt.Sprintf("indigo:%s", c.CDPId)
+}
+
+// IAssetName returns a human-readable name for common iAssets
+func (c *CDPState) IAssetName() string {
+	// Common Indigo iAsset identifiers
+	switch c.IAsset {
+	case hex.EncodeToString([]byte("iUSD")):
+		return "iUSD"
+	case hex.EncodeToString([]byte("iBTC")):
+		return "iBTC"
+	case hex.EncodeToString([]byte("iETH")):
+		return "iETH"
+	default:
+		// Try to decode as ASCII if it looks like a readable name
+		bytes, err := hex.DecodeString(c.IAsset)
+		if err == nil && isPrintable(bytes) {
+			return string(bytes)
+		}
+		return c.IAsset
+	}
+}
+
+// isPrintable checks if all bytes are printable ASCII
+func isPrintable(data []byte) bool {
+	for _, b := range data {
+		if b < 32 || b > 126 {
+			return false
+		}
+	}
+	return len(data) > 0
+}
+
+// Parser implements parsing for Indigo protocol CDPs
+type Parser struct{}
+
+// NewParser creates a parser for Indigo protocol
+func NewParser() *Parser {
+	return &Parser{}
+}
+
+// Protocol returns the protocol name
+func (p *Parser) Protocol() string {
+	return ProtocolName
+}
+
+// ParseCDPDatum parses an Indigo CDP datum and returns the CDP state
+func (p *Parser) ParseCDPDatum(
+	datum []byte,
+	txHash string,
+	txIndex uint32,
+	slot uint64,
+	timestamp time.Time,
+) (*CDPState, error) {
+	var cdpContent CDPContentDatum
+	if _, err := cbor.Decode(datum, &cdpContent); err != nil {
+		return nil, fmt.Errorf("failed to decode Indigo CDP datum: %w", err)
+	}
+
+	// Check if parsing succeeded
+	if cdpContent.Inner == nil {
+		return nil, nil // Not a valid CDP content datum
+	}
+
+	inner := cdpContent.Inner
+
+	// Generate CDP ID
+	cdpId := GenerateCDPId(txHash, txIndex)
+
+	// Extract owner information
+	owner := ""
+	if inner.Owner.IsJust && len(inner.Owner.Hash) > 0 {
+		owner = hex.EncodeToString(inner.Owner.Hash)
+	}
+	hasOwner := owner != ""
+
+	state := &CDPState{
+		CDPId:        cdpId,
+		Protocol:     ProtocolName,
+		Owner:        owner,
+		HasOwner:     hasOwner,
+		IAsset:       hex.EncodeToString(inner.IAsset),
+		MintedAmount: inner.MintedAmount,
+		Slot:         slot,
+		TxHash:       txHash,
+		TxIndex:      txIndex,
+		Timestamp:    timestamp,
+		FeesType:     inner.AccumulatedFees.Type,
+	}
+
+	// Copy fee details based on type
+	if inner.AccumulatedFees.Type == 0 {
+		state.LastUpdated = inner.AccumulatedFees.LastUpdated
+		state.IAssetFees = inner.AccumulatedFees.IAssetAmount
+	} else {
+		state.Treasury = inner.AccumulatedFees.Treasury
+		state.IndyStakers = inner.AccumulatedFees.IndyStakers
+	}
+
+	return state, nil
+}
+
+// GenerateCDPId generates a unique CDP ID from transaction information
+func GenerateCDPId(txHash string, txIndex uint32) string {
+	return fmt.Sprintf("indigo_cdp_%s#%d", txHash, txIndex)
+}
+
+// GetAddresses returns known Indigo contract addresses
+func GetAddresses() []string {
+	return []string{
+		CDPContractAddress,
+		StabilityPoolAddress,
+	}
+}
+
+// GetPolicyIDs returns known Indigo policy IDs
+func GetPolicyIDs() map[string]string {
+	return map[string]string{
+		"iAsset": IAssetPolicyID,
+		"INDY":   INDYPolicyID,
+	}
+}

--- a/internal/oracle/indigo_test.go
+++ b/internal/oracle/indigo_test.go
@@ -1,0 +1,613 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oracle
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+)
+
+func TestNewIndigoParser(t *testing.T) {
+	parser := NewIndigoParser()
+	if parser == nil {
+		t.Fatal("expected non-nil parser")
+	}
+	if parser.Protocol() != "indigo" {
+		t.Errorf("expected protocol 'indigo', got %s", parser.Protocol())
+	}
+}
+
+func TestGenerateIndigoCDPId(t *testing.T) {
+	txHash := "abc123def456789012345678901234567890"
+	txIndex := uint32(2)
+
+	cdpId := generateIndigoCDPId(txHash, txIndex)
+	expected := "indigo_cdp_abc123def456789012345678901234567890#2"
+
+	if cdpId != expected {
+		t.Errorf("expected CDP ID %s, got %s", expected, cdpId)
+	}
+
+	otherTxHash := "abc123def4567890ffffffffffffffffffffffff"
+	otherCDPId := generateIndigoCDPId(otherTxHash, txIndex)
+	if cdpId == otherCDPId {
+		t.Errorf("expected distinct CDP IDs, got %s", cdpId)
+	}
+}
+
+func TestIndigoMaybePubKeyHashWithValue(t *testing.T) {
+	// Test PubKeyHash (Constructor 0 = #6.121)
+	pubKeyHash := make([]byte, 28)
+	for i := range pubKeyHash {
+		pubKeyHash[i] = byte(i + 1)
+	}
+
+	// Create PubKeyHash: #6.121([bytes])
+	pubKeyConstr := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		pubKeyHash,
+	})
+
+	cborData, err := cbor.Encode(&pubKeyConstr)
+	if err != nil {
+		t.Fatalf("failed to encode: %v", err)
+	}
+
+	var maybe IndigoMaybePubKeyHash
+	if _, err := cbor.Decode(cborData, &maybe); err != nil {
+		t.Fatalf("failed to decode: %v", err)
+	}
+
+	if !maybe.IsJust {
+		t.Error("expected IsJust to be true")
+	}
+	if len(maybe.Hash) != 28 {
+		t.Errorf("expected 28 byte hash, got %d", len(maybe.Hash))
+	}
+	if !bytes.Equal(maybe.Hash, pubKeyHash) {
+		t.Errorf("decoded hash mismatch: got %x want %x", maybe.Hash, pubKeyHash)
+	}
+}
+
+func TestIndigoMaybePubKeyHashNothing(t *testing.T) {
+	// Test Nothing (Constructor 1 = #6.122)
+	nothingConstr := cbor.NewConstructorEncoder(1, cbor.IndefLengthList{})
+
+	cborData, err := cbor.Encode(&nothingConstr)
+	if err != nil {
+		t.Fatalf("failed to encode: %v", err)
+	}
+
+	var maybe IndigoMaybePubKeyHash
+	if _, err := cbor.Decode(cborData, &maybe); err != nil {
+		t.Fatalf("failed to decode: %v", err)
+	}
+
+	if maybe.IsJust {
+		t.Error("expected IsJust to be false")
+	}
+	if maybe.Hash != nil {
+		t.Error("expected Hash to be nil")
+	}
+}
+
+func TestIndigoAccumulatedFeesInterest(t *testing.T) {
+	// Test InterestIAssetAmount (Constructor 0 = #6.121)
+	interestConstr := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		int64(1704067200000), // lastUpdated
+		int64(500000),        // iAssetAmount
+	})
+
+	cborData, err := cbor.Encode(&interestConstr)
+	if err != nil {
+		t.Fatalf("failed to encode: %v", err)
+	}
+
+	var fees IndigoAccumulatedFees
+	if _, err := cbor.Decode(cborData, &fees); err != nil {
+		t.Fatalf("failed to decode: %v", err)
+	}
+
+	if fees.Type != 0 {
+		t.Errorf("expected type 0, got %d", fees.Type)
+	}
+	if fees.LastUpdated != 1704067200000 {
+		t.Errorf("expected lastUpdated 1704067200000, got %d", fees.LastUpdated)
+	}
+	if fees.IAssetAmount != 500000 {
+		t.Errorf("expected iAssetAmount 500000, got %d", fees.IAssetAmount)
+	}
+}
+
+func TestIndigoAccumulatedFeesLovelaces(t *testing.T) {
+	// Test FeesLovelacesAmount (Constructor 1 = #6.122)
+	feesConstr := cbor.NewConstructorEncoder(1, cbor.IndefLengthList{
+		int64(1000000), // treasury
+		int64(2000000), // indyStakers
+	})
+
+	cborData, err := cbor.Encode(&feesConstr)
+	if err != nil {
+		t.Fatalf("failed to encode: %v", err)
+	}
+
+	var fees IndigoAccumulatedFees
+	if _, err := cbor.Decode(cborData, &fees); err != nil {
+		t.Fatalf("failed to decode: %v", err)
+	}
+
+	if fees.Type != 1 {
+		t.Errorf("expected type 1, got %d", fees.Type)
+	}
+	if fees.Treasury != 1000000 {
+		t.Errorf("expected treasury 1000000, got %d", fees.Treasury)
+	}
+	if fees.IndyStakers != 2000000 {
+		t.Errorf("expected indyStakers 2000000, got %d", fees.IndyStakers)
+	}
+}
+
+func TestIndigoAccumulatedFeesClearsInactiveFields(t *testing.T) {
+	feesConstr := cbor.NewConstructorEncoder(1, cbor.IndefLengthList{
+		int64(1000000),
+		int64(2000000),
+	})
+	feesData, err := cbor.Encode(&feesConstr)
+	if err != nil {
+		t.Fatalf("failed to encode fees: %v", err)
+	}
+
+	interestConstr := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		int64(1704067200000),
+		int64(500000),
+	})
+	interestData, err := cbor.Encode(&interestConstr)
+	if err != nil {
+		t.Fatalf("failed to encode interest: %v", err)
+	}
+
+	var fees IndigoAccumulatedFees
+	if _, err := cbor.Decode(feesData, &fees); err != nil {
+		t.Fatalf("failed to decode fees: %v", err)
+	}
+	if _, err := cbor.Decode(interestData, &fees); err != nil {
+		t.Fatalf("failed to decode interest: %v", err)
+	}
+	if fees.Treasury != 0 {
+		t.Errorf("expected inactive Treasury to be cleared, got %d", fees.Treasury)
+	}
+	if fees.IndyStakers != 0 {
+		t.Errorf(
+			"expected inactive IndyStakers to be cleared, got %d",
+			fees.IndyStakers,
+		)
+	}
+
+	if _, err := cbor.Decode(feesData, &fees); err != nil {
+		t.Fatalf("failed to decode fees again: %v", err)
+	}
+	if fees.LastUpdated != 0 {
+		t.Errorf(
+			"expected inactive LastUpdated to be cleared, got %d",
+			fees.LastUpdated,
+		)
+	}
+	if fees.IAssetAmount != 0 {
+		t.Errorf(
+			"expected inactive IAssetAmount to be cleared, got %d",
+			fees.IAssetAmount,
+		)
+	}
+}
+
+func TestIndigoCDPContentDatumFull(t *testing.T) {
+	// Build a complete CDP content datum following the CDDL:
+	// CDPContent = #6.121([#6.121([ owner, iAsset, mintedAmount, accumulatedFees ])])
+
+	// Owner: PubKeyHash (Just)
+	pubKeyHash := make([]byte, 28)
+	for i := range pubKeyHash {
+		pubKeyHash[i] = byte(i)
+	}
+	owner := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		pubKeyHash,
+	})
+
+	// iAsset: bytes representing "iUSD"
+	iAsset := []byte("iUSD")
+
+	// mintedAmount
+	mintedAmount := int64(100000000) // 100 iUSD
+
+	// accumulatedFees: InterestIAssetAmount
+	accumulatedFees := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		int64(1704067200000), // lastUpdated
+		int64(50000),         // iAssetAmount
+	})
+
+	// Inner constructor: #6.121([ owner, iAsset, mintedAmount, accumulatedFees ])
+	inner := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		owner,
+		iAsset,
+		mintedAmount,
+		accumulatedFees,
+	})
+
+	// Outer constructor: #6.121([inner])
+	outer := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		inner,
+	})
+
+	cborData, err := cbor.Encode(&outer)
+	if err != nil {
+		t.Fatalf("failed to encode: %v", err)
+	}
+
+	var datum IndigoCDPContentDatum
+	if _, err := cbor.Decode(cborData, &datum); err != nil {
+		t.Fatalf("failed to decode: %v", err)
+	}
+
+	if datum.Inner == nil {
+		t.Fatal("expected Inner to be populated")
+	}
+
+	if !datum.Inner.Owner.IsJust {
+		t.Error("expected owner to be Just")
+	}
+	if len(datum.Inner.Owner.Hash) != 28 {
+		t.Errorf(
+			"expected 28 byte owner hash, got %d",
+			len(datum.Inner.Owner.Hash),
+		)
+	}
+	if string(datum.Inner.IAsset) != "iUSD" {
+		t.Errorf("expected iAsset 'iUSD', got %s", string(datum.Inner.IAsset))
+	}
+	if datum.Inner.MintedAmount != 100000000 {
+		t.Errorf(
+			"expected mintedAmount 100000000, got %d",
+			datum.Inner.MintedAmount,
+		)
+	}
+	if datum.Inner.AccumulatedFees.Type != 0 {
+		t.Errorf(
+			"expected fees type 0, got %d",
+			datum.Inner.AccumulatedFees.Type,
+		)
+	}
+}
+
+func TestIndigoCDPContentDatumClearsInnerOnNonMatch(t *testing.T) {
+	pubKeyHash := make([]byte, 28)
+	owner := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		pubKeyHash,
+	})
+	accumulatedFees := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		int64(1704067200000),
+		int64(50000),
+	})
+	inner := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		owner,
+		[]byte("iUSD"),
+		int64(100000000),
+		accumulatedFees,
+	})
+	outer := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		inner,
+	})
+	cdpData, err := cbor.Encode(&outer)
+	if err != nil {
+		t.Fatalf("failed to encode CDP datum: %v", err)
+	}
+
+	var datum IndigoCDPContentDatum
+	if _, err := cbor.Decode(cdpData, &datum); err != nil {
+		t.Fatalf("failed to decode CDP datum: %v", err)
+	}
+	if datum.Inner == nil {
+		t.Fatal("expected Inner to be populated")
+	}
+
+	nonMatch := cbor.NewConstructorEncoder(1, cbor.IndefLengthList{})
+	nonMatchData, err := cbor.Encode(&nonMatch)
+	if err != nil {
+		t.Fatalf("failed to encode non-matching datum: %v", err)
+	}
+	if _, err := cbor.Decode(nonMatchData, &datum); err != nil {
+		t.Fatalf("failed to decode non-matching datum: %v", err)
+	}
+	if datum.Inner != nil {
+		t.Fatal("expected Inner to be cleared for non-matching datum")
+	}
+}
+
+func TestIndigoParserParseCDPDatum(t *testing.T) {
+	// Build a complete CDP datum
+	pubKeyHash := make([]byte, 28)
+	for i := range pubKeyHash {
+		pubKeyHash[i] = byte(i)
+	}
+	owner := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		pubKeyHash,
+	})
+
+	iAsset := []byte("iBTC")
+	mintedAmount := int64(50000000)
+
+	accumulatedFees := cbor.NewConstructorEncoder(1, cbor.IndefLengthList{
+		int64(1000000), // treasury
+		int64(500000),  // indyStakers
+	})
+
+	inner := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		owner,
+		iAsset,
+		mintedAmount,
+		accumulatedFees,
+	})
+
+	outer := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		inner,
+	})
+
+	cborData, err := cbor.Encode(&outer)
+	if err != nil {
+		t.Fatalf("failed to encode: %v", err)
+	}
+
+	parser := NewIndigoParser()
+	txHash := "abc123def456789012345678901234567890"
+	txIndex := uint32(3)
+	timestamp := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	state, err := parser.ParseCDPDatum(
+		cborData,
+		txHash,
+		txIndex,
+		12345,
+		timestamp,
+	)
+	if err != nil {
+		t.Fatalf("failed to parse: %v", err)
+	}
+
+	if state == nil {
+		t.Fatal("expected non-nil state")
+	}
+	expectedCDPId := "indigo_cdp_abc123def456789012345678901234567890#3"
+	if state.CDPId != expectedCDPId {
+		t.Errorf("expected CDPId %s, got %s", expectedCDPId, state.CDPId)
+	}
+	if state.TxHash != txHash {
+		t.Errorf("expected TxHash %s, got %s", txHash, state.TxHash)
+	}
+	if state.TxIndex != txIndex {
+		t.Errorf("expected TxIndex %d, got %d", txIndex, state.TxIndex)
+	}
+	if !state.Timestamp.Equal(timestamp) {
+		t.Errorf("expected Timestamp %s, got %s", timestamp, state.Timestamp)
+	}
+	if state.MintedAmount != 50000000 {
+		t.Errorf("expected mintedAmount 50000000, got %d", state.MintedAmount)
+	}
+	if state.Slot != 12345 {
+		t.Errorf("expected slot 12345, got %d", state.Slot)
+	}
+	if state.IAsset != hex.EncodeToString([]byte("iBTC")) {
+		t.Errorf(
+			"expected iAsset hex of 'iBTC', got %s",
+			state.IAsset,
+		)
+	}
+	if !state.HasOwner {
+		t.Error("expected HasOwner to be true")
+	}
+	if state.FeesType != 1 {
+		t.Errorf("expected FeesType 1, got %d", state.FeesType)
+	}
+	if state.Treasury != 1000000 {
+		t.Errorf("expected Treasury 1000000, got %d", state.Treasury)
+	}
+	if state.IndyStakers != 500000 {
+		t.Errorf("expected IndyStakers 500000, got %d", state.IndyStakers)
+	}
+}
+
+func TestIndigoParserNothingOwner(t *testing.T) {
+	// Test CDP with Nothing owner
+	owner := cbor.NewConstructorEncoder(1, cbor.IndefLengthList{}) // Nothing
+
+	iAsset := []byte("iETH")
+	mintedAmount := int64(25000000)
+
+	accumulatedFees := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		int64(1704067200000),
+		int64(10000),
+	})
+
+	inner := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		owner,
+		iAsset,
+		mintedAmount,
+		accumulatedFees,
+	})
+
+	outer := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		inner,
+	})
+
+	cborData, err := cbor.Encode(&outer)
+	if err != nil {
+		t.Fatalf("failed to encode: %v", err)
+	}
+
+	parser := NewIndigoParser()
+	state, err := parser.ParseCDPDatum(
+		cborData,
+		"def456789012345678901234567890abcdef",
+		1,
+		54321,
+		time.Now(),
+	)
+	if err != nil {
+		t.Fatalf("failed to parse: %v", err)
+	}
+
+	if state == nil {
+		t.Fatal("expected non-nil state")
+	}
+	if state.HasOwner {
+		t.Error("expected HasOwner to be false")
+	}
+	if state.Owner != "" {
+		t.Errorf("expected empty owner, got %s", state.Owner)
+	}
+}
+
+func TestIndigoParserEmptyOwnerHashHasNoOwner(t *testing.T) {
+	owner := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		[]byte{},
+	})
+
+	iAsset := []byte("iETH")
+	mintedAmount := int64(25000000)
+
+	accumulatedFees := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		int64(1704067200000),
+		int64(10000),
+	})
+
+	inner := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		owner,
+		iAsset,
+		mintedAmount,
+		accumulatedFees,
+	})
+
+	outer := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{
+		inner,
+	})
+
+	cborData, err := cbor.Encode(&outer)
+	if err != nil {
+		t.Fatalf("failed to encode: %v", err)
+	}
+
+	parser := NewIndigoParser()
+	state, err := parser.ParseCDPDatum(
+		cborData,
+		"def456789012345678901234567890abcdef",
+		1,
+		54321,
+		time.Now(),
+	)
+	if err != nil {
+		t.Fatalf("failed to parse: %v", err)
+	}
+
+	if state == nil {
+		t.Fatal("expected non-nil state")
+	}
+	if state.HasOwner {
+		t.Error("expected HasOwner to be false for empty owner hash")
+	}
+	if state.Owner != "" {
+		t.Errorf("expected empty owner, got %s", state.Owner)
+	}
+}
+
+func TestIndigoCDPStateKey(t *testing.T) {
+	state := &IndigoCDPState{
+		CDPId: "indigo_cdp_abc123#0",
+	}
+
+	expected := "indigo:indigo_cdp_abc123#0"
+	if state.Key() != expected {
+		t.Errorf("expected key %s, got %s", expected, state.Key())
+	}
+}
+
+func TestIndigoCDPStateIAssetName(t *testing.T) {
+	// Test known iAsset
+	state := &IndigoCDPState{
+		IAsset: hex.EncodeToString([]byte("iUSD")),
+	}
+	if state.IAssetName() != "iUSD" {
+		t.Errorf("expected iAssetName 'iUSD', got %s", state.IAssetName())
+	}
+
+	// Test iBTC
+	state.IAsset = hex.EncodeToString([]byte("iBTC"))
+	if state.IAssetName() != "iBTC" {
+		t.Errorf("expected iAssetName 'iBTC', got %s", state.IAssetName())
+	}
+
+	// Test iETH
+	state.IAsset = hex.EncodeToString([]byte("iETH"))
+	if state.IAssetName() != "iETH" {
+		t.Errorf("expected iAssetName 'iETH', got %s", state.IAssetName())
+	}
+
+	// Test unknown but printable
+	state.IAsset = hex.EncodeToString([]byte("iGOLD"))
+	if state.IAssetName() != "iGOLD" {
+		t.Errorf("expected iAssetName 'iGOLD', got %s", state.IAssetName())
+	}
+}
+
+func TestIndigoParserPoolDatum(t *testing.T) {
+	// Indigo is not an AMM, so ParsePoolDatum should return nil
+	parser := NewIndigoParser()
+
+	datum := cbor.NewConstructorEncoder(0, cbor.IndefLengthList{})
+	cborData, _ := cbor.Encode(&datum)
+
+	state, err := parser.ParsePoolDatum(
+		cborData,
+		nil,
+		"abc123",
+		0,
+		12345,
+		time.Now(),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if state != nil {
+		t.Error("expected nil pool state for Indigo")
+	}
+}
+
+func TestGetIndigoAddresses(t *testing.T) {
+	addresses := GetIndigoAddresses()
+	if len(addresses) == 0 {
+		t.Error("expected at least one address")
+	}
+
+	// Verify the known mainnet address is included
+	found := false
+	for _, addr := range addresses {
+		if addr == IndigoCDPContractAddress {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected CDP contract address to be in the list")
+	}
+}

--- a/internal/oracle/oracle.go
+++ b/internal/oracle/oracle.go
@@ -22,6 +22,8 @@ import (
 	"time"
 
 	"github.com/blinklabs-io/adder/event"
+	"github.com/blinklabs-io/gouroboros/ledger"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
 	"github.com/blinklabs-io/shai/internal/config"
 	"github.com/blinklabs-io/shai/internal/indexer"
 	"github.com/blinklabs-io/shai/internal/logging"
@@ -32,6 +34,20 @@ const (
 	dropLogSampleRate    = 100
 )
 
+// CDPParser parses synthetics/CDP datums that are tracked separately from AMM
+// pool states.
+type CDPParser interface {
+	Protocol() string
+	ParseCDPDatum(
+		datum []byte,
+		txHash string,
+		txIndex uint32,
+		slot uint64,
+		timestamp time.Time,
+	) (*CDPState, error)
+	CDPIdForOutput(txHash string, txIndex uint32) string
+}
+
 // Oracle tracks pool states from on-chain data
 type Oracle struct {
 	idx           *indexer.Indexer
@@ -39,6 +55,8 @@ type Oracle struct {
 	parser        PoolParser
 	pools         map[string]*PoolState
 	poolsMu       sync.RWMutex
+	cdps          map[string]*CDPState
+	cdpsMu        sync.RWMutex
 	poolAddresses map[string]struct{} // Set for O(1) lookup
 	storage       *OracleStorage
 	stopChan      chan struct{}
@@ -60,19 +78,28 @@ func New(
 		profile:       profile,
 		parser:        parser,
 		pools:         make(map[string]*PoolState),
+		cdps:          make(map[string]*CDPState),
 		poolAddresses: make(map[string]struct{}),
 		stopChan:      make(chan struct{}),
 		mempoolMgr:    NewMempoolStateManager(),
 	}
 
-	// Extract pool addresses from profile config
-	if oracleConfig, ok := profile.Config.(config.OracleProfileConfig); ok {
-		for _, addr := range oracleConfig.PoolAddresses {
+	o.addProfileAddresses()
+
+	return o
+}
+
+func (o *Oracle) addProfileAddresses() {
+	switch profileConfig := o.profile.Config.(type) {
+	case config.OracleProfileConfig:
+		for _, addr := range profileConfig.PoolAddresses {
+			o.poolAddresses[addr.Address] = struct{}{}
+		}
+	case config.SyntheticsProfileConfig:
+		for _, addr := range profileConfig.CDPAddresses {
 			o.poolAddresses[addr.Address] = struct{}{}
 		}
 	}
-
-	return o
 }
 
 // Start begins tracking pool states
@@ -245,16 +272,30 @@ func (o *Oracle) handleTransaction(
 		return nil
 	}
 	cfg := config.GetConfig()
+	cdpParser, hasCDPParser := o.parser.(CDPParser)
+	if hasCDPParser && o.isSyntheticsProfile() {
+		o.deleteSpentCDPStates(logger, cdpParser, transactionInputs(txEvt))
+	}
 
-	// Check for pool UTxOs at monitored addresses
-	for _, utxo := range txEvt.Transaction.Produced() {
+	// Check for tracked UTxOs at monitored addresses.
+	for _, utxo := range producedUTXOs(txEvt, ctx.TransactionHash) {
 		addr := utxo.Output.Address().String()
 		if !o.isPoolAddress(addr) {
 			continue
 		}
-
-		// Skip UTxOs without datum
 		if utxo.Output.Datum() == nil {
+			continue
+		}
+
+		if hasCDPParser && o.isSyntheticsProfile() {
+			o.handleProducedCDPOutput(
+				logger,
+				cdpParser,
+				cfg.Network,
+				txEvt.BlockHash,
+				ctx,
+				utxo,
+			)
 			continue
 		}
 
@@ -269,6 +310,9 @@ func (o *Oracle) handleTransaction(
 		)
 		if err != nil {
 			// Not a valid pool datum for this protocol
+			continue
+		}
+		if state == nil {
 			continue
 		}
 
@@ -313,6 +357,148 @@ func (o *Oracle) handleTransaction(
 	return nil
 }
 
+func (o *Oracle) handleProducedCDPOutput(
+	logger *slog.Logger,
+	parser CDPParser,
+	network string,
+	blockHash string,
+	ctx event.TransactionContext,
+	utxo ledger.Utxo,
+) {
+	now := time.Now()
+	datum := utxo.Output.Datum()
+	if datum == nil {
+		logger.Debug(
+			"skipping produced CDP output without datum",
+			"txHash", ctx.TransactionHash,
+			"outputIndex", utxo.Id.Index(),
+		)
+		return
+	}
+
+	state, err := parser.ParseCDPDatum(
+		datum.Cbor(),
+		ctx.TransactionHash,
+		utxo.Id.Index(),
+		ctx.SlotNumber,
+		now,
+	)
+	if err != nil || state == nil {
+		return
+	}
+
+	state.Network = network
+	state.Protocol = parser.Protocol()
+	state.BlockHash = blockHash
+	state.UpdatedAt = now
+
+	o.cdpsMu.Lock()
+	if o.cdps == nil {
+		o.cdps = make(map[string]*CDPState)
+	}
+	o.cdps[state.CDPId] = state
+	o.cdpsMu.Unlock()
+
+	if err := o.storage.SaveCDPState(state); err != nil {
+		logger.Error(
+			"failed to persist CDP state",
+			"error", err,
+			"cdpId", state.CDPId,
+		)
+	}
+
+	logger.Debug(
+		"CDP state updated",
+		"cdpId", state.CDPId,
+		"protocol", state.Protocol,
+		"slot", state.Slot,
+	)
+}
+
+func (o *Oracle) deleteSpentCDPStates(
+	logger *slog.Logger,
+	parser CDPParser,
+	inputs []ledger.TransactionInput,
+) {
+	for _, input := range inputs {
+		cdpId := parser.CDPIdForOutput(input.Id().String(), input.Index())
+		state, ok := o.deleteCDPStateByID(cdpId)
+		if !ok {
+			continue
+		}
+		network := state.Network
+		if network == "" {
+			network = config.GetConfig().Network
+		}
+		protocol := state.Protocol
+		if protocol == "" {
+			protocol = parser.Protocol()
+		}
+		if err := o.storage.DeleteCDPState(
+			network,
+			protocol,
+			cdpId,
+		); err != nil {
+			logger.Error(
+				"failed to delete spent CDP state",
+				"error", err,
+				"cdpId", cdpId,
+			)
+			continue
+		}
+		logger.Debug(
+			"deleted spent CDP state",
+			"cdpId", cdpId,
+			"protocol", parser.Protocol(),
+		)
+	}
+}
+
+func (o *Oracle) deleteCDPStateByID(cdpId string) (*CDPState, bool) {
+	o.cdpsMu.Lock()
+	defer o.cdpsMu.Unlock()
+	if o.cdps == nil {
+		return nil, false
+	}
+	state, ok := o.cdps[cdpId]
+	if !ok {
+		return nil, false
+	}
+	delete(o.cdps, cdpId)
+	return state, true
+}
+
+func (o *Oracle) isSyntheticsProfile() bool {
+	return o.profile != nil && o.profile.Type == config.ProfileTypeSynthetics
+}
+
+func transactionInputs(txEvt event.TransactionEvent) []ledger.TransactionInput {
+	if len(txEvt.Inputs) > 0 {
+		return txEvt.Inputs
+	}
+	if txEvt.Transaction == nil {
+		return nil
+	}
+	return txEvt.Transaction.Consumed()
+}
+
+func producedUTXOs(
+	txEvt event.TransactionEvent,
+	txHash string,
+) []ledger.Utxo {
+	if txEvt.Transaction != nil {
+		return txEvt.Transaction.Produced()
+	}
+	utxos := make([]ledger.Utxo, 0, len(txEvt.Outputs))
+	for i, output := range txEvt.Outputs {
+		utxos = append(utxos, ledger.Utxo{
+			Id:     shelley.NewShelleyTransactionInput(txHash, i),
+			Output: output,
+		})
+	}
+	return utxos
+}
+
 // handleRollback processes a rollback event by invalidating pool states
 // that were recorded at or after the rollback slot
 func (o *Oracle) handleRollback(evt event.RollbackEvent) error {
@@ -337,6 +523,18 @@ func (o *Oracle) handleRollback(evt event.RollbackEvent) error {
 		delete(o.pools, state.PoolId)
 	}
 	o.poolsMu.Unlock()
+
+	o.cdpsMu.Lock()
+	var cdpsToDelete []*CDPState
+	for _, state := range o.cdps {
+		if state.Slot >= evt.SlotNumber {
+			cdpsToDelete = append(cdpsToDelete, state)
+		}
+	}
+	for _, state := range cdpsToDelete {
+		delete(o.cdps, state.CDPId)
+	}
+	o.cdpsMu.Unlock()
 
 	// Invalidate mempool tracking for rolled-back pools. Otherwise the reorged
 	// confirmed state stays visible to consumers and seeds future pending-tx
@@ -365,10 +563,32 @@ func (o *Oracle) handleRollback(evt event.RollbackEvent) error {
 			)
 		}
 	}
+	for _, state := range cdpsToDelete {
+		if err := o.storage.DeleteCDPState(
+			state.Network,
+			state.Protocol,
+			state.CDPId,
+		); err != nil {
+			logger.Error(
+				"failed to delete rolled-back CDP state",
+				"error", err,
+				"cdpId", state.CDPId,
+				"slot", state.Slot,
+			)
+			errs = append(errs, err)
+		} else {
+			logger.Info(
+				"invalidated CDP state due to rollback",
+				"cdpId", state.CDPId,
+				"slot", state.Slot,
+				"rollbackSlot", evt.SlotNumber,
+			)
+		}
+	}
 
 	if len(errs) > 0 {
 		return fmt.Errorf(
-			"failed to delete %d pool states during rollback",
+			"failed to delete %d oracle states during rollback",
 			len(errs),
 		)
 	}
@@ -382,18 +602,34 @@ func (o *Oracle) isPoolAddress(addr string) bool {
 	return ok
 }
 
-// loadPersistedStates loads pool states from storage
+// loadPersistedStates loads oracle states from storage.
 func (o *Oracle) loadPersistedStates() error {
 	states, err := o.storage.LoadAllPoolStates()
 	if err != nil {
 		return err
 	}
+	cdpStates, err := o.storage.LoadAllCDPStates()
+	if err != nil {
+		return err
+	}
 
 	o.poolsMu.Lock()
+	if o.pools == nil {
+		o.pools = make(map[string]*PoolState)
+	}
 	for _, state := range states {
 		o.pools[state.PoolId] = state
 	}
 	o.poolsMu.Unlock()
+
+	o.cdpsMu.Lock()
+	if o.cdps == nil {
+		o.cdps = make(map[string]*CDPState)
+	}
+	for _, state := range cdpStates {
+		o.cdps[state.CDPId] = state
+	}
+	o.cdpsMu.Unlock()
 
 	if o.mempoolMgr == nil {
 		o.mempoolMgr = NewMempoolStateManager()
@@ -403,7 +639,11 @@ func (o *Oracle) loadPersistedStates() error {
 	}
 
 	logger := logging.GetLogger()
-	logger.Info("loaded persisted pool states", "count", len(states))
+	logger.Info(
+		"loaded persisted oracle states",
+		"pools", len(states),
+		"cdps", len(cdpStates),
+	)
 
 	return nil
 }
@@ -427,6 +667,34 @@ func (o *Oracle) GetAllPools() []*PoolState {
 		pools = append(pools, state)
 	}
 	return pools
+}
+
+// GetCDPState returns the current state of a CDP.
+func (o *Oracle) GetCDPState(cdpId string) (*CDPState, bool) {
+	o.cdpsMu.RLock()
+	defer o.cdpsMu.RUnlock()
+
+	state, ok := o.cdps[cdpId]
+	return state, ok
+}
+
+// GetAllCDPs returns all tracked CDP states.
+func (o *Oracle) GetAllCDPs() []*CDPState {
+	o.cdpsMu.RLock()
+	defer o.cdpsMu.RUnlock()
+
+	cdps := make([]*CDPState, 0, len(o.cdps))
+	for _, state := range o.cdps {
+		cdps = append(cdps, state)
+	}
+	return cdps
+}
+
+// CDPCount returns the number of tracked CDPs.
+func (o *Oracle) CDPCount() int {
+	o.cdpsMu.RLock()
+	defer o.cdpsMu.RUnlock()
+	return len(o.cdps)
 }
 
 // PoolCount returns the number of tracked pools

--- a/internal/oracle/oracle_test.go
+++ b/internal/oracle/oracle_test.go
@@ -20,8 +20,37 @@ import (
 	"time"
 
 	"github.com/blinklabs-io/adder/event"
+
 	"github.com/blinklabs-io/shai/common"
+	"github.com/blinklabs-io/shai/internal/config"
 )
+
+func TestOracleNewUsesSyntheticsCDPAddresses(t *testing.T) {
+	cdpAddress := IndigoCDPContractAddress
+	stabilityPoolAddress := "addr1w80ptp0qgmcklhmeweesqgeurtlma8fsxsr9dt8au30fzss0czhl9"
+	profile := config.Profile{
+		Name: "indigo",
+		Type: config.ProfileTypeSynthetics,
+		Config: config.SyntheticsProfileConfig{
+			Protocol: "indigo",
+			CDPAddresses: []config.ProfileConfigAddress{
+				{Address: cdpAddress},
+				{Address: stabilityPoolAddress},
+			},
+		},
+	}
+
+	o := New(nil, &profile, NewIndigoParser())
+	if !o.isPoolAddress(cdpAddress) {
+		t.Fatalf("expected CDP address to be monitored")
+	}
+	if !o.isPoolAddress(stabilityPoolAddress) {
+		t.Fatalf("expected stability pool address to be monitored")
+	}
+	if o.isPoolAddress("addr1unmonitored") {
+		t.Fatalf("expected unrelated address not to be monitored")
+	}
+}
 
 func TestOracleRollbackClearsMempoolState(t *testing.T) {
 	o := &Oracle{

--- a/internal/oracle/storage.go
+++ b/internal/oracle/storage.go
@@ -25,7 +25,10 @@ import (
 	"github.com/dgraph-io/badger/v4"
 )
 
-const poolStateKeyPrefix = "oracle_pool_"
+const (
+	poolStateKeyPrefix = "oracle_pool_"
+	cdpStateKeyPrefix  = "oracle_cdp_"
+)
 
 // OracleStorage handles persistence of oracle data
 type OracleStorage struct {
@@ -109,6 +112,90 @@ func (s *OracleStorage) LoadAllPoolStates() ([]*PoolState, error) {
 	}
 
 	return states, nil
+}
+
+// SaveCDPState persists a CDP state to storage.
+func (s *OracleStorage) SaveCDPState(state *CDPState) error {
+	key := cdpStateKey(state.Network, state.Protocol, state.CDPId)
+
+	data, err := json.Marshal(state)
+	if err != nil {
+		return fmt.Errorf("failed to marshal CDP state: %w", err)
+	}
+
+	err = s.db.Update(func(txn *badger.Txn) error {
+		return txn.Set([]byte(key), data)
+	})
+	if err != nil {
+		return fmt.Errorf("failed to save CDP state: %w", err)
+	}
+
+	return nil
+}
+
+// LoadAllCDPStates loads all CDP states from storage.
+func (s *OracleStorage) LoadAllCDPStates() ([]*CDPState, error) {
+	logger := logging.GetLogger()
+	var states []*CDPState
+
+	err := s.db.View(func(txn *badger.Txn) error {
+		opts := badger.DefaultIteratorOptions
+		opts.Prefix = []byte(cdpStateKeyPrefix)
+		it := txn.NewIterator(opts)
+		defer it.Close()
+
+		for it.Rewind(); it.Valid(); it.Next() {
+			item := it.Item()
+			err := item.Value(func(val []byte) error {
+				var state CDPState
+				if err := json.Unmarshal(val, &state); err != nil {
+					logger.Warn(
+						"failed to unmarshal CDP state",
+						"key", string(item.Key()),
+						"error", err,
+					)
+					return nil
+				}
+				states = append(states, &state)
+				return nil
+			})
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to load CDP states: %w", err)
+	}
+
+	return states, nil
+}
+
+// LoadCDPState loads a single CDP state by network, protocol, and CDP ID.
+func (s *OracleStorage) LoadCDPState(
+	network,
+	protocol,
+	cdpId string,
+) (*CDPState, error) {
+	key := cdpStateKey(network, protocol, cdpId)
+
+	var state *CDPState
+	err := s.db.View(func(txn *badger.Txn) error {
+		item, err := txn.Get([]byte(key))
+		if err != nil {
+			return err
+		}
+		return item.Value(func(val []byte) error {
+			state = &CDPState{}
+			return json.Unmarshal(val, state)
+		})
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to load CDP state: %w", err)
+	}
+
+	return state, nil
 }
 
 // LoadPoolState loads a single pool state by network, protocol, and pool ID.
@@ -202,9 +289,32 @@ func (s *OracleStorage) DeletePoolState(state *PoolState) error {
 	return nil
 }
 
+// DeleteCDPState removes a CDP state from storage.
+func (s *OracleStorage) DeleteCDPState(
+	network,
+	protocol,
+	cdpId string,
+) error {
+	key := cdpStateKey(network, protocol, cdpId)
+
+	err := s.db.Update(func(txn *badger.Txn) error {
+		return txn.Delete([]byte(key))
+	})
+	if err != nil {
+		return fmt.Errorf("failed to delete CDP state: %w", err)
+	}
+
+	return nil
+}
+
 // poolStateKey generates the storage key for a pool state
 func poolStateKey(network, protocol, poolId string) string {
 	return poolStateKeyPrefix + network + ":" + protocol + ":" + poolId
+}
+
+// cdpStateKey generates the storage key for a CDP state.
+func cdpStateKey(network, protocol, cdpId string) string {
+	return cdpStateKeyPrefix + network + ":" + protocol + ":" + cdpId
 }
 
 // ParsePoolStateKey extracts network, protocol, and poolId from a pool key.
@@ -219,6 +329,22 @@ func ParsePoolStateKey(key string) (network, protocol, poolId string, err error)
 	}
 	if parts[0] == "" || parts[1] == "" || parts[2] == "" {
 		return "", "", "", fmt.Errorf("invalid pool state key: %s", key)
+	}
+	return parts[0], parts[1], parts[2], nil
+}
+
+// ParseCDPStateKey extracts network, protocol, and cdpId from a CDP key.
+func ParseCDPStateKey(key string) (network, protocol, cdpId string, err error) {
+	if !strings.HasPrefix(key, cdpStateKeyPrefix) {
+		return "", "", "", fmt.Errorf("invalid CDP state key: %s", key)
+	}
+	trimmed := strings.TrimPrefix(key, cdpStateKeyPrefix)
+	parts := strings.SplitN(trimmed, ":", 3)
+	if len(parts) != 3 {
+		return "", "", "", fmt.Errorf("invalid CDP state key: %s", key)
+	}
+	if parts[0] == "" || parts[1] == "" || parts[2] == "" {
+		return "", "", "", fmt.Errorf("invalid CDP state key: %s", key)
 	}
 	return parts[0], parts[1], parts[2], nil
 }


### PR DESCRIPTION
Closes #314 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracts and integrates the Indigo synthetics CDP parser under `internal/oracle/indigo`, adds an `indigo` synthetics profile, and unifies startup to track Indigo CDPs end-to-end with persistence, rollback, and API access (targets issue-314).

- **New Features**
  - Added Indigo CDP CBOR models and parser in `internal/oracle/indigo`; `internal/oracle/indigo.go` wraps it, exposes `NewIndigoParser()`, re-exports types/constants, and returns `nil` for AMM pool parsing.
  - Introduced `ProfileTypeSynthetics` and `SyntheticsProfileConfig`; added an `indigo` profile with CDP/Stability Pool addresses; `cmd/shai` now uses `startOracleProfile()` and `getSyntheticsParser("indigo")` to run synthetics alongside oracles.
  - Exposed `GET /api/v1/cdps` and `GET /api/v1/cdps/{cdpId}` (supports `protocol` filter); CDP states are parsed, saved/loaded at startup, deleted on spend, and invalidated on rollbacks.

- **Bug Fixes**
  - Removed stale CDP records when inputs spend previous CDP UTxOs to prevent ghost positions.
  - Robust transaction handling when events lack full `Transaction` data by reconstructing inputs/outputs, ensuring CDP updates and deletions apply correctly.

<sup>Written for commit be513e87c864350803b4cb9d536be8f77e089eab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/shai/pull/336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking Indigo synthetics/CDP data alongside existing oracle data.
  * Exposed new API endpoints to list CDPs and fetch a CDP by ID.
  * Added support for filtering CDPs by protocol and asset name.

* **Bug Fixes**
  * Improved handling of unknown or unsupported protocol profiles.
  * Made rollback and state loading cover both pool and CDP records.

* **Chores**
  * Expanded automated test coverage for CDP parsing, storage, and API behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->