### PR TITLE
feat: track local pool activity

### DIFF
--- a/dex/activity.go
+++ b/dex/activity.go
@@ -1,0 +1,265 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dex
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/blinklabs-io/shai/common"
+)
+
+var (
+	ErrInvalidActivityWindow = errors.New(
+		"dex: activity window must be positive",
+	)
+	ErrMismatchedPoolTransition = errors.New(
+		"dex: pool transition identity or assets changed",
+	)
+	ErrOutOfOrderActivity = errors.New(
+		"dex: pool activity arrived before the latest observed slot",
+	)
+	ErrVolumeOverflow = errors.New("dex: pool volume overflows uint64")
+)
+
+// SwapTransition is a confirmed reserve transition that has the shape of a
+// swap: one reserve increased while the other decreased. Amounts are kept in
+// each asset's native on-chain units.
+type SwapTransition struct {
+	PoolID    string            `json:"poolId"`
+	Network   string            `json:"network"`
+	Protocol  string            `json:"protocol"`
+	AssetX    common.AssetClass `json:"assetX"`
+	AssetY    common.AssetClass `json:"assetY"`
+	AmountX   uint64            `json:"amountX"`
+	AmountY   uint64            `json:"amountY"`
+	InputIsX  bool              `json:"inputIsX"`
+	Slot      uint64            `json:"slot"`
+	BlockHash string            `json:"blockHash"`
+	TxHash    string            `json:"txHash"`
+	TxIndex   uint32            `json:"txIndex"`
+}
+
+// PoolVolume is the exact net reserve turnover inferred from swap-shaped pool
+// transitions over a slot window. It does not claim to measure gross volume
+// when multiple actions are batched into one pool-state transition.
+type PoolVolume struct {
+	PoolID        string            `json:"poolId"`
+	Network       string            `json:"network"`
+	Protocol      string            `json:"protocol"`
+	AssetX        common.AssetClass `json:"assetX"`
+	AssetY        common.AssetClass `json:"assetY"`
+	VolumeX       uint64            `json:"volumeX"`
+	VolumeY       uint64            `json:"volumeY"`
+	SwapCount     uint64            `json:"swapCount"`
+	WindowSlots   uint64            `json:"windowSlots"`
+	WindowEnd     uint64            `json:"windowEndSlot"`
+	FirstSwapSlot uint64            `json:"firstSwapSlot,omitempty"`
+	LastSwapSlot  uint64            `json:"lastSwapSlot,omitempty"`
+}
+
+// ActivityTracker retains confirmed swap-shaped pool transitions over a
+// bounded slot window. Slot windows make historical chain sync deterministic
+// and avoid mistaking sync wall-clock time for trading time.
+type ActivityTracker struct {
+	mu          sync.Mutex
+	windowSlots uint64
+	latestSlot  uint64
+	swaps       map[string][]SwapTransition
+}
+
+// NewActivityTracker creates a rolling pool-activity tracker.
+func NewActivityTracker(windowSlots uint64) (*ActivityTracker, error) {
+	if windowSlots == 0 {
+		return nil, ErrInvalidActivityWindow
+	}
+	return &ActivityTracker{
+		windowSlots: windowSlots,
+		swaps:       make(map[string][]SwapTransition),
+	}, nil
+}
+
+// InferSwapTransition classifies a pair of confirmed pool states. Deposits,
+// withdrawals, and fee-only/no-op changes are excluded because their reserves
+// move in the same direction or do not move.
+func InferSwapTransition(
+	previous,
+	current *PoolState,
+) (SwapTransition, bool, error) {
+	if previous == nil || current == nil {
+		return SwapTransition{}, false, nil
+	}
+	if previous.FromMempool || current.FromMempool {
+		return SwapTransition{}, false, nil
+	}
+	if previous.Key() != current.Key() ||
+		!previous.AssetX.IsAsset(current.AssetX.Class) ||
+		!previous.AssetY.IsAsset(current.AssetY.Class) {
+		return SwapTransition{}, false, ErrMismatchedPoolTransition
+	}
+
+	xIn := current.AssetX.Amount > previous.AssetX.Amount
+	xOut := current.AssetX.Amount < previous.AssetX.Amount
+	yIn := current.AssetY.Amount > previous.AssetY.Amount
+	yOut := current.AssetY.Amount < previous.AssetY.Amount
+	if !((xIn && yOut) || (xOut && yIn)) {
+		return SwapTransition{}, false, nil
+	}
+
+	transition := SwapTransition{
+		PoolID:    current.PoolId,
+		Network:   current.Network,
+		Protocol:  current.Protocol,
+		AssetX:    current.AssetX.Class,
+		AssetY:    current.AssetY.Class,
+		InputIsX:  xIn,
+		Slot:      current.Slot,
+		BlockHash: current.BlockHash,
+		TxHash:    current.TxHash,
+		TxIndex:   current.TxIndex,
+	}
+	if xIn {
+		transition.AmountX = current.AssetX.Amount - previous.AssetX.Amount
+		transition.AmountY = previous.AssetY.Amount - current.AssetY.Amount
+	} else {
+		transition.AmountX = previous.AssetX.Amount - current.AssetX.Amount
+		transition.AmountY = current.AssetY.Amount - previous.AssetY.Amount
+	}
+	return transition, true, nil
+}
+
+// Observe records a confirmed swap-shaped transition and advances the rolling
+// window even when the transition is a liquidity event rather than a swap.
+func (t *ActivityTracker) Observe(
+	previous,
+	current *PoolState,
+) (bool, error) {
+	if current == nil || current.FromMempool {
+		return false, nil
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if current.Slot < t.latestSlot {
+		return false, ErrOutOfOrderActivity
+	}
+	t.latestSlot = current.Slot
+	t.prune(current.Slot)
+
+	transition, ok, err := InferSwapTransition(previous, current)
+	if err != nil || !ok {
+		return false, err
+	}
+	key := current.Key()
+	t.swaps[key] = append(t.swaps[key], transition)
+	return true, nil
+}
+
+// Volume returns net reserve turnover for a pool at the requested slot.
+func (t *ActivityTracker) Volume(
+	network,
+	protocol,
+	poolID string,
+	atSlot uint64,
+) (PoolVolume, bool, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if atSlot < t.latestSlot {
+		return PoolVolume{}, false, ErrOutOfOrderActivity
+	}
+
+	key := fmt.Sprintf("%s:%s:%s", network, protocol, poolID)
+	swaps := t.swaps[key]
+	var cutoff uint64
+	if atSlot > t.windowSlots {
+		cutoff = atSlot - t.windowSlots
+	}
+	first := 0
+	for first < len(swaps) && swaps[first].Slot < cutoff {
+		first++
+	}
+	swaps = swaps[first:]
+	if len(swaps) == 0 {
+		return PoolVolume{}, false, nil
+	}
+	volume := PoolVolume{
+		PoolID:        poolID,
+		Network:       network,
+		Protocol:      protocol,
+		AssetX:        swaps[0].AssetX,
+		AssetY:        swaps[0].AssetY,
+		WindowSlots:   t.windowSlots,
+		WindowEnd:     atSlot,
+		FirstSwapSlot: swaps[0].Slot,
+		LastSwapSlot:  swaps[len(swaps)-1].Slot,
+	}
+	for _, swap := range swaps {
+		if ^uint64(0)-volume.VolumeX < swap.AmountX ||
+			^uint64(0)-volume.VolumeY < swap.AmountY ||
+			volume.SwapCount == ^uint64(0) {
+			return PoolVolume{}, false, ErrVolumeOverflow
+		}
+		volume.VolumeX += swap.AmountX
+		volume.VolumeY += swap.AmountY
+		volume.SwapCount++
+	}
+	return volume, true, nil
+}
+
+// Rollback removes activity at or after the rollback slot.
+func (t *ActivityTracker) Rollback(slot uint64) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for key, swaps := range t.swaps {
+		keep := len(swaps)
+		for keep > 0 && swaps[keep-1].Slot >= slot {
+			keep--
+		}
+		if keep == 0 {
+			delete(t.swaps, key)
+			continue
+		}
+		t.swaps[key] = swaps[:keep]
+	}
+	t.latestSlot = 0
+	if slot > 0 {
+		t.latestSlot = slot - 1
+	}
+	t.prune(t.latestSlot)
+}
+
+func (t *ActivityTracker) prune(atSlot uint64) {
+	var cutoff uint64
+	if atSlot > t.windowSlots {
+		cutoff = atSlot - t.windowSlots
+	}
+	for key, swaps := range t.swaps {
+		first := 0
+		for first < len(swaps) && swaps[first].Slot < cutoff {
+			first++
+		}
+		if first == len(swaps) {
+			delete(t.swaps, key)
+			continue
+		}
+		if first > 0 {
+			t.swaps[key] = append(
+				[]SwapTransition(nil),
+				swaps[first:]...,
+			)
+		}
+	}
+}

--- a/dex/activity.go
+++ b/dex/activity.go
@@ -115,7 +115,8 @@ func InferSwapTransition(
 	xOut := current.AssetX.Amount < previous.AssetX.Amount
 	yIn := current.AssetY.Amount > previous.AssetY.Amount
 	yOut := current.AssetY.Amount < previous.AssetY.Amount
-	if !((xIn && yOut) || (xOut && yIn)) {
+	isSwap := (xIn && yOut) || (xOut && yIn)
+	if !isSwap {
 		return SwapTransition{}, false, nil
 	}
 
@@ -187,34 +188,34 @@ func (t *ActivityTracker) Volume(
 	if atSlot > t.windowSlots {
 		cutoff = atSlot - t.windowSlots
 	}
-	first := 0
-	for first < len(swaps) && swaps[first].Slot < cutoff {
-		first++
-	}
-	swaps = swaps[first:]
-	if len(swaps) == 0 {
-		return PoolVolume{}, false, nil
-	}
 	volume := PoolVolume{
-		PoolID:        poolID,
-		Network:       network,
-		Protocol:      protocol,
-		AssetX:        swaps[0].AssetX,
-		AssetY:        swaps[0].AssetY,
-		WindowSlots:   t.windowSlots,
-		WindowEnd:     atSlot,
-		FirstSwapSlot: swaps[0].Slot,
-		LastSwapSlot:  swaps[len(swaps)-1].Slot,
+		PoolID:      poolID,
+		Network:     network,
+		Protocol:    protocol,
+		WindowSlots: t.windowSlots,
+		WindowEnd:   atSlot,
 	}
 	for _, swap := range swaps {
+		if swap.Slot < cutoff {
+			continue
+		}
 		if ^uint64(0)-volume.VolumeX < swap.AmountX ||
 			^uint64(0)-volume.VolumeY < swap.AmountY ||
 			volume.SwapCount == ^uint64(0) {
 			return PoolVolume{}, false, ErrVolumeOverflow
 		}
+		if volume.SwapCount == 0 {
+			volume.AssetX = swap.AssetX
+			volume.AssetY = swap.AssetY
+			volume.FirstSwapSlot = swap.Slot
+		}
 		volume.VolumeX += swap.AmountX
 		volume.VolumeY += swap.AmountY
 		volume.SwapCount++
+		volume.LastSwapSlot = swap.Slot
+	}
+	if volume.SwapCount == 0 {
+		return PoolVolume{}, false, nil
 	}
 	return volume, true, nil
 }

--- a/dex/activity.go
+++ b/dex/activity.go
@@ -16,7 +16,6 @@ package dex
 
 import (
 	"errors"
-	"fmt"
 	"sync"
 
 	"github.com/blinklabs-io/shai/common"
@@ -182,8 +181,12 @@ func (t *ActivityTracker) Volume(
 		return PoolVolume{}, false, ErrOutOfOrderActivity
 	}
 
-	key := fmt.Sprintf("%s:%s:%s", network, protocol, poolID)
-	swaps := t.swaps[key]
+	pool := PoolState{
+		PoolId:   poolID,
+		Network:  network,
+		Protocol: protocol,
+	}
+	swaps := t.swaps[pool.Key()]
 	var cutoff uint64
 	if atSlot > t.windowSlots {
 		cutoff = atSlot - t.windowSlots

--- a/dex/activity_test.go
+++ b/dex/activity_test.go
@@ -1,0 +1,173 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dex
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/blinklabs-io/shai/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInferSwapTransition(t *testing.T) {
+	previous := activityPool(100, 1_000, 2_000)
+	current := activityPool(101, 1_100, 1_820)
+	current.BlockHash = "block"
+	current.TxHash = "tx"
+	current.TxIndex = 2
+
+	swap, ok, err := InferSwapTransition(previous, current)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.True(t, swap.InputIsX)
+	require.Equal(t, uint64(100), swap.AmountX)
+	require.Equal(t, uint64(180), swap.AmountY)
+	require.Equal(t, uint64(101), swap.Slot)
+	require.Equal(t, "block", swap.BlockHash)
+	require.Equal(t, "tx", swap.TxHash)
+	require.Equal(t, uint32(2), swap.TxIndex)
+
+	reverse := activityPool(102, 900, 2_200)
+	swap, ok, err = InferSwapTransition(current, reverse)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.False(t, swap.InputIsX)
+	require.Equal(t, uint64(200), swap.AmountX)
+	require.Equal(t, uint64(380), swap.AmountY)
+}
+
+func TestInferSwapTransitionExcludesLiquidityChanges(t *testing.T) {
+	previous := activityPool(100, 1_000, 2_000)
+	for _, current := range []*PoolState{
+		activityPool(101, 1_100, 2_200),
+		activityPool(101, 900, 1_800),
+		activityPool(101, 1_000, 2_000),
+	} {
+		_, ok, err := InferSwapTransition(previous, current)
+		require.NoError(t, err)
+		require.False(t, ok)
+	}
+
+	mempool := activityPool(101, 1_100, 1_800)
+	mempool.FromMempool = true
+	_, ok, err := InferSwapTransition(previous, mempool)
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
+func TestInferSwapTransitionRejectsIdentityChanges(t *testing.T) {
+	previous := activityPool(100, 1_000, 2_000)
+	current := activityPool(101, 1_100, 1_800)
+	current.PoolId = "other"
+	_, _, err := InferSwapTransition(previous, current)
+	require.ErrorIs(t, err, ErrMismatchedPoolTransition)
+
+	current = activityPool(101, 1_100, 1_800)
+	current.AssetY.Class = common.Lovelace()
+	_, _, err = InferSwapTransition(previous, current)
+	require.ErrorIs(t, err, ErrMismatchedPoolTransition)
+}
+
+func TestActivityTrackerVolumeWindowAndRollback(t *testing.T) {
+	tracker, err := NewActivityTracker(100)
+	require.NoError(t, err)
+
+	firstBefore := activityPool(9, 1_000, 2_000)
+	firstAfter := activityPool(10, 1_100, 1_820)
+	recorded, err := tracker.Observe(firstBefore, firstAfter)
+	require.NoError(t, err)
+	require.True(t, recorded)
+
+	secondBefore := activityPool(49, 1_100, 1_820)
+	secondAfter := activityPool(50, 900, 2_200)
+	recorded, err = tracker.Observe(secondBefore, secondAfter)
+	require.NoError(t, err)
+	require.True(t, recorded)
+
+	volume, ok, err := tracker.Volume("mainnet", "test", "pool", 50)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, uint64(300), volume.VolumeX)
+	require.Equal(t, uint64(560), volume.VolumeY)
+	require.Equal(t, uint64(2), volume.SwapCount)
+	require.Equal(t, uint64(10), volume.FirstSwapSlot)
+	require.Equal(t, uint64(50), volume.LastSwapSlot)
+
+	// Advancing beyond the first swap's window removes it.
+	volume, ok, err = tracker.Volume("mainnet", "test", "pool", 111)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, uint64(200), volume.VolumeX)
+	require.Equal(t, uint64(380), volume.VolumeY)
+	require.Equal(t, uint64(1), volume.SwapCount)
+
+	tracker.Rollback(50)
+	volume, ok, err = tracker.Volume("mainnet", "test", "pool", 49)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, uint64(100), volume.VolumeX)
+	require.Equal(t, uint64(180), volume.VolumeY)
+	require.Equal(t, uint64(1), volume.SwapCount)
+}
+
+func TestActivityTrackerRejectsOutOfOrderAndOverflow(t *testing.T) {
+	tracker, err := NewActivityTracker(100)
+	require.NoError(t, err)
+	_, err = tracker.Observe(
+		activityPool(99, 0, ^uint64(0)),
+		activityPool(100, ^uint64(0), 0),
+	)
+	require.NoError(t, err)
+	_, err = tracker.Observe(
+		activityPool(100, ^uint64(0), 0),
+		activityPool(101, 0, ^uint64(0)),
+	)
+	require.NoError(t, err)
+
+	_, _, err = tracker.Volume("mainnet", "test", "pool", 101)
+	require.ErrorIs(t, err, ErrVolumeOverflow)
+
+	_, err = tracker.Observe(
+		activityPool(89, 1_000, 2_000),
+		activityPool(90, 1_100, 1_800),
+	)
+	require.True(t, errors.Is(err, ErrOutOfOrderActivity))
+}
+
+func TestNewActivityTrackerRejectsZeroWindow(t *testing.T) {
+	_, err := NewActivityTracker(0)
+	require.ErrorIs(t, err, ErrInvalidActivityWindow)
+}
+
+func activityPool(slot, reserveX, reserveY uint64) *PoolState {
+	return &PoolState{
+		PoolId:   "pool",
+		Network:  "mainnet",
+		Protocol: "test",
+		AssetX: common.AssetAmount{
+			Class:  common.Lovelace(),
+			Amount: reserveX,
+		},
+		AssetY: common.AssetAmount{
+			Class: common.AssetClass{
+				PolicyId: []byte{1},
+				Name:     []byte{2},
+			},
+			Amount: reserveY,
+		},
+		Slot: slot,
+	}
+}

--- a/dex/activity_test.go
+++ b/dex/activity_test.go
@@ -68,6 +68,72 @@ func TestInferSwapTransitionExcludesLiquidityChanges(t *testing.T) {
 	require.False(t, ok)
 }
 
+func TestInferSwapTransitionCurrentMainnetCSWAP(t *testing.T) {
+	usdm, err := common.NewAssetClass(
+		"c48cbb3d5e57ed56e276bc45f99ab39abe94e6cd7ac39fb402da47ad",
+		"0014df105553444d",
+	)
+	require.NoError(t, err)
+	usdcx, err := common.NewAssetClass(
+		"1f3aec8bfe7ea4fe14c5f121e2a92e301afe414147860d557cac7e34",
+		"5553444378",
+	)
+	require.NoError(t, err)
+
+	t.Run("USDM swap", func(t *testing.T) {
+		// Pool input 53c6a52f...#1 was consumed by
+		// 1237c072... and replaced by output #1 at slot 193255027.
+		previous := cswapActivityPool(
+			usdm,
+			4_517_941_431,
+			785_087_730,
+			193_253_135,
+		)
+		previous.TxHash = "53c6a52f402b9fd2d30ae76962010fe57a2a1cc30d6d286db815280c2563f5e6"
+		previous.TxIndex = 1
+		current := cswapActivityPool(
+			usdm,
+			4_579_285_253,
+			774_654_393,
+			193_255_027,
+		)
+		current.TxHash = "1237c072b8d283e3ccc3b9956502825f11533973b5402ed1ef1df459ffca8bfc"
+		current.TxIndex = 1
+
+		swap, ok, err := InferSwapTransition(previous, current)
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.True(t, swap.InputIsX)
+		require.Equal(t, uint64(61_343_822), swap.AmountX)
+		require.Equal(t, uint64(10_433_337), swap.AmountY)
+	})
+
+	t.Run("USDCx liquidity addition", func(t *testing.T) {
+		// Pool input 74aa2e44...#1 was consumed by a24fd5df...; both
+		// reserves increased, so it must not be counted as swap volume.
+		previous := cswapActivityPool(
+			usdcx,
+			8_369_182_751,
+			1_409_463_431,
+			193_253_159,
+		)
+		previous.TxHash = "74aa2e4478ca051a43fc5be6c705271080120ab89b73d451e181ce56d556dea6"
+		previous.TxIndex = 1
+		current := cswapActivityPool(
+			usdcx,
+			8_547_275_688,
+			1_439_463_431,
+			193_253_908,
+		)
+		current.TxHash = "a24fd5df3faebb06ba0aa815890d5c7e3907c27f428c906b792d81321254a8d1"
+		current.TxIndex = 1
+
+		_, ok, err := InferSwapTransition(previous, current)
+		require.NoError(t, err)
+		require.False(t, ok)
+	})
+}
+
 func TestInferSwapTransitionRejectsIdentityChanges(t *testing.T) {
 	previous := activityPool(100, 1_000, 2_000)
 	current := activityPool(101, 1_100, 1_800)
@@ -150,6 +216,28 @@ func TestActivityTrackerRejectsOutOfOrderAndOverflow(t *testing.T) {
 func TestNewActivityTrackerRejectsZeroWindow(t *testing.T) {
 	_, err := NewActivityTracker(0)
 	require.ErrorIs(t, err, ErrInvalidActivityWindow)
+}
+
+func cswapActivityPool(
+	stablecoin common.AssetClass,
+	adaReserve,
+	stableReserve,
+	slot uint64,
+) *PoolState {
+	return &PoolState{
+		PoolId:   stablecoin.Fingerprint(),
+		Network:  "mainnet",
+		Protocol: "cswap",
+		AssetX: common.AssetAmount{
+			Class:  common.Lovelace(),
+			Amount: adaReserve,
+		},
+		AssetY: common.AssetAmount{
+			Class:  stablecoin,
+			Amount: stableReserve,
+		},
+		Slot: slot,
+	}
 }
 
 func activityPool(slot, reserveX, reserveY uint64) *PoolState {

--- a/internal/oracle/dex.go
+++ b/internal/oracle/dex.go
@@ -30,8 +30,17 @@ type PriceUpdate = dex.PriceUpdate
 // PoolParser is an alias for dex.PoolParser.
 type PoolParser = dex.PoolParser
 
+// PoolVolume is an alias for dex.PoolVolume.
+type PoolVolume = dex.PoolVolume
+
+// ActivityTracker is an alias for dex.ActivityTracker.
+type ActivityTracker = dex.ActivityTracker
+
 // NewPriceUpdate re-exports dex.NewPriceUpdate.
 var NewPriceUpdate = dex.NewPriceUpdate
+
+// NewActivityTracker re-exports dex.NewActivityTracker.
+var NewActivityTracker = dex.NewActivityTracker
 
 // clonePoolState wraps dex.ClonePoolState for internal use.
 func clonePoolState(state *PoolState) *PoolState {

--- a/internal/oracle/oracle.go
+++ b/internal/oracle/oracle.go
@@ -689,7 +689,7 @@ func (o *Oracle) GetPoolVolume(
 	atSlot uint64,
 ) (PoolVolume, bool, error) {
 	state, ok := o.GetPoolState(poolId)
-	if !ok || o.activity == nil {
+	if !ok || state == nil || o.activity == nil {
 		return PoolVolume{}, false, nil
 	}
 	return o.activity.Volume(

--- a/internal/oracle/oracle.go
+++ b/internal/oracle/oracle.go
@@ -30,8 +30,9 @@ import (
 )
 
 const (
-	subscriberBufferSize = 100
-	dropLogSampleRate    = 100
+	subscriberBufferSize           = 100
+	dropLogSampleRate              = 100
+	defaultPoolActivityWindowSlots = 86_400
 )
 
 // CDPParser parses synthetics/CDP datums that are tracked separately from AMM
@@ -65,6 +66,7 @@ type Oracle struct {
 	stopped       bool
 	dropCount     atomic.Uint64
 	mempoolMgr    *MempoolStateManager
+	activity      *ActivityTracker
 }
 
 // New creates a new Oracle instance
@@ -73,6 +75,10 @@ func New(
 	profile *config.Profile,
 	parser PoolParser,
 ) *Oracle {
+	activity, err := NewActivityTracker(defaultPoolActivityWindowSlots)
+	if err != nil {
+		panic(err)
+	}
 	o := &Oracle{
 		idx:           idx,
 		profile:       profile,
@@ -82,6 +88,7 @@ func New(
 		poolAddresses: make(map[string]struct{}),
 		stopChan:      make(chan struct{}),
 		mempoolMgr:    NewMempoolStateManager(),
+		activity:      activity,
 	}
 
 	o.addProfileAddresses()
@@ -323,9 +330,23 @@ func (o *Oracle) handleTransaction(
 
 		// Update pool state
 		o.poolsMu.Lock()
-		var prevPrice float64
+		var (
+			prevPrice float64
+			prevState *PoolState
+		)
 		if prev, ok := o.pools[state.PoolId]; ok {
 			prevPrice = prev.PriceXY()
+			prevState = prev
+		}
+		if o.activity != nil {
+			if _, err := o.activity.Observe(prevState, state); err != nil {
+				logger.Warn(
+					"failed to record pool activity",
+					"error", err,
+					"poolId", state.PoolId,
+					"slot", state.Slot,
+				)
+			}
 		}
 		o.pools[state.PoolId] = state
 		o.poolsMu.Unlock()
@@ -536,6 +557,10 @@ func (o *Oracle) handleRollback(evt event.RollbackEvent) error {
 	}
 	o.cdpsMu.Unlock()
 
+	if o.activity != nil {
+		o.activity.Rollback(evt.SlotNumber)
+	}
+
 	// Invalidate mempool tracking for rolled-back pools. Otherwise the reorged
 	// confirmed state stays visible to consumers and seeds future pending-tx
 	// delta calculations with stale data.
@@ -655,6 +680,24 @@ func (o *Oracle) GetPoolState(poolId string) (*PoolState, bool) {
 
 	state, ok := o.pools[poolId]
 	return state, ok
+}
+
+// GetPoolVolume returns locally inferred, confirmed activity for a pool over
+// the configured rolling slot window.
+func (o *Oracle) GetPoolVolume(
+	poolId string,
+	atSlot uint64,
+) (PoolVolume, bool, error) {
+	state, ok := o.GetPoolState(poolId)
+	if !ok || o.activity == nil {
+		return PoolVolume{}, false, nil
+	}
+	return o.activity.Volume(
+		state.Network,
+		state.Protocol,
+		state.PoolId,
+		atSlot,
+	)
 }
 
 // GetAllPools returns all tracked pool states

--- a/internal/oracle/oracle_test.go
+++ b/internal/oracle/oracle_test.go
@@ -41,6 +41,9 @@ func TestOracleNewUsesSyntheticsCDPAddresses(t *testing.T) {
 	}
 
 	o := New(nil, &profile, NewIndigoParser())
+	if o.activity == nil {
+		t.Fatal("expected local pool activity tracking")
+	}
 	if !o.isPoolAddress(cdpAddress) {
 		t.Fatalf("expected CDP address to be monitored")
 	}
@@ -53,11 +56,16 @@ func TestOracleNewUsesSyntheticsCDPAddresses(t *testing.T) {
 }
 
 func TestOracleRollbackClearsMempoolState(t *testing.T) {
+	activity, err := NewActivityTracker(100)
+	if err != nil {
+		t.Fatalf("failed to create activity tracker: %v", err)
+	}
 	o := &Oracle{
 		pools:      make(map[string]*PoolState),
 		stopChan:   make(chan struct{}),
 		storage:    newTestOracleStorage(t),
 		mempoolMgr: NewMempoolStateManager(),
+		activity:   activity,
 	}
 
 	// A confirmed pool state at slot 100, tracked in o.pools, storage, and the
@@ -68,10 +76,35 @@ func TestOracleRollbackClearsMempoolState(t *testing.T) {
 		Protocol: "test",
 		TxHash:   "tx100",
 		Slot:     100,
-		AssetX:   common.AssetAmount{Amount: 1000},
-		AssetY:   common.AssetAmount{Amount: 2000},
+		AssetX: common.AssetAmount{
+			Class:  common.Lovelace(),
+			Amount: 1000,
+		},
+		AssetY: common.AssetAmount{
+			Class: common.AssetClass{
+				PolicyId: []byte{1},
+				Name:     []byte{2},
+			},
+			Amount: 2000,
+		},
+	}
+	previous := clonePoolState(state)
+	previous.Slot = 90
+	previous.AssetX.Amount = 900
+	previous.AssetY.Amount = 2200
+	recorded, err := o.activity.Observe(previous, state)
+	if err != nil {
+		t.Fatalf("failed to record pool activity: %v", err)
+	}
+	if !recorded {
+		t.Fatal("expected swap-shaped activity to be recorded")
 	}
 	o.pools[state.PoolId] = state
+	if volume, ok, err := o.GetPoolVolume("pool1", 100); err != nil {
+		t.Fatalf("failed to read pool activity: %v", err)
+	} else if !ok || volume.SwapCount != 1 {
+		t.Fatalf("expected one recorded swap, got %+v", volume)
+	}
 	if err := o.storage.SavePoolState(state); err != nil {
 		t.Fatalf("failed to save pool state: %v", err)
 	}
@@ -103,6 +136,16 @@ func TestOracleRollbackClearsMempoolState(t *testing.T) {
 			"expected 0 tracked pools in mempool manager, got %d",
 			o.mempoolMgr.PoolCount(),
 		)
+	}
+	if _, ok, err := o.activity.Volume(
+		"mainnet",
+		"test",
+		"pool1",
+		49,
+	); err != nil {
+		t.Fatalf("failed to read rolled-back pool activity: %v", err)
+	} else if ok {
+		t.Error("expected rolled-back pool activity to be removed")
 	}
 }
 


### PR DESCRIPTION
Tracks confirmed pool turnover over a rolling slot window. Handles chain rollbacks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Track confirmed swap-shaped pool activity over a rolling slot window and expose per‑pool volume from the Oracle. Adds reliable keying and stricter state checks; validated with current CSWAP mainnet fixtures in tests.

- **New Features**
  - Added `dex.ActivityTracker` to infer swaps and compute net turnover as `dex.PoolVolume`; validates pool identity/assets, prevents uint64 overflow, and excludes liquidity/no‑op changes.
  - Integrated tracker into `internal/oracle`: observe during transactions using the previous state and a consistent pool key; rollback on reorgs; default window `86_400` slots.
  - Exposed `Oracle.GetPoolVolume(poolId, atSlot)` and re‑exported `NewActivityTracker`/`PoolVolume` via `internal/oracle/dex.go`.

- **Migration**
  - Read activity with `GetPoolVolume(poolId, atSlot)`; it returns `(volume, ok, err)`. `ok` is false if no swaps in the window.
  - `atSlot` must be >= the latest observed slot; activity window defaults to `86_400` slots.

<sup>Written for commit 7cbe8187ed711722bf83b3133a6d1fade95ae892. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/shai/pull/368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added local tracking of confirmed swap activity for liquidity pools.
  * Added rolling-window pool volume reporting, including turnover, swap count, and activity range.
  * Added rollback handling to remove activity from reverted chain state.
  * Exposed pool volume reporting through the oracle interface.

* **Bug Fixes**
  * Excludes liquidity changes, mempool states, mismatched pools, and invalid ordering from swap activity.
  * Detects volume accumulation overflow and invalid tracking windows.

* **Tests**
  * Added coverage for swap detection, volume windows, rollbacks, ordering, and overflow handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->