### PR TITLE
feat: add Strike Finance support

### DIFF
--- a/batch/strike/client.go
+++ b/batch/strike/client.go
@@ -48,10 +48,11 @@ type Client struct {
 type ClientOption func(*clientOptions)
 
 type clientOptions struct {
-	httpClient *http.Client
-	signer     *Ed25519Signer
-	now        func() time.Time
-	nonce      func() (string, error)
+	httpClient                *http.Client
+	signer                    *Ed25519Signer
+	now                       func() time.Time
+	nonce                     func() (string, error)
+	allowInsecureHTTPForTests bool
 }
 
 func WithHTTPClient(httpClient *http.Client) ClientOption {
@@ -75,6 +76,15 @@ func WithClock(now func() time.Time) ClientOption {
 func WithNonce(nonce func() (string, error)) ClientOption {
 	return func(options *clientOptions) {
 		options.nonce = nonce
+	}
+}
+
+// WithInsecureHTTPForTests permits cleartext HTTP endpoints. It is intended
+// only for local test servers; production API credentials must always be sent
+// over HTTPS.
+func WithInsecureHTTPForTests() ClientOption {
+	return func(options *clientOptions) {
+		options.allowInsecureHTTPForTests = true
 	}
 }
 
@@ -115,6 +125,12 @@ func NewClient(config dexstrike.ExternalAPIConfig, opts ...ClientOption) (*Clien
 	if err != nil {
 		return nil, fmt.Errorf("%w: invalid base URL: %w", dexstrike.ErrInvalidExternalAPIConfig, err)
 	}
+	if baseURL.Scheme != "https" && !options.allowInsecureHTTPForTests {
+		return nil, fmt.Errorf(
+			"%w: base URL must use HTTPS",
+			dexstrike.ErrInvalidExternalAPIConfig,
+		)
+	}
 	priceBaseURL := config.PriceBaseURL
 	if priceBaseURL == "" {
 		priceBaseURL = joinURLPath(baseURL, "/price").String()
@@ -125,6 +141,13 @@ func NewClient(config dexstrike.ExternalAPIConfig, opts ...ClientOption) (*Clien
 			"%w: invalid price base URL: %w",
 			dexstrike.ErrInvalidExternalAPIConfig,
 			err,
+		)
+	}
+	if parsedPriceBaseURL.Scheme != "https" &&
+		!options.allowInsecureHTTPForTests {
+		return nil, fmt.Errorf(
+			"%w: price base URL must use HTTPS",
+			dexstrike.ErrInvalidExternalAPIConfig,
 		)
 	}
 	client.baseURL = baseURL
@@ -292,7 +315,21 @@ func (c *Client) doJSON(
 		}
 	}
 
-	resp, err := c.httpClient.Do(req)
+	httpClient := c.httpClient
+	if authenticated {
+		// Do not allow a redirect response to replay an authenticated request,
+		// potentially to another host. Clone the client so public requests keep
+		// the caller's configured redirect behavior.
+		httpClientCopy := *c.httpClient
+		httpClientCopy.CheckRedirect = func(
+			_ *http.Request,
+			_ []*http.Request,
+		) error {
+			return http.ErrUseLastResponse
+		}
+		httpClient = &httpClientCopy
+	}
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return err
 	}

--- a/batch/strike/client.go
+++ b/batch/strike/client.go
@@ -1,0 +1,372 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package strike
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	dexstrike "github.com/blinklabs-io/shai/dex/strike"
+)
+
+const defaultHTTPTimeout = 10 * time.Second
+
+const maxResponseBodySize = 1 << 20
+
+type Client struct {
+	enabled      bool
+	baseURL      *url.URL
+	priceBaseURL *url.URL
+	httpClient   *http.Client
+	signer       *Ed25519Signer
+	now          func() time.Time
+	nonce        func() (string, error)
+}
+
+type ClientOption func(*clientOptions)
+
+type clientOptions struct {
+	httpClient *http.Client
+	signer     *Ed25519Signer
+	now        func() time.Time
+	nonce      func() (string, error)
+}
+
+func WithHTTPClient(httpClient *http.Client) ClientOption {
+	return func(options *clientOptions) {
+		options.httpClient = httpClient
+	}
+}
+
+func WithSigner(signer *Ed25519Signer) ClientOption {
+	return func(options *clientOptions) {
+		options.signer = signer
+	}
+}
+
+func WithClock(now func() time.Time) ClientOption {
+	return func(options *clientOptions) {
+		options.now = now
+	}
+}
+
+func WithNonce(nonce func() (string, error)) ClientOption {
+	return func(options *clientOptions) {
+		options.nonce = nonce
+	}
+}
+
+func NewClient(config dexstrike.ExternalAPIConfig, opts ...ClientOption) (*Client, error) {
+	options := clientOptions{
+		httpClient: &http.Client{Timeout: defaultHTTPTimeout},
+		now:        time.Now,
+		nonce:      randomNonce,
+	}
+	for _, opt := range opts {
+		opt(&options)
+	}
+	if options.httpClient == nil {
+		return nil, fmt.Errorf("%w: HTTP client is nil", dexstrike.ErrInvalidExternalAPIConfig)
+	}
+	if options.now == nil {
+		return nil, fmt.Errorf("%w: clock is nil", dexstrike.ErrInvalidExternalAPIConfig)
+	}
+	if options.nonce == nil {
+		return nil, fmt.Errorf("%w: nonce generator is nil", dexstrike.ErrInvalidExternalAPIConfig)
+	}
+
+	client := &Client{
+		enabled:    config.Enabled,
+		httpClient: options.httpClient,
+		signer:     options.signer,
+		now:        options.now,
+		nonce:      options.nonce,
+	}
+	if !config.Enabled {
+		return client, nil
+	}
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+
+	baseURL, err := dexstrike.ParseBaseURL(config.BaseURL)
+	if err != nil {
+		return nil, fmt.Errorf("%w: invalid base URL: %w", dexstrike.ErrInvalidExternalAPIConfig, err)
+	}
+	priceBaseURL := config.PriceBaseURL
+	if priceBaseURL == "" {
+		priceBaseURL = joinURLPath(baseURL, "/price").String()
+	}
+	parsedPriceBaseURL, err := dexstrike.ParseBaseURL(priceBaseURL)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"%w: invalid price base URL: %w",
+			dexstrike.ErrInvalidExternalAPIConfig,
+			err,
+		)
+	}
+	client.baseURL = baseURL
+	client.priceBaseURL = parsedPriceBaseURL
+	return client, nil
+}
+
+func (c *Client) Enabled() bool {
+	return c != nil && c.enabled
+}
+
+func (c *Client) Ping(ctx context.Context) error {
+	return c.doJSON(ctx, c.baseURL, http.MethodGet, "/v2/ping", nil, nil, nil, false)
+}
+
+type ServerTime struct {
+	ServerTime int64 `json:"serverTime,omitempty"`
+	Time       int64 `json:"time,omitempty"`
+	Timestamp  int64 `json:"timestamp,omitempty"`
+}
+
+func (t ServerTime) UnixMilliseconds() int64 {
+	switch {
+	case t.ServerTime != 0:
+		return t.ServerTime
+	case t.Timestamp != 0:
+		return t.Timestamp
+	default:
+		return t.Time
+	}
+}
+
+func (c *Client) ServerTime(ctx context.Context) (*ServerTime, error) {
+	var serverTime ServerTime
+	if err := c.doJSON(
+		ctx,
+		c.baseURL,
+		http.MethodGet,
+		"/v2/time",
+		nil,
+		nil,
+		&serverTime,
+		false,
+	); err != nil {
+		return nil, err
+	}
+	return &serverTime, nil
+}
+
+type MarkPrice struct {
+	EventType            string `json:"e,omitempty"`
+	EventTime            int64  `json:"E,omitempty"`
+	Symbol               string `json:"s,omitempty"`
+	MarkPrice            string `json:"p,omitempty"`
+	IndexPrice           string `json:"i,omitempty"`
+	EstimatedSettlePrice string `json:"P,omitempty"`
+	FundingRate          string `json:"r,omitempty"`
+	NextFundingTime      int64  `json:"T,omitempty"`
+}
+
+func (p MarkPrice) PriceString() string {
+	return p.MarkPrice
+}
+
+func (c *Client) MarkPrice(
+	ctx context.Context,
+	symbol string,
+) (*MarkPrice, error) {
+	symbol = strings.ToUpper(strings.TrimSpace(symbol))
+	if symbol == "" {
+		return nil, fmt.Errorf("%w: symbol is required", dexstrike.ErrInvalidExternalAPIConfig)
+	}
+	query := url.Values{}
+	query.Set("symbol", symbol)
+
+	var price MarkPrice
+	if err := c.doJSON(
+		ctx,
+		c.priceBaseURL,
+		http.MethodGet,
+		"/v2/markPrice",
+		query,
+		nil,
+		&price,
+		false,
+	); err != nil {
+		return nil, err
+	}
+	return &price, nil
+}
+
+func (c *Client) DoAuthenticated(
+	ctx context.Context,
+	method string,
+	path string,
+	query url.Values,
+	body any,
+	out any,
+) error {
+	return c.doJSON(ctx, c.baseURL, method, path, query, body, out, true)
+}
+
+type APIError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *APIError) Error() string {
+	return fmt.Sprintf("%s: status %d: %s", dexstrike.ErrAPIRequestFailed, e.StatusCode, e.Body)
+}
+
+func (e *APIError) Is(target error) bool {
+	return target == dexstrike.ErrAPIRequestFailed
+}
+
+func (c *Client) doJSON(
+	ctx context.Context,
+	baseURL *url.URL,
+	method string,
+	path string,
+	query url.Values,
+	body any,
+	out any,
+	authenticated bool,
+) error {
+	if c == nil || !c.enabled {
+		return dexstrike.ErrExternalAPIDisabled
+	}
+	if baseURL == nil {
+		return fmt.Errorf("%w: base URL is nil", dexstrike.ErrInvalidExternalAPIConfig)
+	}
+
+	var bodyBytes []byte
+	if body != nil {
+		var err error
+		bodyBytes, err = json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("marshal Strike request body: %w", err)
+		}
+	}
+
+	reqURL := joinURLPath(baseURL, path)
+	reqURL.RawQuery = query.Encode()
+
+	var bodyReader io.Reader
+	if bodyBytes != nil {
+		bodyReader = bytes.NewReader(bodyBytes)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, reqURL.String(), bodyReader)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "application/json")
+	if bodyBytes != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if authenticated {
+		timestamp := strconv.FormatInt(c.now().Unix(), 10)
+		nonce, err := c.nonce()
+		if err != nil {
+			return err
+		}
+		if err := c.signer.SignRequest(req, bodyBytes, timestamp, nonce); err != nil {
+			return err
+		}
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBodySize+1))
+	if err != nil {
+		return err
+	}
+	if len(respBody) > maxResponseBodySize {
+		return fmt.Errorf(
+			"strike API response exceeds %d bytes",
+			maxResponseBodySize,
+		)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return &APIError{
+			StatusCode: resp.StatusCode,
+			Body:       strings.TrimSpace(string(respBody)),
+		}
+	}
+	if out == nil || len(bytes.TrimSpace(respBody)) == 0 {
+		return nil
+	}
+	return decodeJSONEnvelope(respBody, out)
+}
+
+func joinURLPath(baseURL *url.URL, path string) *url.URL {
+	ret := *baseURL
+	basePath := strings.TrimRight(ret.Path, "/")
+	nextPath := strings.TrimLeft(path, "/")
+	if basePath == "" {
+		ret.Path = "/" + nextPath
+	} else if nextPath == "" {
+		ret.Path = basePath
+	} else {
+		ret.Path = basePath + "/" + nextPath
+	}
+	return &ret
+}
+
+func decodeJSONEnvelope(body []byte, out any) error {
+	var envelope struct {
+		Data   json.RawMessage `json:"data"`
+		Result json.RawMessage `json:"result"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return err
+	}
+	switch {
+	case len(bytes.TrimSpace(envelope.Data)) > 0 &&
+		string(bytes.TrimSpace(envelope.Data)) != "null":
+		return json.Unmarshal(envelope.Data, out)
+	case len(bytes.TrimSpace(envelope.Result)) > 0 &&
+		string(bytes.TrimSpace(envelope.Result)) != "null":
+		return json.Unmarshal(envelope.Result, out)
+	default:
+		return json.Unmarshal(body, out)
+	}
+}
+
+func randomNonce() (string, error) {
+	var nonce [16]byte
+	if _, err := rand.Read(nonce[:]); err != nil {
+		return "", err
+	}
+	nonce[6] = (nonce[6] & 0x0f) | 0x40
+	nonce[8] = (nonce[8] & 0x3f) | 0x80
+	encoded := hex.EncodeToString(nonce[:])
+	return encoded[0:8] + "-" +
+		encoded[8:12] + "-" +
+		encoded[12:16] + "-" +
+		encoded[16:20] + "-" +
+		encoded[20:32], nil
+}

--- a/batch/strike/client.go
+++ b/batch/strike/client.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -79,9 +80,9 @@ func WithNonce(nonce func() (string, error)) ClientOption {
 	}
 }
 
-// WithInsecureHTTPForTests permits cleartext HTTP endpoints. It is intended
-// only for local test servers; production API credentials must always be sent
-// over HTTPS.
+// WithInsecureHTTPForTests permits cleartext HTTP endpoints on loopback hosts.
+// It is intended only for local test servers; production API credentials must
+// always be sent over HTTPS.
 func WithInsecureHTTPForTests() ClientOption {
 	return func(options *clientOptions) {
 		options.allowInsecureHTTPForTests = true
@@ -125,9 +126,9 @@ func NewClient(config dexstrike.ExternalAPIConfig, opts ...ClientOption) (*Clien
 	if err != nil {
 		return nil, fmt.Errorf("%w: invalid base URL: %w", dexstrike.ErrInvalidExternalAPIConfig, err)
 	}
-	if baseURL.Scheme != "https" && !options.allowInsecureHTTPForTests {
+	if !isAllowedEndpoint(baseURL, options.allowInsecureHTTPForTests) {
 		return nil, fmt.Errorf(
-			"%w: base URL must use HTTPS",
+			"%w: base URL must use HTTPS or loopback HTTP for tests",
 			dexstrike.ErrInvalidExternalAPIConfig,
 		)
 	}
@@ -143,16 +144,30 @@ func NewClient(config dexstrike.ExternalAPIConfig, opts ...ClientOption) (*Clien
 			err,
 		)
 	}
-	if parsedPriceBaseURL.Scheme != "https" &&
-		!options.allowInsecureHTTPForTests {
+	if !isAllowedEndpoint(
+		parsedPriceBaseURL,
+		options.allowInsecureHTTPForTests,
+	) {
 		return nil, fmt.Errorf(
-			"%w: price base URL must use HTTPS",
+			"%w: price base URL must use HTTPS or loopback HTTP for tests",
 			dexstrike.ErrInvalidExternalAPIConfig,
 		)
 	}
 	client.baseURL = baseURL
 	client.priceBaseURL = parsedPriceBaseURL
 	return client, nil
+}
+
+func isAllowedEndpoint(endpoint *url.URL, allowLoopbackHTTP bool) bool {
+	if endpoint.Scheme == "https" {
+		return true
+	}
+	if !allowLoopbackHTTP || endpoint.Scheme != "http" {
+		return false
+	}
+	hostname := endpoint.Hostname()
+	return strings.EqualFold(hostname, "localhost") ||
+		net.ParseIP(hostname).IsLoopback()
 }
 
 func (c *Client) Enabled() bool {

--- a/batch/strike/client_test.go
+++ b/batch/strike/client_test.go
@@ -200,6 +200,7 @@ func TestClientAuthenticatedRequestSignsHeaders(t *testing.T) {
 	client, err := NewClient(
 		config,
 		WithSigner(signer),
+		WithInsecureHTTPForTests(),
 		WithClock(func() time.Time {
 			return time.UnixMilli(1700000000123)
 		}),
@@ -342,6 +343,95 @@ func TestExternalAPIConfigValidateRejectsInvalidURLs(t *testing.T) {
 	}
 }
 
+func TestNewClientRequiresHTTPS(t *testing.T) {
+	for name, config := range map[string]dexstrike.ExternalAPIConfig{
+		"base URL": {
+			Enabled: true,
+			BaseURL: "http://example.com",
+		},
+		"price base URL": {
+			Enabled:      true,
+			BaseURL:      "https://example.com",
+			PriceBaseURL: "http://prices.example.com",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := NewClient(config)
+			if !errors.Is(err, dexstrike.ErrInvalidExternalAPIConfig) {
+				t.Fatalf(
+					"expected dexstrike.ErrInvalidExternalAPIConfig, got %v",
+					err,
+				)
+			}
+			if !strings.Contains(err.Error(), "must use HTTPS") {
+				t.Fatalf("expected HTTPS requirement error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestClientAuthenticatedRequestDoesNotFollowRedirect(t *testing.T) {
+	privateKey := ed25519.NewKeyFromSeed(
+		[]byte("01234567890123456789012345678901"),
+	)
+	publicKey := privateKey.Public().(ed25519.PublicKey)
+	signer, err := NewEd25519Signer(publicKey, privateKey)
+	if err != nil {
+		t.Fatalf("NewEd25519Signer returned error: %v", err)
+	}
+
+	var redirectedHits atomic.Int64
+	redirected := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			redirectedHits.Add(1)
+			if r.Header.Get(HeaderWalletSignature) != "" {
+				t.Error("redirect target received authentication signature")
+			}
+			w.WriteHeader(http.StatusOK)
+		},
+	))
+	defer redirected.Close()
+
+	source := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get(HeaderWalletSignature) == "" {
+				t.Error("original request was not authenticated")
+			}
+			http.Redirect(w, r, redirected.URL+"/replay", http.StatusTemporaryRedirect)
+		},
+	))
+	defer source.Close()
+
+	config := dexstrike.ExternalAPIConfig{
+		Enabled: true,
+		BaseURL: source.URL,
+	}
+	client, err := NewClient(
+		config,
+		WithSigner(signer),
+		WithInsecureHTTPForTests(),
+	)
+	if err != nil {
+		t.Fatalf("NewClient returned error: %v", err)
+	}
+
+	err = client.DoAuthenticated(
+		context.Background(),
+		http.MethodPost,
+		"/v2/orders",
+		nil,
+		map[string]string{"symbol": "BTC-USD"},
+		nil,
+	)
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) || apiErr.StatusCode != http.StatusTemporaryRedirect {
+		t.Fatalf("expected 307 API error, got %v", err)
+	}
+	if redirectedHits.Load() != 0 {
+		t.Fatalf("redirect target received %d requests", redirectedHits.Load())
+	}
+}
+
 func TestRandomNonceReturnsUUIDV4(t *testing.T) {
 	nonce, err := randomNonce()
 	if err != nil {
@@ -373,7 +463,7 @@ func newEnabledTestClient(
 	if len(priceBaseURLs) > 0 {
 		config.PriceBaseURL = priceBaseURLs[0]
 	}
-	client, err := NewClient(config)
+	client, err := NewClient(config, WithInsecureHTTPForTests())
 	if err != nil {
 		t.Fatalf("NewClient returned error: %v", err)
 	}

--- a/batch/strike/client_test.go
+++ b/batch/strike/client_test.go
@@ -1,0 +1,390 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package strike
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	dexstrike "github.com/blinklabs-io/shai/dex/strike"
+)
+
+func TestNewClientDisabledDoesNotCallNetwork(t *testing.T) {
+	var hits atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	config := dexstrike.MainnetTargets().ExternalAPI
+	config.BaseURL = server.URL
+	client, err := NewClient(config)
+	if err != nil {
+		t.Fatalf("NewClient returned error: %v", err)
+	}
+
+	err = client.Ping(context.Background())
+	if !errors.Is(err, dexstrike.ErrExternalAPIDisabled) {
+		t.Fatalf("expected dexstrike.ErrExternalAPIDisabled, got %v", err)
+	}
+	if hits.Load() != 0 {
+		t.Fatalf("disabled client made %d network requests", hits.Load())
+	}
+}
+
+func TestClientPingAndServerTime(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/ping":
+			w.WriteHeader(http.StatusNoContent)
+		case "/v2/time":
+			writeJSON(t, w, map[string]int64{"serverTime": 1700000000123})
+		default:
+			t.Fatalf("unexpected request path %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := newEnabledTestClient(t, server.URL, server.URL+"/price")
+	if err := client.Ping(context.Background()); err != nil {
+		t.Fatalf("Ping returned error: %v", err)
+	}
+
+	serverTime, err := client.ServerTime(context.Background())
+	if err != nil {
+		t.Fatalf("ServerTime returned error: %v", err)
+	}
+	if serverTime.UnixMilliseconds() != 1700000000123 {
+		t.Fatalf("unexpected server time: %#v", serverTime)
+	}
+}
+
+func TestClientMarkPriceUsesPriceBaseURL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/price/v2/markPrice" {
+			t.Fatalf("unexpected request path %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("symbol") != "BTC-USD" {
+			t.Fatalf("unexpected symbol query %q", r.URL.RawQuery)
+		}
+		writeJSON(t, w, map[string]any{
+			"data": map[string]string{
+				"s": "BTC-USD",
+				"p": "12345.67",
+				"i": "12340.00",
+				"r": "0.0001",
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := newEnabledTestClient(t, server.URL, server.URL+"/price")
+	price, err := client.MarkPrice(context.Background(), "btc-usd")
+	if err != nil {
+		t.Fatalf("MarkPrice returned error: %v", err)
+	}
+	if price.Symbol != "BTC-USD" {
+		t.Fatalf("unexpected symbol %q", price.Symbol)
+	}
+	if price.PriceString() != "12345.67" {
+		t.Fatalf("unexpected mark price %q", price.PriceString())
+	}
+	if price.IndexPrice != "12340.00" || price.FundingRate != "0.0001" {
+		t.Fatalf("unexpected mark price response: %#v", price)
+	}
+}
+
+func TestClientMarkPriceUsesDefaultPriceBaseURL(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/price/v2/markPrice" {
+			t.Fatalf("unexpected request path %s", r.URL.Path)
+		}
+		writeJSON(t, w, map[string]any{
+			"data": map[string]string{
+				"s": "BTC-USD",
+				"p": "12345.67",
+			},
+		})
+	}
+	server := httptest.NewServer(http.HandlerFunc(handler))
+	defer server.Close()
+
+	client := newEnabledTestClient(t, server.URL)
+	if _, err := client.MarkPrice(context.Background(), "BTC-USD"); err != nil {
+		t.Fatalf("MarkPrice returned error: %v", err)
+	}
+}
+
+func TestClientAuthenticatedRequestSignsHeaders(t *testing.T) {
+	privateKey := ed25519.NewKeyFromSeed(
+		[]byte("01234567890123456789012345678901"),
+	)
+	publicKey := privateKey.Public().(ed25519.PublicKey)
+	signer, err := NewEd25519Signer(publicKey, privateKey)
+	if err != nil {
+		t.Fatalf("NewEd25519Signer returned error: %v", err)
+	}
+
+	type orderRequest struct {
+		Side   string `json:"side"`
+		Symbol string `json:"symbol"`
+	}
+	body := orderRequest{
+		Side:   "buy",
+		Symbol: "BTC-USD",
+	}
+	bodyBytes, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("json.Marshal returned error: %v", err)
+	}
+	bodyHash := sha256.Sum256(bodyBytes)
+	expectedPayload := SignaturePayload(
+		http.MethodPost,
+		"/v2/orders?symbol=BTC-USD",
+		"1700000000",
+		"nonce-1",
+		hex.EncodeToString(bodyHash[:]),
+	)
+	expectedSignature := hex.EncodeToString(
+		ed25519.Sign(privateKey, []byte(expectedPayload)),
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.RequestURI() != "/v2/orders?symbol=BTC-USD" {
+			t.Fatalf("unexpected request URI %s", r.URL.RequestURI())
+		}
+		if r.Header.Get(HeaderWalletPublicKey) != hex.EncodeToString(publicKey) {
+			t.Fatalf("unexpected public key header")
+		}
+		if r.Header.Get(HeaderWalletSignature) != expectedSignature {
+			t.Fatalf("unexpected signature header")
+		}
+		if r.Header.Get(HeaderWalletTimestamp) != "1700000000" {
+			t.Fatalf("unexpected timestamp header")
+		}
+		if r.Header.Get(HeaderWalletNonce) != "nonce-1" {
+			t.Fatalf("unexpected nonce header")
+		}
+		writeJSON(t, w, map[string]string{"status": "accepted"})
+	}))
+	defer server.Close()
+
+	config := dexstrike.ExternalAPIConfig{
+		Enabled: true,
+		BaseURL: server.URL,
+	}
+	client, err := NewClient(
+		config,
+		WithSigner(signer),
+		WithClock(func() time.Time {
+			return time.UnixMilli(1700000000123)
+		}),
+		WithNonce(func() (string, error) {
+			return "nonce-1", nil
+		}),
+	)
+	if err != nil {
+		t.Fatalf("NewClient returned error: %v", err)
+	}
+
+	var out map[string]string
+	query := url.Values{"symbol": []string{"BTC-USD"}}
+	err = client.DoAuthenticated(
+		context.Background(),
+		http.MethodPost,
+		"/v2/orders",
+		query,
+		body,
+		&out,
+	)
+	if err != nil {
+		t.Fatalf("DoAuthenticated returned error: %v", err)
+	}
+	if out["status"] != "accepted" {
+		t.Fatalf("unexpected response: %#v", out)
+	}
+}
+
+func TestNewEd25519SignerRejectsMismatchedKeyPair(t *testing.T) {
+	privateKey := ed25519.NewKeyFromSeed(
+		[]byte("01234567890123456789012345678901"),
+	)
+	otherPrivateKey := ed25519.NewKeyFromSeed(
+		[]byte("abcdefghijklmnopqrstuvwxyz123456"),
+	)
+	otherPublicKey := otherPrivateKey.Public().(ed25519.PublicKey)
+
+	_, err := NewEd25519Signer(otherPublicKey, privateKey)
+	if !errors.Is(err, dexstrike.ErrInvalidExternalAPIConfig) {
+		t.Fatalf("expected dexstrike.ErrInvalidExternalAPIConfig, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "private key does not match public key") {
+		t.Fatalf("expected key mismatch error, got %v", err)
+	}
+}
+
+func TestNewEd25519SignerAcceptsSeed(t *testing.T) {
+	seed := []byte("01234567890123456789012345678901")
+	privateKey := ed25519.NewKeyFromSeed(seed)
+	publicKey := privateKey.Public().(ed25519.PublicKey)
+
+	signer, err := NewEd25519Signer(publicKey, ed25519.PrivateKey(seed))
+	if err != nil {
+		t.Fatalf("NewEd25519Signer returned error: %v", err)
+	}
+	payload := "payload"
+	want := hex.EncodeToString(ed25519.Sign(privateKey, []byte(payload)))
+	if got := signer.SignPayload(payload); got != want {
+		t.Fatalf("unexpected signature %q", got)
+	}
+}
+
+func TestClientAuthenticatedRequestRequiresSigner(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("request should not be sent without signer")
+	}))
+	defer server.Close()
+
+	client := newEnabledTestClient(t, server.URL, server.URL+"/price")
+	err := client.DoAuthenticated(
+		context.Background(),
+		http.MethodPost,
+		"/v2/orders",
+		nil,
+		map[string]string{"symbol": "BTC-USD"},
+		nil,
+	)
+	if !errors.Is(err, dexstrike.ErrMissingSigner) {
+		t.Fatalf("expected dexstrike.ErrMissingSigner, got %v", err)
+	}
+}
+
+func TestClientReturnsAPIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "unavailable", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	client := newEnabledTestClient(t, server.URL, server.URL+"/price")
+	err := client.Ping(context.Background())
+	if !errors.Is(err, dexstrike.ErrAPIRequestFailed) {
+		t.Fatalf("expected dexstrike.ErrAPIRequestFailed, got %v", err)
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected APIError, got %T", err)
+	}
+	if apiErr.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("unexpected status code %d", apiErr.StatusCode)
+	}
+	if !strings.Contains(apiErr.Body, "unavailable") {
+		t.Fatalf("unexpected body %q", apiErr.Body)
+	}
+}
+
+func TestExternalAPIConfigValidateRejectsInvalidURLs(t *testing.T) {
+	config := dexstrike.ExternalAPIConfig{
+		Enabled: true,
+		BaseURL: "ftp://example.com",
+	}
+	if err := config.Validate(); !errors.Is(err, dexstrike.ErrInvalidExternalAPIConfig) {
+		t.Fatalf("expected dexstrike.ErrInvalidExternalAPIConfig, got %v", err)
+	}
+
+	config = dexstrike.ExternalAPIConfig{
+		Enabled:      true,
+		BaseURL:      "https://example.com",
+		PriceBaseURL: "/price",
+	}
+	if err := config.Validate(); !errors.Is(err, dexstrike.ErrInvalidExternalAPIConfig) {
+		t.Fatalf("expected dexstrike.ErrInvalidExternalAPIConfig, got %v", err)
+	}
+
+	for _, baseURL := range []string{
+		"https://user:password@example.com",
+		"https://example.com?token=secret",
+		"https://example.com#fragment",
+	} {
+		config = dexstrike.ExternalAPIConfig{
+			Enabled: true,
+			BaseURL: baseURL,
+		}
+		if err := config.Validate(); !errors.Is(
+			err,
+			dexstrike.ErrInvalidExternalAPIConfig,
+		) {
+			t.Fatalf("expected URL %q to be rejected, got %v", baseURL, err)
+		}
+	}
+}
+
+func TestRandomNonceReturnsUUIDV4(t *testing.T) {
+	nonce, err := randomNonce()
+	if err != nil {
+		t.Fatalf("randomNonce returned error: %v", err)
+	}
+	if len(nonce) != 36 || nonce[8] != '-' || nonce[13] != '-' ||
+		nonce[18] != '-' || nonce[23] != '-' {
+		t.Fatalf("nonce is not a UUID: %q", nonce)
+	}
+	if nonce[14] != '4' {
+		t.Fatalf("nonce is not UUID v4: %q", nonce)
+	}
+	if !strings.Contains("89ab", nonce[19:20]) {
+		t.Fatalf("nonce has invalid UUID variant: %q", nonce)
+	}
+}
+
+func newEnabledTestClient(
+	t *testing.T,
+	baseURL string,
+	priceBaseURLs ...string,
+) *Client {
+	t.Helper()
+
+	config := dexstrike.ExternalAPIConfig{
+		Enabled: true,
+		BaseURL: baseURL,
+	}
+	if len(priceBaseURLs) > 0 {
+		config.PriceBaseURL = priceBaseURLs[0]
+	}
+	client, err := NewClient(config)
+	if err != nil {
+		t.Fatalf("NewClient returned error: %v", err)
+	}
+	return client
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, value any) {
+	t.Helper()
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(value); err != nil {
+		t.Fatalf("json.Encode returned error: %v", err)
+	}
+}

--- a/batch/strike/client_test.go
+++ b/batch/strike/client_test.go
@@ -370,6 +370,54 @@ func TestNewClientRequiresHTTPS(t *testing.T) {
 	}
 }
 
+func TestInsecureHTTPForTestsRequiresLoopback(t *testing.T) {
+	for name, config := range map[string]dexstrike.ExternalAPIConfig{
+		"base URL": {
+			Enabled: true,
+			BaseURL: "http://192.0.2.1",
+		},
+		"price base URL": {
+			Enabled:      true,
+			BaseURL:      "https://example.com",
+			PriceBaseURL: "http://prices.example.com",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := NewClient(config, WithInsecureHTTPForTests())
+			if !errors.Is(err, dexstrike.ErrInvalidExternalAPIConfig) {
+				t.Fatalf(
+					"expected dexstrike.ErrInvalidExternalAPIConfig, got %v",
+					err,
+				)
+			}
+			if !strings.Contains(err.Error(), "loopback HTTP") {
+				t.Fatalf("expected loopback HTTP requirement error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestInsecureHTTPForTestsAllowsLoopback(t *testing.T) {
+	for _, baseURL := range []string{
+		"http://localhost:8080",
+		"http://127.0.0.1:8080",
+		"http://[::1]:8080",
+	} {
+		t.Run(baseURL, func(t *testing.T) {
+			config := dexstrike.ExternalAPIConfig{
+				Enabled: true,
+				BaseURL: baseURL,
+			}
+			if _, err := NewClient(
+				config,
+				WithInsecureHTTPForTests(),
+			); err != nil {
+				t.Fatalf("NewClient returned error: %v", err)
+			}
+		})
+	}
+}
+
 func TestClientAuthenticatedRequestDoesNotFollowRedirect(t *testing.T) {
 	privateKey := ed25519.NewKeyFromSeed(
 		[]byte("01234567890123456789012345678901"),

--- a/batch/strike/signer.go
+++ b/batch/strike/signer.go
@@ -1,0 +1,147 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package strike
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	dexstrike "github.com/blinklabs-io/shai/dex/strike"
+)
+
+const (
+	HeaderWalletPublicKey = "X-API-Wallet-Public-Key"
+	HeaderWalletSignature = "X-API-Wallet-Signature"
+	HeaderWalletTimestamp = "X-API-Wallet-Timestamp"
+	HeaderWalletNonce     = "X-API-Wallet-Nonce"
+)
+
+// Ed25519Signer signs Strike authenticated API requests. Header values are
+// hex encoded so they match the usual Cardano public-key representation.
+type Ed25519Signer struct {
+	publicKey  ed25519.PublicKey
+	privateKey ed25519.PrivateKey
+}
+
+func NewEd25519Signer(
+	publicKey ed25519.PublicKey,
+	privateKey ed25519.PrivateKey,
+) (*Ed25519Signer, error) {
+	if len(publicKey) != ed25519.PublicKeySize {
+		return nil, fmt.Errorf(
+			"%w: public key must be %d bytes",
+			dexstrike.ErrInvalidExternalAPIConfig,
+			ed25519.PublicKeySize,
+		)
+	}
+	var signingKey ed25519.PrivateKey
+	switch len(privateKey) {
+	case ed25519.SeedSize:
+		signingKey = ed25519.NewKeyFromSeed(privateKey)
+	case ed25519.PrivateKeySize:
+		signingKey = privateKey
+	default:
+		return nil, fmt.Errorf(
+			"%w: private key must be a %d-byte seed or %d-byte private key",
+			dexstrike.ErrInvalidExternalAPIConfig,
+			ed25519.SeedSize,
+			ed25519.PrivateKeySize,
+		)
+	}
+	if !bytes.Equal(signingKey.Public().(ed25519.PublicKey), publicKey) {
+		return nil, fmt.Errorf(
+			"%w: private key does not match public key",
+			dexstrike.ErrInvalidExternalAPIConfig,
+		)
+	}
+	return &Ed25519Signer{
+		publicKey:  append(ed25519.PublicKey(nil), publicKey...),
+		privateKey: append(ed25519.PrivateKey(nil), signingKey...),
+	}, nil
+}
+
+func (s *Ed25519Signer) PublicKeyHex() string {
+	return hex.EncodeToString(s.publicKey)
+}
+
+func (s *Ed25519Signer) SignPayload(payload string) string {
+	signature := ed25519.Sign(s.privateKey, []byte(payload))
+	return hex.EncodeToString(signature)
+}
+
+func (s *Ed25519Signer) SignRequest(
+	req *http.Request,
+	body []byte,
+	timestamp string,
+	nonce string,
+) error {
+	if s == nil {
+		return dexstrike.ErrMissingSigner
+	}
+	payload := SignaturePayload(
+		req.Method,
+		CanonicalRequestPath(req.URL),
+		timestamp,
+		nonce,
+		BodyHash(req.Method, body),
+	)
+	req.Header.Set(HeaderWalletPublicKey, s.PublicKeyHex())
+	req.Header.Set(HeaderWalletSignature, s.SignPayload(payload))
+	req.Header.Set(HeaderWalletTimestamp, timestamp)
+	req.Header.Set(HeaderWalletNonce, nonce)
+	return nil
+}
+
+func SignaturePayload(
+	method string,
+	path string,
+	timestamp string,
+	nonce string,
+	bodyHash string,
+) string {
+	return fmt.Sprintf(
+		"%s:%s:%s:%s:%s",
+		strings.ToUpper(method),
+		path,
+		timestamp,
+		nonce,
+		bodyHash,
+	)
+}
+
+func BodyHash(method string, body []byte) string {
+	if strings.EqualFold(method, http.MethodGet) {
+		return ""
+	}
+	sum := sha256.Sum256(body)
+	return hex.EncodeToString(sum[:])
+}
+
+func CanonicalRequestPath(reqURL *url.URL) string {
+	path := reqURL.EscapedPath()
+	if path == "" {
+		path = "/"
+	}
+	if reqURL.RawQuery != "" {
+		path += "?" + reqURL.RawQuery
+	}
+	return path
+}

--- a/batch/strike/signer.go
+++ b/batch/strike/signer.go
@@ -127,10 +127,7 @@ func SignaturePayload(
 	)
 }
 
-func BodyHash(method string, body []byte) string {
-	if strings.EqualFold(method, http.MethodGet) {
-		return ""
-	}
+func BodyHash(_ string, body []byte) string {
 	sum := sha256.Sum256(body)
 	return hex.EncodeToString(sum[:])
 }

--- a/batch/strike/signer_test.go
+++ b/batch/strike/signer_test.go
@@ -1,0 +1,61 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package strike
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"testing"
+)
+
+func TestSignRequestGETHashesEmptyBody(t *testing.T) {
+	privateKey := ed25519.NewKeyFromSeed(
+		[]byte("01234567890123456789012345678901"),
+	)
+	publicKey := privateKey.Public().(ed25519.PublicKey)
+	signer, err := NewEd25519Signer(publicKey, privateKey)
+	if err != nil {
+		t.Fatalf("NewEd25519Signer returned error: %v", err)
+	}
+	req, err := http.NewRequest(
+		http.MethodGet,
+		"https://api.strikefinance.org/v2/orders?status=open",
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("http.NewRequest returned error: %v", err)
+	}
+
+	const timestamp = "1700000000"
+	const nonce = "nonce-1"
+	if err := signer.SignRequest(req, nil, timestamp, nonce); err != nil {
+		t.Fatalf("SignRequest returned error: %v", err)
+	}
+
+	emptyBodyHash := sha256.Sum256(nil)
+	payload := SignaturePayload(
+		http.MethodGet,
+		"/v2/orders?status=open",
+		timestamp,
+		nonce,
+		hex.EncodeToString(emptyBodyHash[:]),
+	)
+	want := hex.EncodeToString(ed25519.Sign(privateKey, []byte(payload)))
+	if got := req.Header.Get(HeaderWalletSignature); got != want {
+		t.Fatalf("signature = %q, want %q", got, want)
+	}
+}

--- a/dex/strike/README.md
+++ b/dex/strike/README.md
@@ -1,0 +1,49 @@
+# Strike Finance Perpetuals
+
+This package contains the Strike Finance perpetuals integration boundary. It is
+not connected to `cmd/shai/main.go`, profile defaults, or the oracle runtime.
+On-chain parsing remains gated until script targets and datum schemas are
+verified.
+
+Integration target:
+
+- Protocol: `strike-finance`
+- Product: `perpetuals`
+- Candidate runtime name: `strike-finance-perpetuals`
+- External APIs: optional only, disabled by default, and not a source of truth
+
+Public API targets:
+
+- Mainnet REST base: `https://api.strikefinance.org`
+- Mainnet price REST base: `https://api.strikefinance.org/price`
+- Testnet REST base: `https://api-v2-testnet.strikefinance.org`
+- Testnet price REST base:
+  `https://api-v2-testnet.strikefinance.org/price`
+
+Implemented external API calls:
+
+- `GET /v2/ping`
+- `GET /v2/time`
+- `GET /price/v2/markPrice?symbol=BTC-USD` when using the REST base, or
+  `GET /v2/markPrice?symbol=BTC-USD` when using the price REST base.
+- Generic authenticated JSON requests using the documented Ed25519 signature
+  payload `{METHOD}:{PATH}:{TIMESTAMP}:{NONCE}:{BODY_HASH}`. Timestamps use Unix
+  seconds and nonces are UUID v4 values, as required by the API.
+
+External API usage requires constructing a client with `ExternalAPIConfig.Enabled`
+set to `true`. The default targets keep it false, and tests use `httptest`
+instead of live network calls.
+
+Required before runtime support can be enabled:
+
+- [ ] Verify script addresses for market state, orders, and positions.
+- [ ] Verify the first safe intercept slot and block hash.
+- [ ] Verify datum schemas for market and position state.
+- [ ] Verify redeemer schema and action constructors.
+- [ ] Verify state transitions for open, update, close, liquidation, and
+      settlement flows.
+- [ ] Add deterministic parser fixtures from verified on-chain transactions.
+- [ ] Only then add an explicit profile and parser wiring.
+
+Until those items are complete, on-chain datum and redeemer parsers return
+unsupported verification errors and must remain unused by runtime profiles.

--- a/dex/strike/doc.go
+++ b/dex/strike/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package strike contains the Strike Finance perpetuals integration boundary.
+package strike

--- a/dex/strike/errors.go
+++ b/dex/strike/errors.go
@@ -1,0 +1,28 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package strike
+
+import "errors"
+
+var (
+	ErrUnsupported              = errors.New("strike perpetuals parser unsupported")
+	ErrVerificationRequired     = errors.New("strike perpetuals verification required")
+	ErrExternalAPIDisabled      = errors.New("strike external API disabled")
+	ErrInvalidExternalAPIConfig = errors.New(
+		"invalid strike external API config",
+	)
+	ErrMissingSigner    = errors.New("strike authenticated request signer missing")
+	ErrAPIRequestFailed = errors.New("strike API request failed")
+)

--- a/dex/strike/models.go
+++ b/dex/strike/models.go
@@ -1,0 +1,250 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package strike
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+const (
+	ProtocolName    = "strike-finance"
+	ProductName     = "perpetuals"
+	IntegrationName = ProtocolName + "-" + ProductName
+	MainnetNetwork  = "mainnet"
+	TestnetNetwork  = "testnet"
+
+	DefaultExternalAPIEnabled = false
+
+	MainnetAPIBaseURL      = "https://api.strikefinance.org"
+	MainnetPriceAPIBaseURL = MainnetAPIBaseURL + "/price"
+	TestnetAPIBaseURL      = "https://api-v2-testnet.strikefinance.org"
+	TestnetPriceAPIBaseURL = TestnetAPIBaseURL + "/price"
+)
+
+// ExternalAPIConfig records optional off-chain API usage. Runtime support must
+// not require it, and the default scaffold keeps it disabled.
+type ExternalAPIConfig struct {
+	Enabled      bool
+	BaseURL      string
+	PriceBaseURL string
+}
+
+// VerificationStatus tracks the on-chain facts that must be independently
+// verified before any runtime profile is enabled.
+type VerificationStatus struct {
+	ScriptAddresses  bool
+	InterceptPoint   bool
+	DatumSchema      bool
+	RedeemerSchema   bool
+	StateTransitions bool
+}
+
+func (s VerificationStatus) Complete() bool {
+	return s.ScriptAddresses &&
+		s.InterceptPoint &&
+		s.DatumSchema &&
+		s.RedeemerSchema &&
+		s.StateTransitions
+}
+
+// OnChainTargets records the candidate Strike perpetuals integration target.
+// Empty address and intercept fields are intentional until verified.
+type OnChainTargets struct {
+	Network                  string
+	MarketStateScriptAddress string
+	OrderScriptAddress       string
+	PositionScriptAddress    string
+	InterceptSlot            uint64
+	InterceptHash            string
+	Verification             VerificationStatus
+	ExternalAPI              ExternalAPIConfig
+}
+
+func MainnetTargets() OnChainTargets {
+	return OnChainTargets{
+		Network: MainnetNetwork,
+		ExternalAPI: ExternalAPIConfig{
+			Enabled:      DefaultExternalAPIEnabled,
+			BaseURL:      MainnetAPIBaseURL,
+			PriceBaseURL: MainnetPriceAPIBaseURL,
+		},
+	}
+}
+
+func TestnetTargets() OnChainTargets {
+	return OnChainTargets{
+		Network: TestnetNetwork,
+		ExternalAPI: ExternalAPIConfig{
+			Enabled:      DefaultExternalAPIEnabled,
+			BaseURL:      TestnetAPIBaseURL,
+			PriceBaseURL: TestnetPriceAPIBaseURL,
+		},
+	}
+}
+
+func KnownTargets() []OnChainTargets {
+	return []OnChainTargets{
+		MainnetTargets(),
+		TestnetTargets(),
+	}
+}
+
+func TargetsForNetwork(network string) (OnChainTargets, bool) {
+	for _, targets := range KnownTargets() {
+		if targets.Network == network {
+			return targets, true
+		}
+	}
+	return OnChainTargets{}, false
+}
+
+func (t OnChainTargets) RuntimeReady() bool {
+	return len(t.MissingVerification()) == 0
+}
+
+func (t OnChainTargets) MissingVerification() []string {
+	var missing []string
+	if t.Network == "" {
+		missing = append(missing, "network")
+	}
+	if t.MarketStateScriptAddress == "" ||
+		t.OrderScriptAddress == "" ||
+		t.PositionScriptAddress == "" ||
+		!t.Verification.ScriptAddresses {
+		missing = append(missing, "verified script addresses")
+	}
+	if t.InterceptSlot == 0 ||
+		t.InterceptHash == "" ||
+		!t.Verification.InterceptPoint {
+		missing = append(missing, "verified intercept slot")
+	}
+	if !t.Verification.DatumSchema {
+		missing = append(missing, "verified datum schema")
+	}
+	if !t.Verification.RedeemerSchema {
+		missing = append(missing, "verified redeemer schema")
+	}
+	if !t.Verification.StateTransitions {
+		missing = append(missing, "verified state transitions")
+	}
+	return missing
+}
+
+func (t OnChainTargets) ValidateRuntimeEnablement() error {
+	if t.RuntimeReady() {
+		return nil
+	}
+	return fmt.Errorf(
+		"%w: missing %s",
+		ErrVerificationRequired,
+		strings.Join(t.MissingVerification(), ", "),
+	)
+}
+
+// ParseBaseURL validates and parses an http(s) base URL used by off-chain API
+// clients. It is shared by ExternalAPIConfig.Validate and the batch client.
+func ParseBaseURL(rawURL string) (*url.URL, error) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, err
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return nil, fmt.Errorf("unsupported scheme %q", parsed.Scheme)
+	}
+	if parsed.Host == "" {
+		return nil, fmt.Errorf("missing host")
+	}
+	if parsed.User != nil {
+		return nil, fmt.Errorf("user information is not allowed")
+	}
+	if parsed.RawQuery != "" {
+		return nil, fmt.Errorf("query parameters are not allowed")
+	}
+	if parsed.Fragment != "" {
+		return nil, fmt.Errorf("fragments are not allowed")
+	}
+	return parsed, nil
+}
+
+func (c ExternalAPIConfig) Validate() error {
+	if !c.Enabled {
+		return nil
+	}
+	if c.BaseURL == "" {
+		return fmt.Errorf("%w: base URL is required", ErrInvalidExternalAPIConfig)
+	}
+	if _, err := ParseBaseURL(c.BaseURL); err != nil {
+		return fmt.Errorf("%w: invalid base URL: %w", ErrInvalidExternalAPIConfig, err)
+	}
+	if c.PriceBaseURL != "" {
+		if _, err := ParseBaseURL(c.PriceBaseURL); err != nil {
+			return fmt.Errorf(
+				"%w: invalid price base URL: %w",
+				ErrInvalidExternalAPIConfig,
+				err,
+			)
+		}
+	}
+	return nil
+}
+
+type MarketID string
+type PositionID string
+
+type Direction string
+
+const (
+	DirectionLong  Direction = "long"
+	DirectionShort Direction = "short"
+)
+
+// MarketState is the future normalized state for a Strike perpetual market.
+// The datum schema is not verified, so Parser does not populate it yet.
+type MarketState struct {
+	MarketID          MarketID
+	BaseAssetID       string
+	QuoteAssetID      string
+	LongOpenInterest  uint64
+	ShortOpenInterest uint64
+	Slot              uint64
+	TxHash            string
+	TxIndex           uint32
+}
+
+// PositionState is the future normalized state for an open perpetual position.
+// The datum schema is not verified, so Parser does not populate it yet.
+type PositionState struct {
+	PositionID PositionID
+	MarketID   MarketID
+	Owner      string
+	Direction  Direction
+	Collateral uint64
+	Size       uint64
+	Slot       uint64
+	TxHash     string
+	TxIndex    uint32
+}
+
+type RedeemerAction string
+
+const RedeemerActionUnknown RedeemerAction = "unknown"
+
+// Redeemer is a placeholder for verified Strike perpetuals redeemer actions.
+type Redeemer struct {
+	Action RedeemerAction
+	Raw    []byte
+}

--- a/dex/strike/parser.go
+++ b/dex/strike/parser.go
@@ -1,0 +1,73 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package strike
+
+import (
+	"fmt"
+)
+
+// Parser is a fail-closed placeholder for Strike Finance perpetual datums.
+// It must not be wired into profiles until the on-chain targets are verified.
+type Parser struct {
+	targets OnChainTargets
+}
+
+func NewParser(targets OnChainTargets) *Parser {
+	return &Parser{targets: targets}
+}
+
+func (p *Parser) Protocol() string {
+	return IntegrationName
+}
+
+func (p *Parser) Targets() OnChainTargets {
+	return p.targets
+}
+
+func (p *Parser) ValidateRuntimeEnablement() error {
+	return p.targets.ValidateRuntimeEnablement()
+}
+
+func (p *Parser) ParseMarketDatum(
+	datum []byte,
+	txHash string,
+	txIndex uint32,
+	slot uint64,
+) (*MarketState, error) {
+	return nil, unverifiedSchemaError("market datum")
+}
+
+func (p *Parser) ParsePositionDatum(
+	datum []byte,
+	txHash string,
+	txIndex uint32,
+	slot uint64,
+) (*PositionState, error) {
+	return nil, unverifiedSchemaError("position datum")
+}
+
+func (p *Parser) ParseRedeemer(redeemer []byte) (*Redeemer, error) {
+	return nil, unverifiedSchemaError("redeemer")
+}
+
+func unverifiedSchemaError(subject string) error {
+	return fmt.Errorf(
+		"%w: %s schema is unverified for %s; %w before enabling runtime support",
+		ErrUnsupported,
+		subject,
+		IntegrationName,
+		ErrVerificationRequired,
+	)
+}

--- a/dex/strike/parser_test.go
+++ b/dex/strike/parser_test.go
@@ -1,0 +1,182 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package strike
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestMainnetTargetsAreDisabledUntilVerified(t *testing.T) {
+	targets := MainnetTargets()
+
+	if targets.Network != MainnetNetwork {
+		t.Fatalf("expected network %q, got %q", MainnetNetwork, targets.Network)
+	}
+	if targets.ExternalAPI.Enabled {
+		t.Fatal("expected external API integration to be disabled by default")
+	}
+	if targets.ExternalAPI.BaseURL != MainnetAPIBaseURL {
+		t.Fatalf(
+			"expected mainnet API base URL %q, got %q",
+			MainnetAPIBaseURL,
+			targets.ExternalAPI.BaseURL,
+		)
+	}
+	if targets.ExternalAPI.PriceBaseURL != MainnetPriceAPIBaseURL {
+		t.Fatalf(
+			"expected mainnet price API base URL %q, got %q",
+			MainnetPriceAPIBaseURL,
+			targets.ExternalAPI.PriceBaseURL,
+		)
+	}
+	if targets.RuntimeReady() {
+		t.Fatal("unverified Strike targets must not be runtime ready")
+	}
+
+	missing := strings.Join(targets.MissingVerification(), ",")
+	for _, want := range []string{
+		"verified script addresses",
+		"verified intercept slot",
+		"verified datum schema",
+		"verified redeemer schema",
+		"verified state transitions",
+	} {
+		if !strings.Contains(missing, want) {
+			t.Fatalf("expected missing verification %q in %q", want, missing)
+		}
+	}
+}
+
+func TestTestnetTargetsExposeDisabledAPIConfig(t *testing.T) {
+	targets := TestnetTargets()
+
+	if targets.Network != TestnetNetwork {
+		t.Fatalf("expected network %q, got %q", TestnetNetwork, targets.Network)
+	}
+	if targets.ExternalAPI.Enabled {
+		t.Fatal("expected external API integration to be disabled by default")
+	}
+	if targets.ExternalAPI.BaseURL != TestnetAPIBaseURL {
+		t.Fatalf(
+			"expected testnet API base URL %q, got %q",
+			TestnetAPIBaseURL,
+			targets.ExternalAPI.BaseURL,
+		)
+	}
+	if targets.ExternalAPI.PriceBaseURL != TestnetPriceAPIBaseURL {
+		t.Fatalf(
+			"expected testnet price API base URL %q, got %q",
+			TestnetPriceAPIBaseURL,
+			targets.ExternalAPI.PriceBaseURL,
+		)
+	}
+	if targets.RuntimeReady() {
+		t.Fatal("unverified Strike testnet targets must not be runtime ready")
+	}
+}
+
+func TestTargetsForNetwork(t *testing.T) {
+	targets, ok := TargetsForNetwork(MainnetNetwork)
+	if !ok {
+		t.Fatal("expected mainnet targets")
+	}
+	if targets.Network != MainnetNetwork {
+		t.Fatalf("unexpected targets: %#v", targets)
+	}
+
+	_, ok = TargetsForNetwork("preprod")
+	if ok {
+		t.Fatal("preprod targets should not be exposed without verified config")
+	}
+}
+
+func TestParserReturnsVerificationErrors(t *testing.T) {
+	parser := NewParser(MainnetTargets())
+	if parser.Protocol() != IntegrationName {
+		t.Fatalf("expected protocol %q, got %q", IntegrationName, parser.Protocol())
+	}
+
+	parseChecks := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "market datum",
+			err: func() error {
+				_, err := parser.ParseMarketDatum([]byte{0x01}, "tx", 0, 1)
+				return err
+			}(),
+		},
+		{
+			name: "position datum",
+			err: func() error {
+				_, err := parser.ParsePositionDatum([]byte{0x01}, "tx", 0, 1)
+				return err
+			}(),
+		},
+		{
+			name: "redeemer",
+			err: func() error {
+				_, err := parser.ParseRedeemer([]byte{0x01})
+				return err
+			}(),
+		},
+	}
+
+	for _, check := range parseChecks {
+		if !errors.Is(check.err, ErrUnsupported) {
+			t.Fatalf("%s: expected ErrUnsupported, got %v", check.name, check.err)
+		}
+		if !errors.Is(check.err, ErrVerificationRequired) {
+			t.Fatalf(
+				"%s: expected ErrVerificationRequired, got %v",
+				check.name,
+				check.err,
+			)
+		}
+		if !strings.Contains(check.err.Error(), check.name+" schema is unverified") {
+			t.Fatalf("%s: unclear parser error: %v", check.name, check.err)
+		}
+	}
+}
+
+func TestValidateRuntimeEnablement(t *testing.T) {
+	parser := NewParser(MainnetTargets())
+	err := parser.ValidateRuntimeEnablement()
+	if !errors.Is(err, ErrVerificationRequired) {
+		t.Fatalf("expected ErrVerificationRequired, got %v", err)
+	}
+
+	targets := OnChainTargets{
+		Network:                  MainnetNetwork,
+		MarketStateScriptAddress: "addr_test_market",
+		OrderScriptAddress:       "addr_test_order",
+		PositionScriptAddress:    "addr_test_position",
+		InterceptSlot:            1,
+		InterceptHash:            "block_hash",
+		Verification: VerificationStatus{
+			ScriptAddresses:  true,
+			InterceptPoint:   true,
+			DatumSchema:      true,
+			RedeemerSchema:   true,
+			StateTransitions: true,
+		},
+	}
+	if err := NewParser(targets).ValidateRuntimeEnablement(); err != nil {
+		t.Fatalf("expected verified targets to pass validation, got %v", err)
+	}
+}


### PR DESCRIPTION
Closes #340 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds initial Strike Finance perpetuals integration with an optional, authenticated REST client and a fail-closed on-chain parser not yet wired into any runtime. Closes #340.

- New Features
  - `batch/strike`: JSON REST client for `GET /v2/ping`, `GET /v2/time`, and mark price via `/price/v2/markPrice` (or `/v2/markPrice` when using a price base); 10s timeout, 1MB response cap, envelope (`data`/`result`) decoding, and typed `APIError`.
  - Auth: Ed25519 signing via `X-API-Wallet-*` headers using `{METHOD}:{PATH}:{TIMESTAMP}:{NONCE}:{BODY_HASH}`; hex-encoded key/signature; Unix-seconds timestamp; UUIDv4 nonce; GET hashes empty body; authenticated requests do not follow redirects.
  - Targets/Config: Mainnet/testnet REST bases with default price base `<base>/price`; strict base URL parsing (no user info, query, or fragment); HTTPS required by default with a loopback-HTTP exception for tests via `WithInsecureHTTPForTests`; external API is opt-in via `ExternalAPIConfig.Enabled`.
  - `dex/strike`: parser scaffold for markets, positions, and redeemers that returns verification-required errors until script addresses, intercept point, schemas, and transitions are confirmed; docs list remaining steps.

<sup>Written for commit eeb4b1dbb70d4244e6d307f7582087cb3cc3a200. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/shai/pull/349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added initial Strike Finance perpetuals integration support.
  * Added optional external API connectivity for health checks, server time, and market prices.
  * Added authenticated API requests using wallet-based Ed25519 signatures.
  * Added mainnet and testnet configuration with strict endpoint validation.

* **Documentation**
  * Documented integration scope, configuration, API usage, and verification requirements.

* **Safety**
  * On-chain parsing remains disabled until required schemas and targets are verified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->