### PR TITLE
feat: add testnet oracle profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Shai can be configured via YAML file, environment variables, or both.
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `NETWORK` | Cardano network (`mainnet`, `preview`) | `mainnet` |
+| `NETWORK` | Cardano network (`mainnet`, `preprod`, `preview`) | `mainnet` |
 | `PROFILES` | Comma-separated list of profiles to enable | `spectrum,teddyswap` |
 | `MNEMONIC` | Wallet seed phrase (auto-generates if not set) | - |
 | `STORAGE_DIR` | BadgerDB storage location | `./.shai` |
@@ -101,6 +101,10 @@ Oracle profiles (price tracking):
 Spectrum batching profiles (matcher bot):
 - `spectrum` - Spectrum DEX on mainnet
 - `teddyswap` - TeddySwap on preview/mainnet
+
+Testnet oracle coverage:
+- `NETWORK=preprod PROFILES=minswap-v2` enables the Minswap V2 preprod pool contract.
+- `NETWORK=preview PROFILES=sundaeswap-v3` enables the SundaeSwap V3 preview pool contract.
 
 ## Usage
 

--- a/internal/config/networks.go
+++ b/internal/config/networks.go
@@ -6,6 +6,10 @@ type Network struct {
 }
 
 var Networks = map[string]Network{
+	"preprod": {
+		ShelleyOffsetSlot: 0,
+		ShelleyOffsetTime: 1654041600,
+	},
 	"preview": {
 		ShelleyOffsetSlot: 0,
 		ShelleyOffsetTime: 1666656000,

--- a/internal/config/profile_addresses.go
+++ b/internal/config/profile_addresses.go
@@ -1,0 +1,64 @@
+package config
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	ouroboros "github.com/blinklabs-io/gouroboros"
+	"github.com/blinklabs-io/gouroboros/ledger/common"
+)
+
+func mustScriptEnterpriseAddress(networkName, paymentHashHex string) string {
+	return mustScriptAddress(
+		networkName,
+		common.AddressTypeScriptNone,
+		paymentHashHex,
+		"",
+	)
+}
+
+func mustScriptScriptAddress(
+	networkName string,
+	paymentHashHex string,
+	stakingHashHex string,
+) string {
+	return mustScriptAddress(
+		networkName,
+		common.AddressTypeScriptScript,
+		paymentHashHex,
+		stakingHashHex,
+	)
+}
+
+func mustScriptAddress(
+	networkName string,
+	addressType uint8,
+	paymentHashHex string,
+	stakingHashHex string,
+) string {
+	network, ok := ouroboros.NetworkByName(networkName)
+	if !ok {
+		panic(fmt.Sprintf("unknown Cardano network %q", networkName))
+	}
+	paymentHash, err := hex.DecodeString(paymentHashHex)
+	if err != nil {
+		panic(fmt.Sprintf("invalid payment hash %q: %v", paymentHashHex, err))
+	}
+	var stakingHash []byte
+	if stakingHashHex != "" {
+		stakingHash, err = hex.DecodeString(stakingHashHex)
+		if err != nil {
+			panic(fmt.Sprintf("invalid staking hash %q: %v", stakingHashHex, err))
+		}
+	}
+	address, err := common.NewAddressFromParts(
+		addressType,
+		network.Id,
+		paymentHash,
+		stakingHash,
+	)
+	if err != nil {
+		panic(fmt.Sprintf("invalid script address parts: %v", err))
+	}
+	return address.String()
+}

--- a/internal/config/profiles.go
+++ b/internal/config/profiles.go
@@ -71,7 +71,65 @@ func GetAvailableProfiles() []string {
 }
 
 var Profiles = map[string]map[string]Profile{
+	"preprod": {
+		"minswap-v2": {
+			Name:          "minswap-v2",
+			Type:          ProfileTypeOracle,
+			InterceptSlot: 62910357,
+			InterceptHash: "42d965bbc11668723b3bc3741a969c2750d2df0d16714a0af63b4ef2ee221eb1",
+			Config: OracleProfileConfig{
+				Protocol: "minswap-v2",
+				PoolAddresses: []ProfileConfigAddress{
+					// Minswap V2 pool script address (preprod)
+					{
+						Address: mustScriptEnterpriseAddress(
+							"preprod",
+							"d6ba9b7509eac866288ff5072d2a18205ac56f744bc82dcd808cb8fe",
+						),
+					},
+				},
+				InputRefs: []ProfileConfigInputRef{
+					// Pool reference script
+					{
+						TxId:      "9f30b1c3948a009ceebda32d0b1d25699674b2eaf8b91ef029a43bfc1073ce28",
+						OutputIdx: 0,
+					},
+				},
+			},
+		},
+	},
 	"preview": {
+		"sundaeswap-v3": {
+			Name:          "sundaeswap-v3",
+			Type:          ProfileTypeOracle,
+			InterceptSlot: 48535234,
+			InterceptHash: "311319fd4889453ddbba6fde8b085cd1ec8d7d341e6128c003ad8cbbfbf09043",
+			Config: OracleProfileConfig{
+				Protocol: "sundaeswap-v3",
+				PoolAddresses: []ProfileConfigAddress{
+					// SundaeSwap V3 pool script address (preview)
+					{
+						Address: mustScriptScriptAddress(
+							"preview",
+							"44a1eb2d9f58add4eb1932bd0048e6a1947e85e3fe4f32956a110414",
+							"cc27980a8557fe9db2c9ac0a2677f4d1306dbf10689983758f0b8dbe",
+						),
+					},
+				},
+				InputRefs: []ProfileConfigInputRef{
+					// Order reference script
+					{
+						TxId:      "92ec2274938de291d3837b7facf9eddfaed57cd6ff97e26af57cb7a9978e3887",
+						OutputIdx: 0,
+					},
+					// Pool reference script
+					{
+						TxId:      "8036a88a61427262aba964a42d0b9924739ffc3214de9a07c54b5a09af7f0d7d",
+						OutputIdx: 0,
+					},
+				},
+			},
+		},
 		"teddyswap": {
 			Name:          "teddyswap",
 			Type:          ProfileTypeSpectrum,

--- a/internal/config/profiles_test.go
+++ b/internal/config/profiles_test.go
@@ -90,3 +90,101 @@ func TestMainnetSundaeSwapV1ProfileIsWired(t *testing.T) {
 		t.Fatalf("pool address has unexpected format: %q", oracleCfg.PoolAddresses[0].Address)
 	}
 }
+
+func TestPreprodMinswapV2ProfileIsWired(t *testing.T) {
+	t.Parallel()
+
+	profile := requireProfile(t, "preprod", "minswap-v2")
+
+	if profile.Type != ProfileTypeOracle {
+		t.Fatalf("unexpected profile type: got %v want %v", profile.Type, ProfileTypeOracle)
+	}
+	if profile.InterceptSlot != 62910357 {
+		t.Fatalf("unexpected intercept slot: got %d want %d", profile.InterceptSlot, 62910357)
+	}
+	if profile.InterceptHash != "42d965bbc11668723b3bc3741a969c2750d2df0d16714a0af63b4ef2ee221eb1" {
+		t.Fatalf("unexpected intercept hash: got %q", profile.InterceptHash)
+	}
+
+	oracleCfg, ok := profile.Config.(OracleProfileConfig)
+	if !ok {
+		t.Fatalf("unexpected config type: %T", profile.Config)
+	}
+	if oracleCfg.Protocol != "minswap-v2" {
+		t.Fatalf("unexpected protocol: got %q want %q", oracleCfg.Protocol, "minswap-v2")
+	}
+	if len(oracleCfg.PoolAddresses) != 1 {
+		t.Fatalf("unexpected pool address count: got %d want 1", len(oracleCfg.PoolAddresses))
+	}
+	if oracleCfg.PoolAddresses[0].Address != "addr_test1wrtt4xm4p84vse3g3l6swtf2rqs943t0w39ustwdszxt3lsyrt40u" {
+		t.Fatalf("unexpected pool address: %q", oracleCfg.PoolAddresses[0].Address)
+	}
+	if len(oracleCfg.InputRefs) != 1 {
+		t.Fatalf("unexpected input ref count: got %d want 1", len(oracleCfg.InputRefs))
+	}
+	if oracleCfg.InputRefs[0] != (ProfileConfigInputRef{
+		TxId:      "9f30b1c3948a009ceebda32d0b1d25699674b2eaf8b91ef029a43bfc1073ce28",
+		OutputIdx: 0,
+	}) {
+		t.Fatalf("unexpected input ref: %#v", oracleCfg.InputRefs[0])
+	}
+}
+
+func TestPreviewSundaeSwapV3ProfileIsWired(t *testing.T) {
+	t.Parallel()
+
+	profile := requireProfile(t, "preview", "sundaeswap-v3")
+
+	if profile.Type != ProfileTypeOracle {
+		t.Fatalf("unexpected profile type: got %v want %v", profile.Type, ProfileTypeOracle)
+	}
+	if profile.InterceptSlot != 48535234 {
+		t.Fatalf("unexpected intercept slot: got %d want %d", profile.InterceptSlot, 48535234)
+	}
+	if profile.InterceptHash != "311319fd4889453ddbba6fde8b085cd1ec8d7d341e6128c003ad8cbbfbf09043" {
+		t.Fatalf("unexpected intercept hash: got %q", profile.InterceptHash)
+	}
+
+	oracleCfg, ok := profile.Config.(OracleProfileConfig)
+	if !ok {
+		t.Fatalf("unexpected config type: %T", profile.Config)
+	}
+	if oracleCfg.Protocol != "sundaeswap-v3" {
+		t.Fatalf("unexpected protocol: got %q want %q", oracleCfg.Protocol, "sundaeswap-v3")
+	}
+	if len(oracleCfg.PoolAddresses) != 1 {
+		t.Fatalf("unexpected pool address count: got %d want 1", len(oracleCfg.PoolAddresses))
+	}
+	if oracleCfg.PoolAddresses[0].Address != "addr_test1xpz2r6ednav2m48tryet6qzgu6segl59u0ly7v54dggsg9xvy7vq4p2hl6wm9jdvpgn80ax3xpkm7yrgnxphtrct3klq005j2r" {
+		t.Fatalf("unexpected pool address: %q", oracleCfg.PoolAddresses[0].Address)
+	}
+	if len(oracleCfg.InputRefs) != 2 {
+		t.Fatalf("unexpected input ref count: got %d want 2", len(oracleCfg.InputRefs))
+	}
+	if oracleCfg.InputRefs[0] != (ProfileConfigInputRef{
+		TxId:      "92ec2274938de291d3837b7facf9eddfaed57cd6ff97e26af57cb7a9978e3887",
+		OutputIdx: 0,
+	}) {
+		t.Fatalf("unexpected order input ref: %#v", oracleCfg.InputRefs[0])
+	}
+	if oracleCfg.InputRefs[1] != (ProfileConfigInputRef{
+		TxId:      "8036a88a61427262aba964a42d0b9924739ffc3214de9a07c54b5a09af7f0d7d",
+		OutputIdx: 0,
+	}) {
+		t.Fatalf("unexpected pool input ref: %#v", oracleCfg.InputRefs[1])
+	}
+}
+
+func requireProfile(t *testing.T, network string, name string) Profile {
+	t.Helper()
+
+	networkProfiles, ok := Profiles[network]
+	if !ok {
+		t.Fatalf("missing %s profiles", network)
+	}
+	profile, ok := networkProfiles[name]
+	if !ok {
+		t.Fatalf("missing %s profile", name)
+	}
+	return profile
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds testnet oracle profiles for Minswap V2 on `preprod` and SundaeSwap V3 on `preview`, enabling local testing of oracle coverage. Also adds `preprod` network config, helper address builders, docs, and tests.

- **New Features**
  - Added `preprod` network to config.
  - Added oracle profiles:
    - `preprod`: `minswap-v2` (pool script address + ref script).
    - `preview`: `sundaeswap-v3` (pool script address + order/pool ref scripts).
  - Introduced helpers to build script addresses for profiles.
  - Updated README:
    - `NETWORK` now supports `mainnet`, `preprod`, `preview`.
    - Usage: `NETWORK=preprod PROFILES=minswap-v2` and `NETWORK=preview PROFILES=sundaeswap-v3`.
  - Added tests to verify profile wiring, addresses, and input refs.

<sup>Written for commit fc6b6655c2ceb04c52df30ec5dcb51e036ec2f9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/shai/pull/352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

