### PR TITLE
feat: parse Djed oracle state

### DIFF
--- a/price/djed/oracle.go
+++ b/price/djed/oracle.go
@@ -50,13 +50,15 @@ var (
 // OracleDatum is the authenticated price and validity interval stored with the
 // Djed Oracle NFT.
 type OracleDatum struct {
-	Signature        []byte
-	PriceNumerator   uint64
-	PriceDenominator uint64
-	ValidFrom        time.Time
-	ValidUntil       time.Time
-	ExpressedIn      []byte
-	OraclePolicy     []byte
+	Signature           []byte
+	PriceNumerator      uint64
+	PriceDenominator    uint64
+	ValidFrom           time.Time
+	ValidFromInclusive  bool
+	ValidUntil          time.Time
+	ValidUntilInclusive bool
+	ExpressedIn         []byte
+	OraclePolicy        []byte
 }
 
 // OracleUTxO contains the identity-bearing parts of the UTxO holding a datum.
@@ -69,15 +71,17 @@ type OracleUTxO struct {
 
 // Observation is a validated local-ledger ADA/USD observation.
 type Observation struct {
-	Pair             string    `json:"pair"`
-	Source           string    `json:"source"`
-	PriceNumerator   uint64    `json:"priceNumerator"`
-	PriceDenominator uint64    `json:"priceDenominator"`
-	Price            float64   `json:"price"`
-	ValidFrom        time.Time `json:"validFrom"`
-	ValidUntil       time.Time `json:"validUntil"`
-	TxHash           string    `json:"txHash"`
-	TxIndex          uint32    `json:"txIndex"`
+	Pair                string    `json:"pair"`
+	Source              string    `json:"source"`
+	PriceNumerator      uint64    `json:"priceNumerator"`
+	PriceDenominator    uint64    `json:"priceDenominator"`
+	Price               float64   `json:"price"`
+	ValidFrom           time.Time `json:"validFrom"`
+	ValidFromInclusive  bool      `json:"validFromInclusive"`
+	ValidUntil          time.Time `json:"validUntil"`
+	ValidUntilInclusive bool      `json:"validUntilInclusive"`
+	TxHash              string    `json:"txHash"`
+	TxIndex             uint32    `json:"txIndex"`
 }
 
 // ParseOracleDatum decodes the Open Djed OracleDatum schema.
@@ -141,7 +145,9 @@ func ParseOracleDatum(data []byte) (OracleDatum, error) {
 			err,
 		)
 	}
-	validFromMillis, err := finiteBoundMillis(validityFields[0])
+	validFromMillis, validFromInclusive, err := finiteBound(
+		validityFields[0],
+	)
 	if err != nil {
 		return OracleDatum{}, fmt.Errorf(
 			"%w: lower bound: %v",
@@ -149,7 +155,9 @@ func ParseOracleDatum(data []byte) (OracleDatum, error) {
 			err,
 		)
 	}
-	validUntilMillis, err := finiteBoundMillis(validityFields[1])
+	validUntilMillis, validUntilInclusive, err := finiteBound(
+		validityFields[1],
+	)
 	if err != nil {
 		return OracleDatum{}, fmt.Errorf(
 			"%w: upper bound: %v",
@@ -158,7 +166,9 @@ func ParseOracleDatum(data []byte) (OracleDatum, error) {
 		)
 	}
 	datum.ValidFrom = time.UnixMilli(validFromMillis).UTC()
+	datum.ValidFromInclusive = validFromInclusive
 	datum.ValidUntil = time.UnixMilli(validUntilMillis).UTC()
+	datum.ValidUntilInclusive = validUntilInclusive
 
 	if _, err := cbor.Decode(
 		oracleFields[2],
@@ -222,14 +232,18 @@ func (d OracleDatum) ValidateMainnet(
 	if d.PriceNumerator == 0 || d.PriceDenominator == 0 {
 		return ErrInvalidRate
 	}
-	if !d.ValidFrom.Before(d.ValidUntil) {
+	if d.ValidFrom.After(d.ValidUntil) ||
+		(d.ValidFrom.Equal(d.ValidUntil) &&
+			(!d.ValidFromInclusive || !d.ValidUntilInclusive)) {
 		return fmt.Errorf("%w: invalid validity interval", ErrInvalidDatum)
 	}
 	now = now.UTC()
-	if now.Before(d.ValidFrom) {
+	if now.Before(d.ValidFrom) ||
+		(now.Equal(d.ValidFrom) && !d.ValidFromInclusive) {
 		return ErrNotYetValid
 	}
-	if !now.Before(d.ValidUntil) {
+	if now.After(d.ValidUntil) ||
+		(now.Equal(d.ValidUntil) && !d.ValidUntilInclusive) {
 		return ErrExpired
 	}
 	return nil
@@ -265,15 +279,17 @@ func ParseMainnetObservation(
 	}
 	price, _ := rate.Float64()
 	return Observation{
-		Pair:             "ADA/USD",
-		Source:           "djed",
-		PriceNumerator:   datum.PriceNumerator,
-		PriceDenominator: datum.PriceDenominator,
-		Price:            price,
-		ValidFrom:        datum.ValidFrom,
-		ValidUntil:       datum.ValidUntil,
-		TxHash:           utxo.TxHash,
-		TxIndex:          utxo.TxIndex,
+		Pair:                "ADA/USD",
+		Source:              "djed",
+		PriceNumerator:      datum.PriceNumerator,
+		PriceDenominator:    datum.PriceDenominator,
+		Price:               price,
+		ValidFrom:           datum.ValidFrom,
+		ValidFromInclusive:  datum.ValidFromInclusive,
+		ValidUntil:          datum.ValidUntil,
+		ValidUntilInclusive: datum.ValidUntilInclusive,
+		TxHash:              utxo.TxHash,
+		TxIndex:             utxo.TxIndex,
 	}, nil
 }
 
@@ -307,21 +323,49 @@ func constructorFields(
 	return fields, nil
 }
 
-func finiteBoundMillis(data []byte) (int64, error) {
+func finiteBound(data []byte) (int64, bool, error) {
 	boundFields, err := constructorFields(data, 0, 2)
 	if err != nil {
-		return 0, err
+		return 0, false, err
 	}
 	valueFields, err := constructorFields(boundFields[0], 1, 1)
 	if err != nil {
-		return 0, err
+		return 0, false, err
 	}
 	var millis uint64
 	if _, err := cbor.Decode(valueFields[0], &millis); err != nil {
-		return 0, err
+		return 0, false, err
 	}
 	if millis > math.MaxInt64 {
-		return 0, fmt.Errorf("timestamp overflows int64")
+		return 0, false, fmt.Errorf("timestamp overflows int64")
 	}
-	return int64(millis), nil
+	inclusive, err := plutusBool(boundFields[1])
+	if err != nil {
+		return 0, false, fmt.Errorf("closure: %w", err)
+	}
+	return int64(millis), inclusive, nil
+}
+
+func plutusBool(data []byte) (bool, error) {
+	var constructor cbor.ConstructorDecoder
+	if _, err := cbor.Decode(data, &constructor); err != nil {
+		return false, err
+	}
+	if constructor.Tag() > 1 {
+		return false, fmt.Errorf(
+			"expected boolean constructor 0 or 1, got %d",
+			constructor.Tag(),
+		)
+	}
+	var fields []cbor.RawMessage
+	if _, err := cbor.Decode(constructor.Fields(), &fields); err != nil {
+		return false, err
+	}
+	if len(fields) != 0 {
+		return false, fmt.Errorf(
+			"expected boolean with no fields, got %d",
+			len(fields),
+		)
+	}
+	return constructor.Tag() == 1, nil
 }

--- a/price/djed/oracle.go
+++ b/price/djed/oracle.go
@@ -1,0 +1,327 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package djed decodes and validates Open Djed on-chain oracle state.
+package djed
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"math"
+	"math/big"
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/shai/common"
+)
+
+const (
+	MainnetOracleAddress = "addr1wxyc99q448xlkv4q2y3truxq7j2msr6hkqqg0wmzz9n9r6q8j7kpa"
+	MainnetOraclePolicy  = "815aca02042ba9188a2ca4f8ce7b276046e2376b4bce56391342299e"
+	OracleNFTName        = "446a65644f7261636c654e4654"
+	QuoteCurrency        = "USD"
+
+	oracleSignatureLength = 64
+)
+
+var (
+	ErrInvalidDatum = errors.New("djed: invalid oracle datum")
+	ErrInvalidRate  = errors.New("djed: invalid ADA/USD rate")
+	ErrWrongAddress = errors.New("djed: wrong oracle address")
+	ErrMissingNFT   = errors.New("djed: missing oracle NFT")
+	ErrWrongPolicy  = errors.New("djed: wrong oracle policy")
+	ErrWrongQuote   = errors.New("djed: wrong quote currency")
+	ErrNotYetValid  = errors.New("djed: oracle value is not yet valid")
+	ErrExpired      = errors.New("djed: oracle value is expired")
+)
+
+// OracleDatum is the authenticated price and validity interval stored with the
+// Djed Oracle NFT.
+type OracleDatum struct {
+	Signature        []byte
+	PriceNumerator   uint64
+	PriceDenominator uint64
+	ValidFrom        time.Time
+	ValidUntil       time.Time
+	ExpressedIn      []byte
+	OraclePolicy     []byte
+}
+
+// OracleUTxO contains the identity-bearing parts of the UTxO holding a datum.
+type OracleUTxO struct {
+	Address string
+	Assets  []common.AssetAmount
+	TxHash  string
+	TxIndex uint32
+}
+
+// Observation is a validated local-ledger ADA/USD observation.
+type Observation struct {
+	Pair             string    `json:"pair"`
+	Source           string    `json:"source"`
+	PriceNumerator   uint64    `json:"priceNumerator"`
+	PriceDenominator uint64    `json:"priceDenominator"`
+	Price            float64   `json:"price"`
+	ValidFrom        time.Time `json:"validFrom"`
+	ValidUntil       time.Time `json:"validUntil"`
+	TxHash           string    `json:"txHash"`
+	TxIndex          uint32    `json:"txIndex"`
+}
+
+// ParseOracleDatum decodes the Open Djed OracleDatum schema.
+func ParseOracleDatum(data []byte) (OracleDatum, error) {
+	fields, err := constructorFields(data, 0, 3)
+	if err != nil {
+		return OracleDatum{}, fmt.Errorf("%w: %v", ErrInvalidDatum, err)
+	}
+
+	var datum OracleDatum
+	if _, err := cbor.Decode(fields[0], &datum.Signature); err != nil {
+		return OracleDatum{}, fmt.Errorf(
+			"%w: signature: %v",
+			ErrInvalidDatum,
+			err,
+		)
+	}
+
+	oracleFields, err := constructorFields(fields[1], 0, 3)
+	if err != nil {
+		return OracleDatum{}, fmt.Errorf(
+			"%w: oracle fields: %v",
+			ErrInvalidDatum,
+			err,
+		)
+	}
+	rateFields, err := constructorFields(oracleFields[0], 0, 2)
+	if err != nil {
+		return OracleDatum{}, fmt.Errorf(
+			"%w: exchange rate: %v",
+			ErrInvalidDatum,
+			err,
+		)
+	}
+	if _, err := cbor.Decode(
+		rateFields[0],
+		&datum.PriceDenominator,
+	); err != nil {
+		return OracleDatum{}, fmt.Errorf(
+			"%w: rate denominator: %v",
+			ErrInvalidDatum,
+			err,
+		)
+	}
+	if _, err := cbor.Decode(
+		rateFields[1],
+		&datum.PriceNumerator,
+	); err != nil {
+		return OracleDatum{}, fmt.Errorf(
+			"%w: rate numerator: %v",
+			ErrInvalidDatum,
+			err,
+		)
+	}
+
+	validityFields, err := constructorFields(oracleFields[1], 0, 2)
+	if err != nil {
+		return OracleDatum{}, fmt.Errorf(
+			"%w: validity range: %v",
+			ErrInvalidDatum,
+			err,
+		)
+	}
+	validFromMillis, err := finiteBoundMillis(validityFields[0])
+	if err != nil {
+		return OracleDatum{}, fmt.Errorf(
+			"%w: lower bound: %v",
+			ErrInvalidDatum,
+			err,
+		)
+	}
+	validUntilMillis, err := finiteBoundMillis(validityFields[1])
+	if err != nil {
+		return OracleDatum{}, fmt.Errorf(
+			"%w: upper bound: %v",
+			ErrInvalidDatum,
+			err,
+		)
+	}
+	datum.ValidFrom = time.UnixMilli(validFromMillis).UTC()
+	datum.ValidUntil = time.UnixMilli(validUntilMillis).UTC()
+
+	if _, err := cbor.Decode(
+		oracleFields[2],
+		&datum.ExpressedIn,
+	); err != nil {
+		return OracleDatum{}, fmt.Errorf(
+			"%w: quote currency: %v",
+			ErrInvalidDatum,
+			err,
+		)
+	}
+	if _, err := cbor.Decode(fields[2], &datum.OraclePolicy); err != nil {
+		return OracleDatum{}, fmt.Errorf(
+			"%w: oracle policy: %v",
+			ErrInvalidDatum,
+			err,
+		)
+	}
+	return datum, nil
+}
+
+// ValidateMainnet authenticates a decoded datum against the mainnet deployment
+// and checks that its rate is currently usable.
+func (d OracleDatum) ValidateMainnet(
+	utxo OracleUTxO,
+	now time.Time,
+) error {
+	if utxo.Address != MainnetOracleAddress {
+		return ErrWrongAddress
+	}
+	oracleAsset, err := common.NewAssetClass(
+		MainnetOraclePolicy,
+		OracleNFTName,
+	)
+	if err != nil {
+		return fmt.Errorf("djed: invalid built-in oracle identity: %w", err)
+	}
+	hasNFT := false
+	for _, asset := range utxo.Assets {
+		if asset.IsAsset(oracleAsset) && asset.Amount == 1 {
+			hasNFT = true
+			break
+		}
+	}
+	if !hasNFT {
+		return ErrMissingNFT
+	}
+	if len(d.Signature) != oracleSignatureLength {
+		return fmt.Errorf(
+			"%w: signature must be %d bytes",
+			ErrInvalidDatum,
+			oracleSignatureLength,
+		)
+	}
+	if !bytes.Equal(d.OraclePolicy, oracleAsset.PolicyId) {
+		return ErrWrongPolicy
+	}
+	if string(d.ExpressedIn) != QuoteCurrency {
+		return ErrWrongQuote
+	}
+	if d.PriceNumerator == 0 || d.PriceDenominator == 0 {
+		return ErrInvalidRate
+	}
+	if !d.ValidFrom.Before(d.ValidUntil) {
+		return fmt.Errorf("%w: invalid validity interval", ErrInvalidDatum)
+	}
+	now = now.UTC()
+	if now.Before(d.ValidFrom) {
+		return ErrNotYetValid
+	}
+	if !now.Before(d.ValidUntil) {
+		return ErrExpired
+	}
+	return nil
+}
+
+// Rat returns the exact ADA/USD exchange rate.
+func (d OracleDatum) Rat() (*big.Rat, error) {
+	if d.PriceNumerator == 0 || d.PriceDenominator == 0 {
+		return nil, ErrInvalidRate
+	}
+	return new(big.Rat).SetFrac(
+		new(big.Int).SetUint64(d.PriceNumerator),
+		new(big.Int).SetUint64(d.PriceDenominator),
+	), nil
+}
+
+// ParseMainnetObservation decodes and validates a mainnet Djed observation.
+func ParseMainnetObservation(
+	data []byte,
+	utxo OracleUTxO,
+	now time.Time,
+) (Observation, error) {
+	datum, err := ParseOracleDatum(data)
+	if err != nil {
+		return Observation{}, err
+	}
+	if err := datum.ValidateMainnet(utxo, now); err != nil {
+		return Observation{}, err
+	}
+	rate, err := datum.Rat()
+	if err != nil {
+		return Observation{}, err
+	}
+	price, _ := rate.Float64()
+	return Observation{
+		Pair:             "ADA/USD",
+		Source:           "djed",
+		PriceNumerator:   datum.PriceNumerator,
+		PriceDenominator: datum.PriceDenominator,
+		Price:            price,
+		ValidFrom:        datum.ValidFrom,
+		ValidUntil:       datum.ValidUntil,
+		TxHash:           utxo.TxHash,
+		TxIndex:          utxo.TxIndex,
+	}, nil
+}
+
+func constructorFields(
+	data []byte,
+	expectedTag uint,
+	expectedCount int,
+) ([]cbor.RawMessage, error) {
+	var constructor cbor.ConstructorDecoder
+	if _, err := cbor.Decode(data, &constructor); err != nil {
+		return nil, err
+	}
+	if constructor.Tag() != expectedTag {
+		return nil, fmt.Errorf(
+			"expected constructor %d, got %d",
+			expectedTag,
+			constructor.Tag(),
+		)
+	}
+	var fields []cbor.RawMessage
+	if _, err := cbor.Decode(constructor.Fields(), &fields); err != nil {
+		return nil, err
+	}
+	if len(fields) != expectedCount {
+		return nil, fmt.Errorf(
+			"expected %d fields, got %d",
+			expectedCount,
+			len(fields),
+		)
+	}
+	return fields, nil
+}
+
+func finiteBoundMillis(data []byte) (int64, error) {
+	boundFields, err := constructorFields(data, 0, 2)
+	if err != nil {
+		return 0, err
+	}
+	valueFields, err := constructorFields(boundFields[0], 1, 1)
+	if err != nil {
+		return 0, err
+	}
+	var millis uint64
+	if _, err := cbor.Decode(valueFields[0], &millis); err != nil {
+		return 0, err
+	}
+	if millis > math.MaxInt64 {
+		return 0, fmt.Errorf("timestamp overflows int64")
+	}
+	return int64(millis), nil
+}

--- a/price/djed/oracle_test.go
+++ b/price/djed/oracle_test.go
@@ -1,0 +1,244 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package djed
+
+import (
+	"encoding/hex"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/shai/common"
+	"github.com/stretchr/testify/require"
+)
+
+const currentMainnetDatum = "d8799f584004ea10278c7b8c3c636536a8a1b831d8e193e8aca7df1ee2b83fe856f1fede93fb818e3453f135f37a68d464bf3c6e38d1e4e4750d60cba6dbc3a96132aa6507d8799fd8799f1a000f42401a00029463ffd8799fd8799fd87a9f1b0000019f90e8fcc0ffd87a80ffd8799fd87a9f1b0000019f90f6b860ffd87a80ffff43555344ff581c815aca02042ba9188a2ca4f8ce7b276046e2376b4bce56391342299eff"
+
+func TestParseMainnetObservationCurrentFixture(t *testing.T) {
+	data := mustDecodeHex(t, currentMainnetDatum)
+	utxo := currentMainnetUTxO(t)
+	now := time.Unix(1_784_842_625, 0).UTC()
+
+	observation, err := ParseMainnetObservation(data, utxo, now)
+	require.NoError(t, err)
+	require.Equal(t, "ADA/USD", observation.Pair)
+	require.Equal(t, "djed", observation.Source)
+	require.Equal(t, uint64(169_059), observation.PriceNumerator)
+	require.Equal(t, uint64(1_000_000), observation.PriceDenominator)
+	require.InDelta(t, 0.169059, observation.Price, 0.0000001)
+	require.Equal(
+		t,
+		time.UnixMilli(1_784_842_616_000).UTC(),
+		observation.ValidFrom,
+	)
+	require.Equal(
+		t,
+		time.UnixMilli(1_784_843_516_000).UTC(),
+		observation.ValidUntil,
+	)
+	require.Equal(
+		t,
+		"b8ec7d85670902edafdc73b1f2faa57e2aed867e3718851b2c1489ae7c0587d4",
+		observation.TxHash,
+	)
+	require.Equal(t, uint32(0), observation.TxIndex)
+}
+
+func TestParseOfficialOpenDjedFixture(t *testing.T) {
+	data := mustDecodeHex(
+		t,
+		"d8799f5840baf00a3eaa2919ef46bbdc67cfe6b50819a64781189d95317a8183c34bdce1cb32647a5bbe7950c97ec31c601064fbd255bb69a52d8b7c8b1f706e1aba3deb07d8799fd8799f19c350196ce7ffd8799fd8799fd87a9f1b0000019617d34560ffd87a80ffd8799fd87a9f1b0000019617e10100ffd87a80ffff43555344ff581c815aca02042ba9188a2ca4f8ce7b276046e2376b4bce56391342299eff",
+	)
+	datum, err := ParseOracleDatum(data)
+	require.NoError(t, err)
+	require.Equal(t, uint64(27_879), datum.PriceNumerator)
+	require.Equal(t, uint64(50_000), datum.PriceDenominator)
+	require.Equal(t, []byte("USD"), datum.ExpressedIn)
+	require.Equal(
+		t,
+		time.UnixMilli(1_744_156_444_000).UTC(),
+		datum.ValidFrom,
+	)
+	require.Equal(
+		t,
+		time.UnixMilli(1_744_157_344_000).UTC(),
+		datum.ValidUntil,
+	)
+}
+
+func TestValidateMainnetRejectsInvalidCandidates(t *testing.T) {
+	datum, err := ParseOracleDatum(mustDecodeHex(t, currentMainnetDatum))
+	require.NoError(t, err)
+	utxo := currentMainnetUTxO(t)
+	validNow := time.Unix(1_784_842_625, 0).UTC()
+
+	tests := []struct {
+		name   string
+		mutate func(*OracleDatum, *OracleUTxO, *time.Time)
+		want   error
+	}{
+		{
+			name: "wrong address",
+			mutate: func(_ *OracleDatum, u *OracleUTxO, _ *time.Time) {
+				u.Address = "addr1wrong"
+			},
+			want: ErrWrongAddress,
+		},
+		{
+			name: "missing NFT",
+			mutate: func(_ *OracleDatum, u *OracleUTxO, _ *time.Time) {
+				u.Assets = nil
+			},
+			want: ErrMissingNFT,
+		},
+		{
+			name: "NFT quantity",
+			mutate: func(_ *OracleDatum, u *OracleUTxO, _ *time.Time) {
+				u.Assets[0].Amount = 2
+			},
+			want: ErrMissingNFT,
+		},
+		{
+			name: "signature length",
+			mutate: func(d *OracleDatum, _ *OracleUTxO, _ *time.Time) {
+				d.Signature = d.Signature[:63]
+			},
+			want: ErrInvalidDatum,
+		},
+		{
+			name: "wrong policy",
+			mutate: func(d *OracleDatum, _ *OracleUTxO, _ *time.Time) {
+				d.OraclePolicy[0] ^= 0xff
+			},
+			want: ErrWrongPolicy,
+		},
+		{
+			name: "wrong quote",
+			mutate: func(d *OracleDatum, _ *OracleUTxO, _ *time.Time) {
+				d.ExpressedIn = []byte("EUR")
+			},
+			want: ErrWrongQuote,
+		},
+		{
+			name: "zero numerator",
+			mutate: func(d *OracleDatum, _ *OracleUTxO, _ *time.Time) {
+				d.PriceNumerator = 0
+			},
+			want: ErrInvalidRate,
+		},
+		{
+			name: "zero denominator",
+			mutate: func(d *OracleDatum, _ *OracleUTxO, _ *time.Time) {
+				d.PriceDenominator = 0
+			},
+			want: ErrInvalidRate,
+		},
+		{
+			name: "invalid interval",
+			mutate: func(d *OracleDatum, _ *OracleUTxO, _ *time.Time) {
+				d.ValidUntil = d.ValidFrom
+			},
+			want: ErrInvalidDatum,
+		},
+		{
+			name: "not yet valid",
+			mutate: func(_ *OracleDatum, _ *OracleUTxO, now *time.Time) {
+				*now = time.UnixMilli(1_784_842_615_999).UTC()
+			},
+			want: ErrNotYetValid,
+		},
+		{
+			name: "expired",
+			mutate: func(_ *OracleDatum, _ *OracleUTxO, now *time.Time) {
+				*now = time.UnixMilli(1_784_843_516_000).UTC()
+			},
+			want: ErrExpired,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			candidateDatum := cloneDatum(datum)
+			candidateUTxO := cloneUTxO(utxo)
+			now := validNow
+			test.mutate(&candidateDatum, &candidateUTxO, &now)
+			err := candidateDatum.ValidateMainnet(candidateUTxO, now)
+			require.ErrorIs(t, err, test.want)
+		})
+	}
+}
+
+func TestParseOracleDatumRejectsMalformedSchema(t *testing.T) {
+	for _, data := range [][]byte{
+		{0xff},
+		mustEncode(t, cbor.NewConstructorEncoder(
+			1,
+			cbor.IndefLengthList{},
+		)),
+		mustEncode(t, cbor.NewConstructorEncoder(
+			0,
+			cbor.IndefLengthList{[]byte("short")},
+		)),
+	} {
+		_, err := ParseOracleDatum(data)
+		require.ErrorIs(t, err, ErrInvalidDatum)
+	}
+}
+
+func currentMainnetUTxO(t *testing.T) OracleUTxO {
+	t.Helper()
+	asset, err := common.NewAssetClass(MainnetOraclePolicy, OracleNFTName)
+	require.NoError(t, err)
+	return OracleUTxO{
+		Address: MainnetOracleAddress,
+		Assets: []common.AssetAmount{{
+			Class:  asset,
+			Amount: 1,
+		}},
+		TxHash: "b8ec7d85670902edafdc73b1f2faa57e2aed867e3718851b2c1489ae7c0587d4",
+	}
+}
+
+func cloneDatum(datum OracleDatum) OracleDatum {
+	datum.Signature = append([]byte(nil), datum.Signature...)
+	datum.ExpressedIn = append([]byte(nil), datum.ExpressedIn...)
+	datum.OraclePolicy = append([]byte(nil), datum.OraclePolicy...)
+	return datum
+}
+
+func cloneUTxO(utxo OracleUTxO) OracleUTxO {
+	utxo.Assets = append([]common.AssetAmount(nil), utxo.Assets...)
+	return utxo
+}
+
+func mustDecodeHex(t *testing.T, value string) []byte {
+	t.Helper()
+	data, err := hex.DecodeString(value)
+	require.NoError(t, err)
+	return data
+}
+
+func mustEncode(t *testing.T, value any) []byte {
+	t.Helper()
+	data, err := cbor.Encode(value)
+	require.NoError(t, err)
+	return data
+}
+
+func TestRatRejectsInvalidRate(t *testing.T) {
+	_, err := (OracleDatum{}).Rat()
+	require.True(t, errors.Is(err, ErrInvalidRate))
+}

--- a/price/djed/oracle_test.go
+++ b/price/djed/oracle_test.go
@@ -44,11 +44,13 @@ func TestParseMainnetObservationCurrentFixture(t *testing.T) {
 		time.UnixMilli(1_784_842_616_000).UTC(),
 		observation.ValidFrom,
 	)
+	require.True(t, observation.ValidFromInclusive)
 	require.Equal(
 		t,
 		time.UnixMilli(1_784_843_516_000).UTC(),
 		observation.ValidUntil,
 	)
+	require.True(t, observation.ValidUntilInclusive)
 	require.Equal(
 		t,
 		"b8ec7d85670902edafdc73b1f2faa57e2aed867e3718851b2c1489ae7c0587d4",
@@ -77,6 +79,8 @@ func TestParseOfficialOpenDjedFixture(t *testing.T) {
 		time.UnixMilli(1_744_157_344_000).UTC(),
 		datum.ValidUntil,
 	)
+	require.True(t, datum.ValidFromInclusive)
+	require.True(t, datum.ValidUntilInclusive)
 }
 
 func TestValidateMainnetRejectsInvalidCandidates(t *testing.T) {
@@ -149,9 +153,17 @@ func TestValidateMainnetRejectsInvalidCandidates(t *testing.T) {
 		{
 			name: "invalid interval",
 			mutate: func(d *OracleDatum, _ *OracleUTxO, _ *time.Time) {
-				d.ValidUntil = d.ValidFrom
+				d.ValidUntil = d.ValidFrom.Add(-time.Nanosecond)
 			},
 			want: ErrInvalidDatum,
+		},
+		{
+			name: "exclusive lower endpoint",
+			mutate: func(d *OracleDatum, _ *OracleUTxO, now *time.Time) {
+				d.ValidFromInclusive = false
+				*now = d.ValidFrom
+			},
+			want: ErrNotYetValid,
 		},
 		{
 			name: "not yet valid",
@@ -161,9 +173,17 @@ func TestValidateMainnetRejectsInvalidCandidates(t *testing.T) {
 			want: ErrNotYetValid,
 		},
 		{
+			name: "exclusive upper endpoint",
+			mutate: func(d *OracleDatum, _ *OracleUTxO, now *time.Time) {
+				d.ValidUntilInclusive = false
+				*now = d.ValidUntil
+			},
+			want: ErrExpired,
+		},
+		{
 			name: "expired",
-			mutate: func(_ *OracleDatum, _ *OracleUTxO, now *time.Time) {
-				*now = time.UnixMilli(1_784_843_516_000).UTC()
+			mutate: func(d *OracleDatum, _ *OracleUTxO, now *time.Time) {
+				*now = d.ValidUntil.Add(time.Nanosecond)
 			},
 			want: ErrExpired,
 		},
@@ -181,6 +201,15 @@ func TestValidateMainnetRejectsInvalidCandidates(t *testing.T) {
 	}
 }
 
+func TestValidateMainnetAcceptsInclusiveEndpoints(t *testing.T) {
+	datum, err := ParseOracleDatum(mustDecodeHex(t, currentMainnetDatum))
+	require.NoError(t, err)
+	utxo := currentMainnetUTxO(t)
+
+	require.NoError(t, datum.ValidateMainnet(utxo, datum.ValidFrom))
+	require.NoError(t, datum.ValidateMainnet(utxo, datum.ValidUntil))
+}
+
 func TestParseOracleDatumRejectsMalformedSchema(t *testing.T) {
 	for _, data := range [][]byte{
 		{0xff},
@@ -196,6 +225,20 @@ func TestParseOracleDatumRejectsMalformedSchema(t *testing.T) {
 		_, err := ParseOracleDatum(data)
 		require.ErrorIs(t, err, ErrInvalidDatum)
 	}
+}
+
+func TestPlutusBoolRejectsMalformedClosure(t *testing.T) {
+	_, err := plutusBool(mustEncode(
+		t,
+		cbor.NewConstructorEncoder(2, cbor.IndefLengthList{}),
+	))
+	require.Error(t, err)
+
+	_, err = plutusBool(mustEncode(
+		t,
+		cbor.NewConstructorEncoder(1, cbor.IndefLengthList{uint64(1)}),
+	))
+	require.Error(t, err)
 }
 
 func currentMainnetUTxO(t *testing.T) OracleUTxO {


### PR DESCRIPTION
Parses and validates authenticated Djed ADA/USD oracle UTxOs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parses and validates authenticated Djed ADA/USD oracle UTxOs and returns a typed observation with exact and float price and validity times. Validation now honors inclusive/exclusive validity boundaries.

- **New Features**
  - `price/djed/oracle.go`: `ParseOracleDatum`, `ValidateMainnet`, `ParseMainnetObservation`, `Rat`; new `Observation` and `OracleUTxO` types.
  - Validates mainnet identity (address, NFT policy `815aca02042ba9188a2ca4f8ce7b276046e2376b4bce56391342299e`, NFT name, 64-byte signature), quote `USD`, non-zero rate, and active validity window.

- **Bug Fixes**
  - Correctly handle validity closures (inclusive/exclusive bounds) during validation and in tests.

<sup>Written for commit 13ac75c19b86b4eefb24f3fd6776b8aba803be61. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/shai/pull/370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

