### PR TITLE
feat: derive ADA/USD from local stablecoin pools

### DIFF
--- a/internal/oracle/api.go
+++ b/internal/oracle/api.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/blinklabs-io/shai/internal/logging"
+	shaiprice "github.com/blinklabs-io/shai/price"
 	"github.com/gorilla/websocket"
 )
 
@@ -183,6 +184,7 @@ func (a *OracleAPI) RegisterHandlers(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/v1/cdps", a.HandleListCDPs)
 	mux.HandleFunc("GET /api/v1/cdps/{cdpId}", a.HandleGetCDP)
 	mux.HandleFunc("GET /api/v1/prices", a.HandleListPrices)
+	mux.HandleFunc("GET /api/v1/prices/ada-usd", a.HandleADAUSDPrice)
 	mux.HandleFunc("/ws/prices", a.HandlePriceStream)
 	a.startBroadcastPriceUpdates()
 }
@@ -336,6 +338,28 @@ func (a *OracleAPI) HandleListPrices(w http.ResponseWriter, r *http.Request) {
 		"prices": prices,
 		"count":  len(prices),
 	})
+}
+
+// HandleADAUSDPrice returns an ADA/USD estimate derived only from qualified
+// locally tracked ADA/stablecoin DEX pools.
+func (a *OracleAPI) HandleADAUSDPrice(
+	w http.ResponseWriter,
+	_ *http.Request,
+) {
+	result, err := shaiprice.AggregateADAUSD(
+		a.getAllPools(),
+		shaiprice.DefaultConfig(),
+	)
+	w.Header().Set("Content-Type", "application/json")
+	if err != nil {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"error":  err.Error(),
+			"result": result,
+		})
+		return
+	}
+	_ = json.NewEncoder(w).Encode(result)
 }
 
 // HandlePriceStream handles WebSocket connections for price streaming

--- a/internal/oracle/api_test.go
+++ b/internal/oracle/api_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/blinklabs-io/shai/common"
+	shaiprice "github.com/blinklabs-io/shai/price"
 	"github.com/gorilla/websocket"
 )
 
@@ -190,6 +191,88 @@ func TestHandleListPrices(t *testing.T) {
 	}
 	if response.Count != 2 {
 		t.Fatalf("expected count 2, got %d", response.Count)
+	}
+}
+
+func TestHandleADAUSDPriceFromLocalPools(t *testing.T) {
+	usdm, err := common.NewAssetClass(
+		shaiprice.USDMPolicyID,
+		shaiprice.USDMAssetName,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	usdcx, err := common.NewAssetClass(
+		shaiprice.USDCxPolicyID,
+		shaiprice.USDCxAssetName,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	o := &Oracle{
+		pools: map[string]*PoolState{
+			"usdm": {
+				PoolId:   "usdm",
+				Protocol: "cswap",
+				AssetX: common.AssetAmount{
+					Class:  common.Lovelace(),
+					Amount: 4_579_285_253,
+				},
+				AssetY: common.AssetAmount{
+					Class:  usdm,
+					Amount: 774_654_393,
+				},
+			},
+			"usdcx": {
+				PoolId:   "usdcx",
+				Protocol: "cswap",
+				AssetX: common.AssetAmount{
+					Class:  common.Lovelace(),
+					Amount: 8_547_275_688,
+				},
+				AssetY: common.AssetAmount{
+					Class:  usdcx,
+					Amount: 1_439_463_431,
+				},
+			},
+		},
+		stopChan: make(chan struct{}),
+	}
+	api := NewOracleAPI(o)
+	mux := http.NewServeMux()
+	api.RegisterHandlers(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/prices/ada-usd", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var response shaiprice.Result
+	if err := json.Unmarshal(rr.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if response.Pair != "ADA/USD" {
+		t.Fatalf("expected ADA/USD, got %s", response.Pair)
+	}
+	if response.Price < 0.16 || response.Price > 0.18 {
+		t.Fatalf("unexpected ADA/USD price %f", response.Price)
+	}
+	if len(response.Observations) != 2 {
+		t.Fatalf("expected 2 observations, got %d", len(response.Observations))
+	}
+}
+
+func TestHandleADAUSDPriceUnavailableWithoutDiversity(t *testing.T) {
+	api := NewOracleAPI(newTestOracleWithPools())
+	mux := http.NewServeMux()
+	api.RegisterHandlers(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/prices/ada-usd", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected status 503, got %d", rr.Code)
 	}
 }
 

--- a/price/ada_usd.go
+++ b/price/ada_usd.go
@@ -18,8 +18,10 @@ package price
 import (
 	"errors"
 	"fmt"
+	"math"
 	"math/big"
 	"sort"
+	"strconv"
 
 	"github.com/blinklabs-io/shai/common"
 	"github.com/blinklabs-io/shai/dex"
@@ -131,21 +133,29 @@ func AggregateADAUSD(
 	if len(symbols) < config.MinStablecoins {
 		return result, ErrInsufficientDiversity
 	}
+	if totalWeight == 0 {
+		return result, ErrInsufficientObservations
+	}
+	maxPoolShare := configRatio(config.MaxPoolShare)
 	for _, observation := range observations {
-		share := float64(observation.StableMicros) / float64(totalWeight)
-		if share > config.MaxPoolShare {
+		share := new(big.Rat).SetFrac(
+			new(big.Int).SetUint64(observation.StableMicros),
+			new(big.Int).SetUint64(totalWeight),
+		)
+		if share.Cmp(maxPoolShare) > 0 {
 			return result, ErrConcentratedLiquidity
 		}
 	}
 
-	minPrice, maxPrice := observations[0].Price, observations[0].Price
+	minPrice := new(big.Rat).Set(observations[0].price)
+	maxPrice := new(big.Rat).Set(observations[0].price)
 	weightedPrice := new(big.Rat)
 	for _, observation := range observations {
-		if observation.Price < minPrice {
-			minPrice = observation.Price
+		if observation.price.Cmp(minPrice) < 0 {
+			minPrice.Set(observation.price)
 		}
-		if observation.Price > maxPrice {
-			maxPrice = observation.Price
+		if observation.price.Cmp(maxPrice) > 0 {
+			maxPrice.Set(observation.price)
 		}
 		term := new(big.Rat).Mul(
 			observation.price,
@@ -155,8 +165,12 @@ func AggregateADAUSD(
 		)
 		weightedPrice.Add(weightedPrice, term)
 	}
-	result.Spread = (maxPrice - minPrice) / minPrice
-	if result.Spread > config.MaxDivergence {
+	spread := new(big.Rat).Quo(
+		new(big.Rat).Sub(maxPrice, minPrice),
+		minPrice,
+	)
+	result.Spread, _ = spread.Float64()
+	if spread.Cmp(configRatio(config.MaxDivergence)) > 0 {
 		return result, ErrDivergentPrices
 	}
 	weightedPrice.Quo(
@@ -181,7 +195,13 @@ func observationsFromPools(
 		}
 		key := pool.Protocol + ":" + pool.PoolId
 		current, ok := latest[key]
-		if !ok || pool.Slot > current.Slot {
+		if !ok ||
+			pool.Slot > current.Slot ||
+			(pool.Slot == current.Slot &&
+				pool.TxIndex > current.TxIndex) ||
+			(pool.Slot == current.Slot &&
+				pool.TxIndex == current.TxIndex &&
+				pool.TxHash > current.TxHash) {
 			latest[key] = pool
 		}
 	}
@@ -228,7 +248,10 @@ func observationFromPool(
 			break
 		}
 	}
-	if stablecoin.Symbol == "" || ada.Amount < config.MinADAReserve {
+	if stablecoin.Symbol == "" ||
+		ada.Amount == 0 ||
+		stable.Amount == 0 ||
+		ada.Amount < config.MinADAReserve {
 		return PoolObservation{}, false
 	}
 	stableMicros, ok := normalizeToMicros(stable.Amount, stablecoin.Decimals)
@@ -292,13 +315,28 @@ func validateConfig(config Config) error {
 	if config.MinObservations < 1 || config.MinStablecoins < 1 {
 		return errors.New("price: minimum counts must be positive")
 	}
-	if config.MaxPoolShare <= 0 || config.MaxPoolShare > 1 {
+	if math.IsNaN(config.MaxPoolShare) ||
+		math.IsInf(config.MaxPoolShare, 0) ||
+		config.MaxPoolShare <= 0 ||
+		config.MaxPoolShare > 1 {
 		return errors.New("price: max pool share must be in (0,1]")
 	}
-	if config.MaxDivergence < 0 {
+	if math.IsNaN(config.MaxDivergence) ||
+		math.IsInf(config.MaxDivergence, 0) ||
+		config.MaxDivergence < 0 {
 		return errors.New("price: max divergence must be non-negative")
 	}
 	return nil
+}
+
+func configRatio(value float64) *big.Rat {
+	ratio, ok := new(big.Rat).SetString(
+		strconv.FormatFloat(value, 'g', -1, 64),
+	)
+	if !ok {
+		panic("validated floating-point configuration is not rational")
+	}
+	return ratio
 }
 
 func pow10Uint(power uint8) uint64 {

--- a/price/ada_usd.go
+++ b/price/ada_usd.go
@@ -1,0 +1,321 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package price derives prices solely from locally supplied Cardano state.
+package price
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+	"sort"
+
+	"github.com/blinklabs-io/shai/common"
+	"github.com/blinklabs-io/shai/dex"
+)
+
+var (
+	ErrInsufficientObservations = errors.New("price: insufficient qualified ADA/stablecoin pools")
+	ErrInsufficientDiversity    = errors.New("price: insufficient stablecoin diversity")
+	ErrConcentratedLiquidity    = errors.New("price: one pool dominates qualified liquidity")
+	ErrDivergentPrices          = errors.New("price: qualified pool prices diverge")
+)
+
+const usdMicrosDecimals = 6
+
+// Config controls qualification and agreement for ADA/USD pool observations.
+type Config struct {
+	Stablecoins     []Stablecoin
+	MinADAReserve   uint64
+	MinStableUSD    uint64
+	MinObservations int
+	MinStablecoins  int
+	MaxPoolShare    float64
+	MaxDivergence   float64
+	IncludeMempool  bool
+}
+
+// DefaultConfig is conservative enough to reject dust pools while accepting
+// the independently pegged mainnet USDM and USDCx CSWAP pools observed during
+// implementation.
+func DefaultConfig() Config {
+	return Config{
+		Stablecoins:     MainnetStablecoins(),
+		MinADAReserve:   1_000_000_000,
+		MinStableUSD:    100_000_000,
+		MinObservations: 2,
+		MinStablecoins:  2,
+		MaxPoolShare:    0.75,
+		MaxDivergence:   0.05,
+	}
+}
+
+// PoolObservation is one qualified ADA/stablecoin spot price.
+type PoolObservation struct {
+	PoolID        string  `json:"poolId"`
+	Protocol      string  `json:"protocol"`
+	Stablecoin    string  `json:"stablecoin"`
+	ADAReserve    uint64  `json:"adaReserve"`
+	StableReserve uint64  `json:"stableReserve"`
+	StableMicros  uint64  `json:"stableMicros"`
+	PriceNum      string  `json:"priceNumerator"`
+	PriceDen      string  `json:"priceDenominator"`
+	Price         float64 `json:"price"`
+	Slot          uint64  `json:"slot"`
+	TxHash        string  `json:"txHash"`
+	TxIndex       uint32  `json:"txIndex"`
+
+	price *big.Rat
+}
+
+// Result is a liquidity-weighted local ADA/USD estimate.
+type Result struct {
+	Pair         string            `json:"pair"`
+	Method       string            `json:"method"`
+	PriceNum     string            `json:"priceNumerator"`
+	PriceDen     string            `json:"priceDenominator"`
+	Price        float64           `json:"price"`
+	Spread       float64           `json:"spread"`
+	Observations []PoolObservation `json:"observations"`
+
+	price *big.Rat
+}
+
+// Rat returns a copy of the exact aggregate price.
+func (r Result) Rat() *big.Rat {
+	if r.price == nil {
+		return new(big.Rat)
+	}
+	return new(big.Rat).Set(r.price)
+}
+
+// AggregateADAUSD qualifies ADA/stablecoin pools, enforces diversity and
+// agreement, then computes a stablecoin-liquidity-weighted mean.
+func AggregateADAUSD(
+	pools []*dex.PoolState,
+	config Config,
+) (Result, error) {
+	if err := validateConfig(config); err != nil {
+		return Result{}, err
+	}
+	observations := observationsFromPools(pools, config)
+	result := Result{
+		Pair:         "ADA/USD",
+		Method:       "local-dex-stablecoin-weighted",
+		Observations: observations,
+	}
+	if len(observations) < config.MinObservations {
+		return result, ErrInsufficientObservations
+	}
+
+	symbols := make(map[string]struct{}, len(observations))
+	var totalWeight uint64
+	for _, observation := range observations {
+		symbols[observation.Stablecoin] = struct{}{}
+		if ^uint64(0)-totalWeight < observation.StableMicros {
+			return result, fmt.Errorf("price: aggregate liquidity overflows uint64")
+		}
+		totalWeight += observation.StableMicros
+	}
+	if len(symbols) < config.MinStablecoins {
+		return result, ErrInsufficientDiversity
+	}
+	for _, observation := range observations {
+		share := float64(observation.StableMicros) / float64(totalWeight)
+		if share > config.MaxPoolShare {
+			return result, ErrConcentratedLiquidity
+		}
+	}
+
+	minPrice, maxPrice := observations[0].Price, observations[0].Price
+	weightedPrice := new(big.Rat)
+	for _, observation := range observations {
+		if observation.Price < minPrice {
+			minPrice = observation.Price
+		}
+		if observation.Price > maxPrice {
+			maxPrice = observation.Price
+		}
+		term := new(big.Rat).Mul(
+			observation.price,
+			new(big.Rat).SetInt(
+				new(big.Int).SetUint64(observation.StableMicros),
+			),
+		)
+		weightedPrice.Add(weightedPrice, term)
+	}
+	result.Spread = (maxPrice - minPrice) / minPrice
+	if result.Spread > config.MaxDivergence {
+		return result, ErrDivergentPrices
+	}
+	weightedPrice.Quo(
+		weightedPrice,
+		new(big.Rat).SetInt(new(big.Int).SetUint64(totalWeight)),
+	)
+	result.price = weightedPrice
+	result.PriceNum = weightedPrice.Num().String()
+	result.PriceDen = weightedPrice.Denom().String()
+	result.Price, _ = weightedPrice.Float64()
+	return result, nil
+}
+
+func observationsFromPools(
+	pools []*dex.PoolState,
+	config Config,
+) []PoolObservation {
+	latest := make(map[string]*dex.PoolState)
+	for _, pool := range pools {
+		if pool == nil || (!config.IncludeMempool && pool.FromMempool) {
+			continue
+		}
+		key := pool.Protocol + ":" + pool.PoolId
+		current, ok := latest[key]
+		if !ok || pool.Slot > current.Slot {
+			latest[key] = pool
+		}
+	}
+
+	var observations []PoolObservation
+	for _, pool := range latest {
+		observation, ok := observationFromPool(pool, config)
+		if ok {
+			observations = append(observations, observation)
+		}
+	}
+	sort.Slice(observations, func(i, j int) bool {
+		if observations[i].Stablecoin != observations[j].Stablecoin {
+			return observations[i].Stablecoin < observations[j].Stablecoin
+		}
+		if observations[i].Protocol != observations[j].Protocol {
+			return observations[i].Protocol < observations[j].Protocol
+		}
+		return observations[i].PoolID < observations[j].PoolID
+	})
+	return observations
+}
+
+func observationFromPool(
+	pool *dex.PoolState,
+	config Config,
+) (PoolObservation, bool) {
+	var ada common.AssetAmount
+	var stable common.AssetAmount
+	var stablecoin Stablecoin
+	switch {
+	case pool.AssetX.IsLovelace():
+		ada = pool.AssetX
+		stable = pool.AssetY
+	case pool.AssetY.IsLovelace():
+		ada = pool.AssetY
+		stable = pool.AssetX
+	default:
+		return PoolObservation{}, false
+	}
+	for _, candidate := range config.Stablecoins {
+		if stable.IsAsset(candidate.Asset) {
+			stablecoin = candidate
+			break
+		}
+	}
+	if stablecoin.Symbol == "" || ada.Amount < config.MinADAReserve {
+		return PoolObservation{}, false
+	}
+	stableMicros, ok := normalizeToMicros(stable.Amount, stablecoin.Decimals)
+	if !ok || stableMicros < config.MinStableUSD {
+		return PoolObservation{}, false
+	}
+	price := new(big.Rat).SetFrac(
+		new(big.Int).Mul(
+			new(big.Int).SetUint64(stable.Amount),
+			pow10Big(usdMicrosDecimals),
+		),
+		new(big.Int).Mul(
+			new(big.Int).SetUint64(ada.Amount),
+			pow10Big(stablecoin.Decimals),
+		),
+	)
+	priceFloat, _ := price.Float64()
+	return PoolObservation{
+		PoolID:        pool.PoolId,
+		Protocol:      pool.Protocol,
+		Stablecoin:    stablecoin.Symbol,
+		ADAReserve:    ada.Amount,
+		StableReserve: stable.Amount,
+		StableMicros:  stableMicros,
+		PriceNum:      price.Num().String(),
+		PriceDen:      price.Denom().String(),
+		Price:         priceFloat,
+		Slot:          pool.Slot,
+		TxHash:        pool.TxHash,
+		TxIndex:       pool.TxIndex,
+		price:         price,
+	}, true
+}
+
+func normalizeToMicros(
+	amount uint64,
+	decimals uint8,
+) (uint64, bool) {
+	switch {
+	case decimals == usdMicrosDecimals:
+		return amount, true
+	case decimals < usdMicrosDecimals:
+		multiplier := pow10Uint(usdMicrosDecimals - decimals)
+		if multiplier == 0 || amount > ^uint64(0)/multiplier {
+			return 0, false
+		}
+		return amount * multiplier, true
+	default:
+		divisor := pow10Uint(decimals - usdMicrosDecimals)
+		if divisor == 0 {
+			return 0, false
+		}
+		return amount / divisor, true
+	}
+}
+
+func validateConfig(config Config) error {
+	if len(config.Stablecoins) == 0 {
+		return errors.New("price: no stablecoins configured")
+	}
+	if config.MinObservations < 1 || config.MinStablecoins < 1 {
+		return errors.New("price: minimum counts must be positive")
+	}
+	if config.MaxPoolShare <= 0 || config.MaxPoolShare > 1 {
+		return errors.New("price: max pool share must be in (0,1]")
+	}
+	if config.MaxDivergence < 0 {
+		return errors.New("price: max divergence must be non-negative")
+	}
+	return nil
+}
+
+func pow10Uint(power uint8) uint64 {
+	var value uint64 = 1
+	for range power {
+		if value > ^uint64(0)/10 {
+			return 0
+		}
+		value *= 10
+	}
+	return value
+}
+
+func pow10Big(power uint8) *big.Int {
+	return new(big.Int).Exp(
+		big.NewInt(10),
+		new(big.Int).SetUint64(uint64(power)),
+		nil,
+	)
+}

--- a/price/ada_usd_test.go
+++ b/price/ada_usd_test.go
@@ -1,0 +1,200 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package price
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/blinklabs-io/shai/common"
+	"github.com/blinklabs-io/shai/dex"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAggregateADAUSDCurrentCSwapFixtures(t *testing.T) {
+	// Current unspent mainnet CSWAP pools checked on 2026-07-23.
+	pools := []*dex.PoolState{
+		poolFixture(
+			t,
+			"usdcx",
+			USDCxPolicyID,
+			USDCxAssetName,
+			8_547_275_688,
+			1_439_463_431,
+			"a24fd5df3faebb06ba0aa815890d5c7e3907c27f428c906b792d81321254a8d1",
+			1,
+		),
+		poolFixture(
+			t,
+			"usdm",
+			USDMPolicyID,
+			USDMAssetName,
+			4_579_285_253,
+			774_654_393,
+			"1237c072b8d283e3ccc3b9956502825f11533973b5402ed1ef1df459ffca8bfc",
+			1,
+		),
+	}
+
+	result, err := AggregateADAUSD(pools, DefaultConfig())
+	require.NoError(t, err)
+	require.Equal(t, "ADA/USD", result.Pair)
+	require.Equal(t, "local-dex-stablecoin-weighted", result.Method)
+	require.Len(t, result.Observations, 2)
+	require.Less(t, result.Spread, 0.01)
+	require.InDelta(t, 0.16868, result.Price, 0.0001)
+	require.NotZero(t, result.PriceNum)
+	require.NotZero(t, result.PriceDen)
+}
+
+func TestAggregateADAUSDRequiresStablecoinDiversity(t *testing.T) {
+	pool := poolFixture(
+		t,
+		"usdcx",
+		USDCxPolicyID,
+		USDCxAssetName,
+		8_547_275_688,
+		1_439_463_431,
+		"one",
+		1,
+	)
+	duplicate := *pool
+	duplicate.PoolId = "usdcx-2"
+	duplicate.TxHash = "two"
+
+	_, err := AggregateADAUSD(
+		[]*dex.PoolState{pool, &duplicate},
+		DefaultConfig(),
+	)
+	require.ErrorIs(t, err, ErrInsufficientDiversity)
+}
+
+func TestAggregateADAUSDRejectsDivergenceAndMempool(t *testing.T) {
+	usdcx := poolFixture(
+		t,
+		"usdcx",
+		USDCxPolicyID,
+		USDCxAssetName,
+		5_000_000_000,
+		1_000_000_000,
+		"one",
+		1,
+	)
+	usdm := poolFixture(
+		t,
+		"usdm",
+		USDMPolicyID,
+		USDMAssetName,
+		5_000_000_000,
+		500_000_000,
+		"two",
+		1,
+	)
+	_, err := AggregateADAUSD(
+		[]*dex.PoolState{usdcx, usdm},
+		DefaultConfig(),
+	)
+	require.ErrorIs(t, err, ErrDivergentPrices)
+
+	usdm.FromMempool = true
+	_, err = AggregateADAUSD(
+		[]*dex.PoolState{usdcx, usdm},
+		DefaultConfig(),
+	)
+	require.True(t, errors.Is(err, ErrInsufficientObservations))
+}
+
+func TestAggregateADAUSDRejectsThinAndConcentratedPools(t *testing.T) {
+	thin := poolFixture(
+		t,
+		"thin",
+		USDCxPolicyID,
+		USDCxAssetName,
+		999_999_999,
+		200_000_000,
+		"thin",
+		1,
+	)
+	_, err := AggregateADAUSD([]*dex.PoolState{thin}, DefaultConfig())
+	require.ErrorIs(t, err, ErrInsufficientObservations)
+
+	usdcx := poolFixture(
+		t,
+		"usdcx",
+		USDCxPolicyID,
+		USDCxAssetName,
+		20_000_000_000,
+		3_000_000_000,
+		"one",
+		1,
+	)
+	usdm := poolFixture(
+		t,
+		"usdm",
+		USDMPolicyID,
+		USDMAssetName,
+		1_000_000_000,
+		150_000_000,
+		"two",
+		1,
+	)
+	_, err = AggregateADAUSD(
+		[]*dex.PoolState{usdcx, usdm},
+		DefaultConfig(),
+	)
+	require.ErrorIs(t, err, ErrConcentratedLiquidity)
+}
+
+func TestMainnetStablecoinRegistry(t *testing.T) {
+	stablecoins := MainnetStablecoins()
+	require.Len(t, stablecoins, 2)
+	require.Equal(t, "USDM", stablecoins[0].Symbol)
+	require.Equal(t, USDMPolicyID, stablecoins[0].Asset.PolicyIdHex())
+	require.Equal(t, USDMAssetName, stablecoins[0].Asset.NameHex())
+	require.Equal(t, uint8(6), stablecoins[0].Decimals)
+	require.Equal(t, "USDCx", stablecoins[1].Symbol)
+	require.Equal(t, USDCxPolicyID, stablecoins[1].Asset.PolicyIdHex())
+	require.Equal(t, USDCxAssetName, stablecoins[1].Asset.NameHex())
+}
+
+func poolFixture(
+	t *testing.T,
+	id,
+	policyID,
+	assetName string,
+	ada,
+	stable uint64,
+	txHash string,
+	txIndex uint32,
+) *dex.PoolState {
+	t.Helper()
+	asset, err := common.NewAssetClass(policyID, assetName)
+	require.NoError(t, err)
+	return &dex.PoolState{
+		PoolId:   id,
+		Protocol: "cswap",
+		AssetX: common.AssetAmount{
+			Class:  common.Lovelace(),
+			Amount: ada,
+		},
+		AssetY: common.AssetAmount{
+			Class:  asset,
+			Amount: stable,
+		},
+		Slot:    193_000_000,
+		TxHash:  txHash,
+		TxIndex: txIndex,
+	}
+}

--- a/price/ada_usd_test.go
+++ b/price/ada_usd_test.go
@@ -16,6 +16,7 @@ package price
 
 import (
 	"errors"
+	"math"
 	"testing"
 
 	"github.com/blinklabs-io/shai/common"
@@ -157,6 +158,127 @@ func TestAggregateADAUSDRejectsThinAndConcentratedPools(t *testing.T) {
 	require.ErrorIs(t, err, ErrConcentratedLiquidity)
 }
 
+func TestAggregateADAUSDAllowsExactDivergenceLimit(t *testing.T) {
+	config := DefaultConfig()
+	config.MinADAReserve = 0
+	config.MinStableUSD = 0
+	config.MaxDivergence = 0.05
+	pools := []*dex.PoolState{
+		poolFixture(
+			t,
+			"usdcx",
+			USDCxPolicyID,
+			USDCxAssetName,
+			10_000_000_000,
+			1_000_000_000,
+			"one",
+			1,
+		),
+		poolFixture(
+			t,
+			"usdm",
+			USDMPolicyID,
+			USDMAssetName,
+			10_000_000_000,
+			1_050_000_000,
+			"two",
+			1,
+		),
+	}
+
+	result, err := AggregateADAUSD(pools, config)
+	require.NoError(t, err)
+	require.Equal(t, 0.05, result.Spread)
+}
+
+func TestAggregateADAUSDRejectsZeroReservesWithZeroThresholds(t *testing.T) {
+	config := DefaultConfig()
+	config.MinADAReserve = 0
+	config.MinStableUSD = 0
+	config.MinObservations = 1
+	config.MinStablecoins = 1
+	config.MaxPoolShare = 1
+
+	for _, amounts := range []struct {
+		name   string
+		ada    uint64
+		stable uint64
+	}{
+		{name: "ADA", stable: 1_000_000},
+		{name: "stablecoin", ada: 1_000_000},
+	} {
+		t.Run(amounts.name, func(t *testing.T) {
+			pool := poolFixture(
+				t,
+				"zero",
+				USDCxPolicyID,
+				USDCxAssetName,
+				amounts.ada,
+				amounts.stable,
+				"zero",
+				1,
+			)
+			_, err := AggregateADAUSD([]*dex.PoolState{pool}, config)
+			require.ErrorIs(t, err, ErrInsufficientObservations)
+		})
+	}
+}
+
+func TestObservationsFromPoolsUsesLatestSameSlotOutput(t *testing.T) {
+	older := poolFixture(
+		t,
+		"usdcx",
+		USDCxPolicyID,
+		USDCxAssetName,
+		8_000_000_000,
+		1_000_000_000,
+		"older",
+		1,
+	)
+	newer := poolFixture(
+		t,
+		"usdcx",
+		USDCxPolicyID,
+		USDCxAssetName,
+		8_000_000_000,
+		1_250_000_000,
+		"newer",
+		2,
+	)
+
+	observations := observationsFromPools(
+		[]*dex.PoolState{newer, older},
+		DefaultConfig(),
+	)
+	require.Len(t, observations, 1)
+	require.Equal(t, uint32(2), observations[0].TxIndex)
+	require.Equal(t, uint64(1_250_000_000), observations[0].StableReserve)
+}
+
+func TestAggregateADAUSDRejectsNonFiniteConfig(t *testing.T) {
+	pool := poolFixture(
+		t,
+		"usdcx",
+		USDCxPolicyID,
+		USDCxAssetName,
+		8_000_000_000,
+		1_000_000_000,
+		"one",
+		1,
+	)
+	for _, value := range []float64{math.NaN(), math.Inf(1), math.Inf(-1)} {
+		config := DefaultConfig()
+		config.MaxPoolShare = value
+		_, err := AggregateADAUSD([]*dex.PoolState{pool}, config)
+		require.Error(t, err)
+
+		config = DefaultConfig()
+		config.MaxDivergence = value
+		_, err = AggregateADAUSD([]*dex.PoolState{pool}, config)
+		require.Error(t, err)
+	}
+}
+
 func TestMainnetStablecoinRegistry(t *testing.T) {
 	stablecoins := MainnetStablecoins()
 	require.Len(t, stablecoins, 2)
@@ -167,6 +289,7 @@ func TestMainnetStablecoinRegistry(t *testing.T) {
 	require.Equal(t, "USDCx", stablecoins[1].Symbol)
 	require.Equal(t, USDCxPolicyID, stablecoins[1].Asset.PolicyIdHex())
 	require.Equal(t, USDCxAssetName, stablecoins[1].Asset.NameHex())
+	require.Equal(t, uint8(6), stablecoins[1].Decimals)
 }
 
 func poolFixture(

--- a/price/stablecoins.go
+++ b/price/stablecoins.go
@@ -1,0 +1,61 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package price
+
+import (
+	"github.com/blinklabs-io/shai/common"
+)
+
+const (
+	USDMPolicyID  = "c48cbb3d5e57ed56e276bc45f99ab39abe94e6cd7ac39fb402da47ad"
+	USDMAssetName = "0014df105553444d"
+
+	USDCxPolicyID  = "1f3aec8bfe7ea4fe14c5f121e2a92e301afe414147860d557cac7e34"
+	USDCxAssetName = "5553444378"
+)
+
+// Stablecoin is an explicitly authenticated dollar-pegged Cardano asset.
+// Decimals are display units; on-chain quantities remain integers.
+type Stablecoin struct {
+	Symbol   string
+	Asset    common.AssetClass
+	Decimals uint8
+}
+
+// MainnetStablecoins returns the reviewed stablecoin registry used for local
+// ADA/USD pool observations.
+func MainnetStablecoins() []Stablecoin {
+	return []Stablecoin{
+		mustStablecoin("USDM", USDMPolicyID, USDMAssetName, 6),
+		mustStablecoin("USDCx", USDCxPolicyID, USDCxAssetName, 6),
+	}
+}
+
+func mustStablecoin(
+	symbol,
+	policyID,
+	assetName string,
+	decimals uint8,
+) Stablecoin {
+	asset, err := common.NewAssetClass(policyID, assetName)
+	if err != nil {
+		panic(err)
+	}
+	return Stablecoin{
+		Symbol:   symbol,
+		Asset:    asset,
+		Decimals: decimals,
+	}
+}


### PR DESCRIPTION
Derives ADA/USD from locally tracked USDM and USDCx pools.

Adds liquidity, diversity, concentration, and divergence gates plus `GET /api/v1/prices/ada-usd`.

Tests: `go test ./...`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a local ADA/USD price derived from tracked ADA/stablecoin DEX pools and exposes it via GET /api/v1/prices/ada-usd. Adds spread and rational price fields and hardens validation for safer results.

- **New Features**
  - New endpoint GET /api/v1/prices/ada-usd. Returns a stablecoin-liquidity-weighted ADA/USD estimate plus per-pool observations; 503 with error when gates fail.
  - Aggregation in `price` (`AggregateADAUSD`, `DefaultConfig`) using only local pools and excluding mempool. Picks the latest state per pool, normalizes to USD micros, and returns spread plus exact numerators/denominators.
  - Qualification gates: min ADA and stable reserves, at least two stablecoins, max 75% single-pool share, max 5% price spread. Adds strict config validation and overflow checks; tests included.

<sup>Written for commit baa40951c030f339c61a6157d71bda3b25e0d02a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/shai/pull/364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

