### PR TITLE
fix: saturate pool TVL overflow

### DIFF
--- a/dex/models.go
+++ b/dex/models.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"math"
 	"math/big"
 	"time"
 
@@ -96,10 +97,16 @@ func (p *PoolState) PriceYX() float64 {
 	return float64(p.AssetX.Amount) / float64(p.AssetY.Amount)
 }
 
-// TVL returns the total value locked in the pool (sum of both assets)
-// Note: This is a raw sum, not normalized to any common unit
+// TVL returns the total value locked in the pool (sum of both assets).
+// Note: This is a raw sum, not normalized to any common unit. If the sum would
+// overflow uint64 it is capped at math.MaxUint64 rather than wrapping around to
+// a small, misleading value.
 func (p *PoolState) TVL() uint64 {
-	return p.AssetX.Amount + p.AssetY.Amount
+	sum := p.AssetX.Amount + p.AssetY.Amount
+	if sum < p.AssetX.Amount {
+		return math.MaxUint64
+	}
+	return sum
 }
 
 // EffectiveFee returns the pool's trading fee as a decimal

--- a/dex/tvl_test.go
+++ b/dex/tvl_test.go
@@ -1,0 +1,50 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dex
+
+import (
+	"math"
+	"testing"
+
+	"github.com/blinklabs-io/shai/common"
+)
+
+func TestTVL(t *testing.T) {
+	tests := []struct {
+		name string
+		x, y uint64
+		want uint64
+	}{
+		{name: "simple sum", x: 100, y: 250, want: 350},
+		{name: "zero", x: 0, y: 0, want: 0},
+		{
+			name: "overflow saturates to MaxUint64",
+			x:    math.MaxUint64 - 10,
+			y:    100,
+			want: math.MaxUint64,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &PoolState{
+				AssetX: common.AssetAmount{Amount: tc.x},
+				AssetY: common.AssetAmount{Amount: tc.y},
+			}
+			if got := p.TVL(); got != tc.want {
+				t.Errorf("TVL() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Prevents raw pool TVL from wrapping on overflow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent TVL overflow in pool state by capping the sum at `math.MaxUint64` instead of wrapping. Adds `dex/tvl_test.go` to cover simple, zero, and overflow cases.

<sup>Written for commit c7492581382f2f1c63aa57b8d8038838d1b097b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/shai/pull/369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

