### PR TITLE
feat: report ADA USD provenance

### DIFF
--- a/internal/oracle/api_test.go
+++ b/internal/oracle/api_test.go
@@ -195,6 +195,7 @@ func TestHandleListPrices(t *testing.T) {
 }
 
 func TestHandleADAUSDPriceFromLocalPools(t *testing.T) {
+	observedAt := time.Now().Add(-time.Minute)
 	usdm, err := common.NewAssetClass(
 		shaiprice.USDMPolicyID,
 		shaiprice.USDMAssetName,
@@ -212,8 +213,10 @@ func TestHandleADAUSDPriceFromLocalPools(t *testing.T) {
 	o := &Oracle{
 		pools: map[string]*PoolState{
 			"usdm": {
-				PoolId:   "usdm",
-				Protocol: "cswap",
+				PoolId:    "usdm",
+				Protocol:  "cswap",
+				BlockHash: "usdm-block",
+				Timestamp: observedAt,
 				AssetX: common.AssetAmount{
 					Class:  common.Lovelace(),
 					Amount: 4_579_285_253,
@@ -224,8 +227,10 @@ func TestHandleADAUSDPriceFromLocalPools(t *testing.T) {
 				},
 			},
 			"usdcx": {
-				PoolId:   "usdcx",
-				Protocol: "cswap",
+				PoolId:    "usdcx",
+				Protocol:  "cswap",
+				BlockHash: "usdcx-block",
+				Timestamp: observedAt,
 				AssetX: common.AssetAmount{
 					Class:  common.Lovelace(),
 					Amount: 8_547_275_688,
@@ -261,6 +266,15 @@ func TestHandleADAUSDPriceFromLocalPools(t *testing.T) {
 	if len(response.Observations) != 2 {
 		t.Fatalf("expected 2 observations, got %d", len(response.Observations))
 	}
+	if response.Source != shaiprice.SourceLocalDEXStablecoins {
+		t.Fatalf("unexpected source %q", response.Source)
+	}
+	if response.Validation != shaiprice.ValidationQualified {
+		t.Fatalf("unexpected validation %q", response.Validation)
+	}
+	if response.ObservedAt.IsZero() || response.AgeSeconds == nil {
+		t.Fatal("expected observation time and age")
+	}
 }
 
 func TestHandleADAUSDPriceUnavailableWithoutDiversity(t *testing.T) {
@@ -273,6 +287,18 @@ func TestHandleADAUSDPriceUnavailableWithoutDiversity(t *testing.T) {
 	mux.ServeHTTP(rr, req)
 	if rr.Code != http.StatusServiceUnavailable {
 		t.Fatalf("expected status 503, got %d", rr.Code)
+	}
+	var response struct {
+		Result shaiprice.Result `json:"result"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if response.Result.Validation != shaiprice.ValidationUnavailable {
+		t.Fatalf(
+			"unexpected validation %q",
+			response.Result.Validation,
+		)
 	}
 }
 

--- a/price/ada_usd.go
+++ b/price/ada_usd.go
@@ -22,6 +22,7 @@ import (
 	"math/big"
 	"sort"
 	"strconv"
+	"time"
 
 	"github.com/blinklabs-io/shai/common"
 	"github.com/blinklabs-io/shai/dex"
@@ -34,7 +35,13 @@ var (
 	ErrDivergentPrices          = errors.New("price: qualified pool prices diverge")
 )
 
-const usdMicrosDecimals = 6
+const (
+	usdMicrosDecimals = 6
+
+	SourceLocalDEXStablecoins = "local-dex-stablecoins"
+	ValidationQualified       = "qualified"
+	ValidationUnavailable     = "unavailable"
+)
 
 // Config controls qualification and agreement for ADA/USD pool observations.
 type Config struct {
@@ -65,18 +72,22 @@ func DefaultConfig() Config {
 
 // PoolObservation is one qualified ADA/stablecoin spot price.
 type PoolObservation struct {
-	PoolID        string  `json:"poolId"`
-	Protocol      string  `json:"protocol"`
-	Stablecoin    string  `json:"stablecoin"`
-	ADAReserve    uint64  `json:"adaReserve"`
-	StableReserve uint64  `json:"stableReserve"`
-	StableMicros  uint64  `json:"stableMicros"`
-	PriceNum      string  `json:"priceNumerator"`
-	PriceDen      string  `json:"priceDenominator"`
-	Price         float64 `json:"price"`
-	Slot          uint64  `json:"slot"`
-	TxHash        string  `json:"txHash"`
-	TxIndex       uint32  `json:"txIndex"`
+	PoolID        string    `json:"poolId"`
+	Protocol      string    `json:"protocol"`
+	Stablecoin    string    `json:"stablecoin"`
+	ADAReserve    uint64    `json:"adaReserve"`
+	StableReserve uint64    `json:"stableReserve"`
+	StableMicros  uint64    `json:"stableMicros"`
+	PriceNum      string    `json:"priceNumerator"`
+	PriceDen      string    `json:"priceDenominator"`
+	Price         float64   `json:"price"`
+	Slot          uint64    `json:"slot"`
+	BlockHash     string    `json:"blockHash"`
+	TxHash        string    `json:"txHash"`
+	TxIndex       uint32    `json:"txIndex"`
+	ObservedAt    time.Time `json:"observedAt"`
+	AgeSeconds    *int64    `json:"ageSeconds"`
+	Validation    string    `json:"validation"`
 
 	price *big.Rat
 }
@@ -84,7 +95,11 @@ type PoolObservation struct {
 // Result is a liquidity-weighted local ADA/USD estimate.
 type Result struct {
 	Pair         string            `json:"pair"`
+	Source       string            `json:"source"`
 	Method       string            `json:"method"`
+	Validation   string            `json:"validation"`
+	ObservedAt   time.Time         `json:"observedAt"`
+	AgeSeconds   *int64            `json:"ageSeconds"`
 	PriceNum     string            `json:"priceNumerator"`
 	PriceDen     string            `json:"priceDenominator"`
 	Price        float64           `json:"price"`
@@ -108,13 +123,25 @@ func AggregateADAUSD(
 	pools []*dex.PoolState,
 	config Config,
 ) (Result, error) {
+	return AggregateADAUSDAt(pools, config, time.Now())
+}
+
+// AggregateADAUSDAt is AggregateADAUSD with an explicit evaluation time for
+// deterministic provenance and age reporting.
+func AggregateADAUSDAt(
+	pools []*dex.PoolState,
+	config Config,
+	now time.Time,
+) (Result, error) {
 	if err := validateConfig(config); err != nil {
 		return Result{}, err
 	}
-	observations := observationsFromPools(pools, config)
+	observations := observationsFromPools(pools, config, now)
 	result := Result{
 		Pair:         "ADA/USD",
+		Source:       SourceLocalDEXStablecoins,
 		Method:       "local-dex-stablecoin-weighted",
+		Validation:   ValidationUnavailable,
 		Observations: observations,
 	}
 	if len(observations) < config.MinObservations {
@@ -181,12 +208,24 @@ func AggregateADAUSD(
 	result.PriceNum = weightedPrice.Num().String()
 	result.PriceDen = weightedPrice.Denom().String()
 	result.Price, _ = weightedPrice.Float64()
+	result.Validation = ValidationQualified
+	for _, observation := range observations {
+		if observation.ObservedAt.IsZero() {
+			continue
+		}
+		if result.ObservedAt.IsZero() ||
+			observation.ObservedAt.Before(result.ObservedAt) {
+			result.ObservedAt = observation.ObservedAt
+			result.AgeSeconds = observation.AgeSeconds
+		}
+	}
 	return result, nil
 }
 
 func observationsFromPools(
 	pools []*dex.PoolState,
 	config Config,
+	now time.Time,
 ) []PoolObservation {
 	latest := make(map[string]*dex.PoolState)
 	for _, pool := range pools {
@@ -208,7 +247,7 @@ func observationsFromPools(
 
 	var observations []PoolObservation
 	for _, pool := range latest {
-		observation, ok := observationFromPool(pool, config)
+		observation, ok := observationFromPool(pool, config, now)
 		if ok {
 			observations = append(observations, observation)
 		}
@@ -228,6 +267,7 @@ func observationsFromPools(
 func observationFromPool(
 	pool *dex.PoolState,
 	config Config,
+	now time.Time,
 ) (PoolObservation, bool) {
 	var ada common.AssetAmount
 	var stable common.AssetAmount
@@ -269,6 +309,11 @@ func observationFromPool(
 		),
 	)
 	priceFloat, _ := price.Float64()
+	var ageSeconds *int64
+	if !pool.Timestamp.IsZero() {
+		age := int64(now.Sub(pool.Timestamp).Seconds())
+		ageSeconds = &age
+	}
 	return PoolObservation{
 		PoolID:        pool.PoolId,
 		Protocol:      pool.Protocol,
@@ -280,8 +325,12 @@ func observationFromPool(
 		PriceDen:      price.Denom().String(),
 		Price:         priceFloat,
 		Slot:          pool.Slot,
+		BlockHash:     pool.BlockHash,
 		TxHash:        pool.TxHash,
 		TxIndex:       pool.TxIndex,
+		ObservedAt:    pool.Timestamp,
+		AgeSeconds:    ageSeconds,
+		Validation:    ValidationQualified,
 		price:         price,
 	}, true
 }

--- a/price/ada_usd_test.go
+++ b/price/ada_usd_test.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"math"
 	"testing"
+	"time"
 
 	"github.com/blinklabs-io/shai/common"
 	"github.com/blinklabs-io/shai/dex"
@@ -58,6 +59,54 @@ func TestAggregateADAUSDCurrentCSwapFixtures(t *testing.T) {
 	require.InDelta(t, 0.16868, result.Price, 0.0001)
 	require.NotZero(t, result.PriceNum)
 	require.NotZero(t, result.PriceDen)
+}
+
+func TestAggregateADAUSDReportsLocalProvenance(t *testing.T) {
+	now := time.Date(2026, 7, 23, 20, 0, 0, 0, time.UTC)
+	usdcx := poolFixture(
+		t,
+		"usdcx",
+		USDCxPolicyID,
+		USDCxAssetName,
+		8_547_275_688,
+		1_439_463_431,
+		"usdcx-tx",
+		1,
+	)
+	usdcx.BlockHash = "usdcx-block"
+	usdcx.Timestamp = now.Add(-2 * time.Minute)
+	usdm := poolFixture(
+		t,
+		"usdm",
+		USDMPolicyID,
+		USDMAssetName,
+		4_579_285_253,
+		774_654_393,
+		"usdm-tx",
+		1,
+	)
+	usdm.BlockHash = "usdm-block"
+	usdm.Timestamp = now.Add(-5 * time.Minute)
+
+	result, err := AggregateADAUSDAt(
+		[]*dex.PoolState{usdcx, usdm},
+		DefaultConfig(),
+		now,
+	)
+	require.NoError(t, err)
+	require.Equal(t, SourceLocalDEXStablecoins, result.Source)
+	require.Equal(t, ValidationQualified, result.Validation)
+	require.Equal(t, usdm.Timestamp, result.ObservedAt)
+	require.NotNil(t, result.AgeSeconds)
+	require.Equal(t, int64(300), *result.AgeSeconds)
+	require.Equal(t, "usdcx-block", result.Observations[0].BlockHash)
+	require.Equal(
+		t,
+		ValidationQualified,
+		result.Observations[0].Validation,
+	)
+	require.NotNil(t, result.Observations[0].AgeSeconds)
+	require.Equal(t, int64(120), *result.Observations[0].AgeSeconds)
 }
 
 func TestAggregateADAUSDRequiresStablecoinDiversity(t *testing.T) {
@@ -249,6 +298,7 @@ func TestObservationsFromPoolsUsesLatestSameSlotOutput(t *testing.T) {
 	observations := observationsFromPools(
 		[]*dex.PoolState{newer, older},
 		DefaultConfig(),
+		time.Now(),
 	)
 	require.Len(t, observations, 1)
 	require.Equal(t, uint32(2), observations[0].TxIndex)


### PR DESCRIPTION
Expose local source health and chain provenance.

Stacked on #364.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose ADA/USD price provenance and freshness from local stablecoin DEX pools. API and pricing now report source, validation, observation time, age, and block context for better traceability.

- **New Features**
  - Result includes `source`, `validation`, `observedAt`, and `ageSeconds` (`source: local-dex-stablecoins`; `validation: qualified` when diverse pools; `unavailable` on 503).
  - Each pool observation adds `blockHash`, `observedAt`, `ageSeconds`, and `validation`; age is computed from pool `timestamp`.
  - Added `AggregateADAUSDAt(now)` for deterministic provenance/age; `AggregateADAUSD` delegates to it. Tests updated for API and pricing paths.

<sup>Written for commit 42c18e67046bce0e2047650a260e9467d8adb289. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/shai/pull/366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

