### PR TITLE
feat: use reuseable workflows from blinklabs-io/actions

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -1,33 +1,18 @@
-name: Docker CI
+# Generated automatically by org-governance-bot. Do not edit manually.
+name: "Docker CI"
 
 on:
   pull_request:
-    branches: ['main']
-    paths: ['Dockerfile','*.go','go.*','.github/workflows/ci-docker.yml']
-
-permissions:
-  contents: read
-
-env:
-  GHCR_IMAGE_NAME: ghcr.io/blinklabs-io/shai
+    branches:
+      - main
+    paths:
+      - Dockerfile
+      - '*.go'
+      - go.*
+      - .github/workflows/ci-docker.yml
 
 jobs:
-  docker:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: qemu
-        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
-      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
-      - id: meta
-        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
-        with:
-          images: ${{ env.GHCR_IMAGE_NAME }}
-      - name: build
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
-        with:
-          context: .
-          push: false
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+  orchestrate:
+    uses: blinklabs-io/actions/.github/workflows/reuseable-ci-docker.yml@main
+    with:
+      image-name: blinklabs-io/shai

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,20 +1,9 @@
-# The below is pulled from upstream and slightly modified
-# https://github.com/webiny/action-conventional-commits/blob/master/README.md#usage
-
-name: Conventional Commits
+# Generated automatically by org-governance-bot. Do not edit manually.
+name: "Conventional Commits"
 
 on:
   pull_request:
 
-permissions: {}
-
 jobs:
-  build:
-    name: Conventional Commits
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: webiny/action-conventional-commits@7f91b1595ca1951cdb671ddc9f07a49081ec5b69 # v1.4.2
+  orchestrate:
+    uses: blinklabs-io/actions/.github/workflows/reuseable-conventional-commits.yml@main

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -1,27 +1,16 @@
-name: go-test
+# Generated automatically by org-governance-bot. Do not edit manually.
+name: "go-test"
 
 on:
+  pull_request:
   push:
-    tags:
-      - v*
     branches:
       - main
-  pull_request:
-
-permissions:
-  contents: read
+    tags:
+      - v*
 
 jobs:
-  go-test:
-    name: go-test
-    strategy:
-      matrix:
-        go-version: [1.26.x]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version: ${{ matrix.go-version }}
-      - name: go-test
-        run: go test ./...
+  orchestrate:
+    uses: blinklabs-io/actions/.github/workflows/reuseable-go-test.yml@main
+    with:
+      go-versions: '["1.26.x"]'

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,26 +1,16 @@
-name: golangci-lint
+# Generated automatically by org-governance-bot. Do not edit manually.
+name: "golangci-lint"
+
 on:
+  pull_request:
   push:
-    tags:
-      - v*
     branches:
       - main
-  pull_request:
-
-permissions:
-  contents: read
-  pull-requests: read
+    tags:
+      - v*
 
 jobs:
-  golangci:
-    name: lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version: 1.26.x
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
-        with:
-          only-new-issues: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
+  orchestrate:
+    uses: blinklabs-io/actions/.github/workflows/reuseable-golangci-lint.yml@main
+    with:
+      go-version: "1.26.x"

--- a/.github/workflows/nilaway.yml
+++ b/.github/workflows/nilaway.yml
@@ -1,25 +1,17 @@
-name: nilaway
+# Generated automatically by org-governance-bot. Do not edit manually.
+name: "nilaway"
+
 on:
+  pull_request:
   push:
-    tags:
-      - v*
     branches:
       - main
-  pull_request:
-
-permissions:
-  contents: read
+    tags:
+      - v*
 
 jobs:
-  nilaway:
-    name: nilaway
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version: 1.26.x
-      - name: install nilaway
-        run: go install go.uber.org/nilaway/cmd/nilaway@latest
-      - name: run nilaway
-        run: nilaway -include-pkgs=github.com/blinklabs-io/shai ./...
+  orchestrate:
+    uses: blinklabs-io/actions/.github/workflows/reuseable-nilaway.yml@main
+    with:
+      include-pkgs: github.com/blinklabs-io/shai
+      go-version: "1.26.x"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,133 +1,26 @@
-name: publish
+# Generated automatically by org-governance-bot. Do not edit manually.
+name: "publish"
 
 on:
   push:
-    branches: ['main']
+    branches:
+      - main
     tags:
-      - 'v*.*.*'
+      - v*.*.*
 
-concurrency: ${{ github.ref }}
-
-permissions: {}
+permissions:
+  actions: write
+  attestations: write
+  checks: write
+  contents: write
+  id-token: write
+  packages: write
+  statuses: write
 
 jobs:
-  create-draft-release:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    outputs:
-      RELEASE_ID: ${{ steps.create-release.outputs.result }}
-    steps:
-      - run: "echo \"RELEASE_TAG=${GITHUB_REF#refs/tags/}\" >> $GITHUB_ENV"
-      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        id: create-release
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          result-encoding: string
-          script: |
-            try {
-              const response = await github.rest.repos.createRelease({
-                draft: true,
-                generate_release_notes: true,
-                name: process.env.RELEASE_TAG,
-                owner: context.repo.owner,
-                prerelease: false,
-                repo: context.repo.repo,
-                tag_name: process.env.RELEASE_TAG,
-              });
-
-              return response.data.id;
-            } catch (error) {
-              core.setFailed(error.message);
-            }
-
-  build-binaries:
-    strategy:
-      matrix:
-        os: [linux]
-        arch: [amd64, arm64]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    needs: [create-draft-release]
-    steps:
-      - run: "echo \"RELEASE_TAG=${GITHUB_REF#refs/tags/}\" >> $GITHUB_ENV"
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version: 1.26.x
-      - name: Build binary
-        run: GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} make build
-      - name: Upload release asset
-        if: startsWith(github.ref, 'refs/tags/')
-        run: |
-          _filename=shai-${{ env.RELEASE_TAG }}-${{ matrix.os }}-${{ matrix.arch }}
-          if [[ ${{ matrix.os }} == windows ]]; then
-            _filename=${_filename}.exe
-          fi
-          mv shai ${_filename}
-          curl \
-            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            -H "Content-Type: application/octet-stream" \
-            --data-binary @${_filename} \
-            https://uploads.github.com/repos/${{ github.repository_owner }}/shai/releases/${{ needs.create-draft-release.outputs.RELEASE_ID }}/assets?name=${_filename}
-
-  build-images:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    needs: [create-draft-release]
-    steps:
-      - run: "echo \"RELEASE_TAG=${GITHUB_REF#refs/tags/}\" >> $GITHUB_ENV"
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
-      - name: Login to GHCR
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        with:
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-          registry: ghcr.io
-      - id: meta
-        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
-        with:
-          images: |
-            ghcr.io/${{ github.repository }}
-          tags: |
-            # branch
-            type=ref,event=branch
-            # semver
-            type=semver,pattern={{version}}
-      - name: Build images
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
-        with:
-          outputs: "type=registry,push=true"
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-
-  finalize-release:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    needs: [create-draft-release, build-binaries, build-images]
-    steps:
-      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            try {
-              await github.rest.repos.updateRelease({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                release_id: ${{ needs.create-draft-release.outputs.RELEASE_ID }},
-                draft: false,
-              });
-            } catch (error) {
-              core.setFailed(error.message);
-            }
+  orchestrate:
+    uses: blinklabs-io/actions/.github/workflows/reuseable-publish.yml@main
+    with:
+      binary-name: shai
+      go-version: "1.26.x"
+      binary-os-matrix: '["linux"]'

--- a/.github/workflows/test-issue-on-close.yml
+++ b/.github/workflows/test-issue-on-close.yml
@@ -1,23 +1,14 @@
-name: Test Issue Close Trigger
-permissions:
-  contents: read
+# Generated automatically by org-governance-bot. Do not edit manually.
+name: "Test Issue Close Trigger"
+
 on:
   issues:
-    types: [closed]
+    types:
+      - closed
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Print closed issue info
-        env:
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
-          ISSUE_TITLE: ${{ github.event.issue.title }}
-        run: |
-          echo "Issue Number: $ISSUE_NUMBER"
-          # Prevent workflow command injection from untrusted issue titles
-          TOKEN=$(uuidgen)
-          echo "::stop-commands::${TOKEN}"
-          echo "Title: $ISSUE_TITLE"
-          echo "::${TOKEN}::"
-          echo "Workflow triggered successfully when issue was closed."
+  orchestrate:
+    uses: blinklabs-io/actions/.github/workflows/reuseable-test-issue-on-close.yml@main
+    with:
+      issue_number: ${{ github.event.issue.number }}
+      issue_title: ${{ github.event.issue.title }}

--- a/.github/workflows/update-issue-on-close.yml
+++ b/.github/workflows/update-issue-on-close.yml
@@ -1,39 +1,18 @@
-name: Set Project Closed Date
+# Generated automatically by org-governance-bot. Do not edit manually.
+name: "Set Project Closed Date"
 
 on:
   issues:
-    types: [closed]
-
-permissions:
-  contents: read
-  issues: read
-
-env:
-  PROJECT_URL: https://github.com/orgs/blinklabs-io/projects/11
-  CLOSED_DATE_FIELD: "Closed Date"
+    types:
+      - closed
+  workflow_dispatch:
 
 jobs:
-  set-date:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Resolve closed date
-        id: when
-        shell: bash
-        run: |
-          ts='${{ github.event.issue.closed_at }}'
-          if [ -z "$ts" ] || [ "$ts" = "null" ]; then
-            echo "Error: closed_at timestamp is missing or null. Refusing to set an incorrect closed date." >&2
-            exit 1
-          fi
-          d=$(date -u -d "$ts" +%F)
-          echo "date=$d" >> "$GITHUB_OUTPUT"
-          echo "Closed date -> $d"
-
-      # Update the "Closed Date" field on that project item
-      - name: Update Closed Date field
-        uses: nipe0324/update-project-v2-item-field@c4af58452d1c5a788c1ea4f20e073fa722ec4a6b
-        with:
-          project-url: ${{ env.PROJECT_URL }}
-          github-token: ${{ secrets.ORG_PROJECT_PAT }}
-          field-name: ${{ env.CLOSED_DATE_FIELD }}
-          field-value: ${{ steps.when.outputs.date }}
+  orchestrate:
+    uses: blinklabs-io/actions/.github/workflows/reuseable-set-project-closed-date.yml@main
+    secrets:
+      project_pat: ${{ secrets.ORG_PROJECT_PAT }}
+    with:
+      project_url: https://github.com/orgs/blinklabs-io/projects/11
+      closed_date_field: Closed Date
+      closed_at: ${{ github.event.issue.closed_at }}


### PR DESCRIPTION
Closes: #351 

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch CI/CD to reusable workflows from `blinklabs-io/actions` to standardize pipelines and reduce maintenance. Behavior remains the same for tests, linting, Docker builds, releases, and project automation.

- **Refactors**
  - `ci-docker` -> `reuseable-ci-docker.yml` (image-name: `blinklabs-io/shai`)
  - `conventional-commits` -> `reuseable-conventional-commits.yml`
  - `go-test` -> `reuseable-go-test.yml` (go-versions: ["1.26.x"])
  - `golangci-lint` -> `reuseable-golangci-lint.yml` (go-version: "1.26.x")
  - `nilaway` -> `reuseable-nilaway.yml` (include-pkgs: `github.com/blinklabs-io/shai`, go-version: "1.26.x")
  - `publish` -> `reuseable-publish.yml` (binary-name: `shai`, binary-os-matrix: ["linux"]; GHCR-only; explicit permissions for actions/attestations/checks/contents/id-token/packages/statuses)
  - `test-issue-on-close` -> `reuseable-test-issue-on-close.yml` (passes issue number/title)
  - `update-issue-on-close` -> `reuseable-set-project-closed-date.yml` (uses `ORG_PROJECT_PAT`, sets Closed Date on project `https://github.com/orgs/blinklabs-io/projects/11`)

<sup>Written for commit 7e5cac50cae7a951466ec6469c52fea6691414c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/shai/pull/348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

