### PR TITLE
feat: track Djed oracle state

### DIFF
--- a/price/djed/oracle.go
+++ b/price/djed/oracle.go
@@ -63,10 +63,12 @@ type OracleDatum struct {
 
 // OracleUTxO contains the identity-bearing parts of the UTxO holding a datum.
 type OracleUTxO struct {
-	Address string
-	Assets  []common.AssetAmount
-	TxHash  string
-	TxIndex uint32
+	Address   string
+	Assets    []common.AssetAmount
+	TxHash    string
+	TxIndex   uint32
+	Slot      uint64
+	BlockHash string
 }
 
 // Observation is a validated local-ledger ADA/USD observation.
@@ -82,6 +84,19 @@ type Observation struct {
 	ValidUntilInclusive bool      `json:"validUntilInclusive"`
 	TxHash              string    `json:"txHash"`
 	TxIndex             uint32    `json:"txIndex"`
+	Slot                uint64    `json:"slot"`
+	BlockHash           string    `json:"blockHash"`
+}
+
+// ValidateAt checks whether the observation is usable at the supplied time.
+func (o Observation) ValidateAt(now time.Time) error {
+	return validateInterval(
+		o.ValidFrom,
+		o.ValidFromInclusive,
+		o.ValidUntil,
+		o.ValidUntilInclusive,
+		now,
+	)
 }
 
 // ParseOracleDatum decodes the Open Djed OracleDatum schema.
@@ -232,21 +247,13 @@ func (d OracleDatum) ValidateMainnet(
 	if d.PriceNumerator == 0 || d.PriceDenominator == 0 {
 		return ErrInvalidRate
 	}
-	if d.ValidFrom.After(d.ValidUntil) ||
-		(d.ValidFrom.Equal(d.ValidUntil) &&
-			(!d.ValidFromInclusive || !d.ValidUntilInclusive)) {
-		return fmt.Errorf("%w: invalid validity interval", ErrInvalidDatum)
-	}
-	now = now.UTC()
-	if now.Before(d.ValidFrom) ||
-		(now.Equal(d.ValidFrom) && !d.ValidFromInclusive) {
-		return ErrNotYetValid
-	}
-	if now.After(d.ValidUntil) ||
-		(now.Equal(d.ValidUntil) && !d.ValidUntilInclusive) {
-		return ErrExpired
-	}
-	return nil
+	return validateInterval(
+		d.ValidFrom,
+		d.ValidFromInclusive,
+		d.ValidUntil,
+		d.ValidUntilInclusive,
+		now,
+	)
 }
 
 // Rat returns the exact ADA/USD exchange rate.
@@ -290,7 +297,33 @@ func ParseMainnetObservation(
 		ValidUntilInclusive: datum.ValidUntilInclusive,
 		TxHash:              utxo.TxHash,
 		TxIndex:             utxo.TxIndex,
+		Slot:                utxo.Slot,
+		BlockHash:           utxo.BlockHash,
 	}, nil
+}
+
+func validateInterval(
+	validFrom time.Time,
+	validFromInclusive bool,
+	validUntil time.Time,
+	validUntilInclusive bool,
+	now time.Time,
+) error {
+	if validFrom.After(validUntil) ||
+		(validFrom.Equal(validUntil) &&
+			(!validFromInclusive || !validUntilInclusive)) {
+		return fmt.Errorf("%w: invalid validity interval", ErrInvalidDatum)
+	}
+	now = now.UTC()
+	if now.Before(validFrom) ||
+		(now.Equal(validFrom) && !validFromInclusive) {
+		return ErrNotYetValid
+	}
+	if now.After(validUntil) ||
+		(now.Equal(validUntil) && !validUntilInclusive) {
+		return ErrExpired
+	}
+	return nil
 }
 
 func constructorFields(

--- a/price/djed/oracle.go
+++ b/price/djed/oracle.go
@@ -63,12 +63,14 @@ type OracleDatum struct {
 
 // OracleUTxO contains the identity-bearing parts of the UTxO holding a datum.
 type OracleUTxO struct {
-	Address   string
-	Assets    []common.AssetAmount
-	TxHash    string
-	TxIndex   uint32
-	Slot      uint64
-	BlockHash string
+	Address string
+	Assets  []common.AssetAmount
+	TxHash  string
+	TxIndex uint32
+	// TransactionIndex is the transaction's position within its block.
+	TransactionIndex uint32
+	Slot             uint64
+	BlockHash        string
 }
 
 // Observation is a validated local-ledger ADA/USD observation.
@@ -84,6 +86,7 @@ type Observation struct {
 	ValidUntilInclusive bool      `json:"validUntilInclusive"`
 	TxHash              string    `json:"txHash"`
 	TxIndex             uint32    `json:"txIndex"`
+	TransactionIndex    uint32    `json:"transactionIndex"`
 	Slot                uint64    `json:"slot"`
 	BlockHash           string    `json:"blockHash"`
 }
@@ -284,7 +287,10 @@ func ParseMainnetObservation(
 	if err != nil {
 		return Observation{}, err
 	}
-	price, _ := rate.Float64()
+	price, err := finiteRateFloat64(rate)
+	if err != nil {
+		return Observation{}, err
+	}
 	return Observation{
 		Pair:                "ADA/USD",
 		Source:              "djed",
@@ -297,9 +303,22 @@ func ParseMainnetObservation(
 		ValidUntilInclusive: datum.ValidUntilInclusive,
 		TxHash:              utxo.TxHash,
 		TxIndex:             utxo.TxIndex,
+		TransactionIndex:    utxo.TransactionIndex,
 		Slot:                utxo.Slot,
 		BlockHash:           utxo.BlockHash,
 	}, nil
+}
+
+func finiteRateFloat64(rate *big.Rat) (float64, error) {
+	approximation, exact := rate.Float64()
+	if math.IsInf(approximation, 0) || math.IsNaN(approximation) {
+		return 0, ErrInvalidRate
+	}
+	if exact {
+		return approximation, nil
+	}
+	// JSON exposes an approximation alongside the exact rational fields.
+	return approximation, nil
 }
 
 func validateInterval(

--- a/price/djed/oracle_test.go
+++ b/price/djed/oracle_test.go
@@ -17,6 +17,7 @@ package djed
 import (
 	"encoding/hex"
 	"errors"
+	"math/big"
 	"testing"
 	"time"
 
@@ -284,4 +285,14 @@ func mustEncode(t *testing.T, value any) []byte {
 func TestRatRejectsInvalidRate(t *testing.T) {
 	_, err := (OracleDatum{}).Rat()
 	require.True(t, errors.Is(err, ErrInvalidRate))
+}
+
+func TestFiniteRateFloat64RejectsOverflow(t *testing.T) {
+	hugeInteger := new(big.Int).Exp(
+		big.NewInt(10),
+		big.NewInt(400),
+		nil,
+	)
+	_, err := finiteRateFloat64(new(big.Rat).SetInt(hugeInteger))
+	require.ErrorIs(t, err, ErrInvalidRate)
 }

--- a/price/djed/tracker.go
+++ b/price/djed/tracker.go
@@ -1,0 +1,133 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package djed
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+var ErrNoCurrentObservation = errors.New(
+	"djed: no authenticated unspent oracle observation",
+)
+
+// OutputRef identifies an on-chain transaction output.
+type OutputRef struct {
+	TxHash  string
+	TxIndex uint32
+}
+
+type trackedObservation struct {
+	observation Observation
+	spentAt     *uint64
+}
+
+// Tracker maintains Djed observations from a caller's local chain-sync stream.
+// It keeps spent entries so a rollback can restore the preceding oracle UTxO.
+type Tracker struct {
+	mu           sync.RWMutex
+	observations map[OutputRef]trackedObservation
+}
+
+// NewTracker creates an empty Djed oracle tracker.
+func NewTracker() *Tracker {
+	return &Tracker{
+		observations: make(map[OutputRef]trackedObservation),
+	}
+}
+
+// Apply validates and records a produced Djed oracle UTxO.
+func (t *Tracker) Apply(
+	data []byte,
+	utxo OracleUTxO,
+	now time.Time,
+) (Observation, error) {
+	observation, err := ParseMainnetObservation(data, utxo, now)
+	if err != nil {
+		return Observation{}, err
+	}
+	ref := OutputRef{TxHash: utxo.TxHash, TxIndex: utxo.TxIndex}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.observations[ref] = trackedObservation{observation: observation}
+	return observation, nil
+}
+
+// ConsumeAt marks an oracle UTxO spent at the supplied chain slot.
+func (t *Tracker) ConsumeAt(ref OutputRef, slot uint64) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	tracked, ok := t.observations[ref]
+	if !ok {
+		return
+	}
+	spentAt := slot
+	tracked.spentAt = &spentAt
+	t.observations[ref] = tracked
+}
+
+// Rollback removes observations produced at or after the rollback slot and
+// restores observations whose spends were rolled back.
+func (t *Tracker) Rollback(slot uint64) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for ref, tracked := range t.observations {
+		if tracked.observation.Slot >= slot {
+			delete(t.observations, ref)
+			continue
+		}
+		if tracked.spentAt != nil && *tracked.spentAt >= slot {
+			tracked.spentAt = nil
+			t.observations[ref] = tracked
+		}
+	}
+}
+
+// Current returns the newest authenticated, unspent observation and checks its
+// on-chain validity interval at the supplied time.
+func (t *Tracker) Current(now time.Time) (Observation, error) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	var current Observation
+	found := false
+	for _, tracked := range t.observations {
+		if tracked.spentAt != nil {
+			continue
+		}
+		candidate := tracked.observation
+		if !found || observationAfter(candidate, current) {
+			current = candidate
+			found = true
+		}
+	}
+	if !found {
+		return Observation{}, ErrNoCurrentObservation
+	}
+	if err := current.ValidateAt(now); err != nil {
+		return current, err
+	}
+	return current, nil
+}
+
+func observationAfter(candidate, current Observation) bool {
+	if candidate.Slot != current.Slot {
+		return candidate.Slot > current.Slot
+	}
+	if candidate.TxIndex != current.TxIndex {
+		return candidate.TxIndex > current.TxIndex
+	}
+	return candidate.TxHash > current.TxHash
+}

--- a/price/djed/tracker.go
+++ b/price/djed/tracker.go
@@ -79,17 +79,18 @@ func (t *Tracker) ConsumeAt(ref OutputRef, slot uint64) {
 	t.observations[ref] = tracked
 }
 
-// Rollback removes observations produced at or after the rollback slot and
-// restores observations whose spends were rolled back.
+// Rollback removes observations produced after the rollback point and restores
+// observations whose spends occurred after it. State in the point's block is
+// retained.
 func (t *Tracker) Rollback(slot uint64) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	for ref, tracked := range t.observations {
-		if tracked.observation.Slot >= slot {
+		if tracked.observation.Slot > slot {
 			delete(t.observations, ref)
 			continue
 		}
-		if tracked.spentAt != nil && *tracked.spentAt >= slot {
+		if tracked.spentAt != nil && *tracked.spentAt > slot {
 			tracked.spentAt = nil
 			t.observations[ref] = tracked
 		}

--- a/price/djed/tracker.go
+++ b/price/djed/tracker.go
@@ -24,6 +24,10 @@ var ErrNoCurrentObservation = errors.New(
 	"djed: no authenticated unspent oracle observation",
 )
 
+var ErrConflictingObservation = errors.New(
+	"djed: output reference has conflicting oracle observations",
+)
+
 // OutputRef identifies an on-chain transaction output.
 type OutputRef struct {
 	TxHash  string
@@ -62,6 +66,14 @@ func (t *Tracker) Apply(
 	ref := OutputRef{TxHash: utxo.TxHash, TxIndex: utxo.TxIndex}
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	if existing, ok := t.observations[ref]; ok {
+		if existing.observation != observation {
+			return Observation{}, ErrConflictingObservation
+		}
+		// Chain replay may deliver the same output again. Preserve its spend
+		// state rather than resurrecting an already-consumed UTxO.
+		return observation, nil
+	}
 	t.observations[ref] = trackedObservation{observation: observation}
 	return observation, nil
 }
@@ -72,11 +84,29 @@ func (t *Tracker) ConsumeAt(ref OutputRef, slot uint64) {
 	defer t.mu.Unlock()
 	tracked, ok := t.observations[ref]
 	if !ok {
+		// A tracker started mid-chain may see a spend whose output predates
+		// its local history. There is no state to update in that case.
 		return
 	}
 	spentAt := slot
 	tracked.spentAt = &spentAt
 	t.observations[ref] = tracked
+}
+
+// Prune removes spent entries older than beforeSlot. Callers should advance
+// beforeSlot only beyond their immutable rollback horizon. Entries spent at the
+// boundary are retained.
+func (t *Tracker) Prune(beforeSlot uint64) int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	removed := 0
+	for ref, tracked := range t.observations {
+		if tracked.spentAt != nil && *tracked.spentAt < beforeSlot {
+			delete(t.observations, ref)
+			removed++
+		}
+	}
+	return removed
 }
 
 // Rollback removes observations produced after the rollback point and restores
@@ -104,31 +134,49 @@ func (t *Tracker) Current(now time.Time) (Observation, error) {
 	defer t.mu.RUnlock()
 	var current Observation
 	found := false
+	var newestInvalid Observation
+	var newestInvalidErr error
+	sawUnspent := false
 	for _, tracked := range t.observations {
 		if tracked.spentAt != nil {
 			continue
 		}
+		sawUnspent = true
 		candidate := tracked.observation
+		if err := candidate.ValidateAt(now); err != nil {
+			if newestInvalidErr == nil ||
+				observationAfter(candidate, newestInvalid) {
+				newestInvalid = candidate
+				newestInvalidErr = err
+			}
+			continue
+		}
 		if !found || observationAfter(candidate, current) {
 			current = candidate
 			found = true
 		}
 	}
-	if !found {
+	if found {
+		return current, nil
+	}
+	if !sawUnspent {
 		return Observation{}, ErrNoCurrentObservation
 	}
-	if err := current.ValidateAt(now); err != nil {
-		return current, err
-	}
-	return current, nil
+	return Observation{}, newestInvalidErr
 }
 
 func observationAfter(candidate, current Observation) bool {
 	if candidate.Slot != current.Slot {
 		return candidate.Slot > current.Slot
 	}
+	if candidate.TransactionIndex != current.TransactionIndex {
+		return candidate.TransactionIndex > current.TransactionIndex
+	}
 	if candidate.TxIndex != current.TxIndex {
 		return candidate.TxIndex > current.TxIndex
 	}
+	// With complete provenance, block transaction index and output index are
+	// unique. The hash fallback is deterministic for incomplete caller data,
+	// but does not claim to reconstruct chain order.
 	return candidate.TxHash > current.TxHash
 }

--- a/price/djed/tracker_test.go
+++ b/price/djed/tracker_test.go
@@ -1,0 +1,129 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package djed
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTrackerTracksCurrentUnspentObservation(t *testing.T) {
+	tracker := NewTracker()
+	now := time.Unix(1_784_842_625, 0).UTC()
+	utxo := currentMainnetUTxO(t)
+	utxo.Slot = 193_104_715
+	utxo.BlockHash = "current-block"
+
+	applied, err := tracker.Apply(
+		mustDecodeHex(t, currentMainnetDatum),
+		utxo,
+		now,
+	)
+	require.NoError(t, err)
+	require.Equal(t, utxo.Slot, applied.Slot)
+	require.Equal(t, utxo.BlockHash, applied.BlockHash)
+
+	current, err := tracker.Current(now)
+	require.NoError(t, err)
+	require.Equal(t, applied, current)
+
+	tracker.ConsumeAt(
+		OutputRef{TxHash: utxo.TxHash, TxIndex: utxo.TxIndex},
+		utxo.Slot+1,
+	)
+	_, err = tracker.Current(now)
+	require.ErrorIs(t, err, ErrNoCurrentObservation)
+}
+
+func TestTrackerRejectsExpiredCurrentObservation(t *testing.T) {
+	tracker := NewTracker()
+	utxo := currentMainnetUTxO(t)
+	utxo.Slot = 10
+	validAt := time.Unix(1_784_842_625, 0).UTC()
+	_, err := tracker.Apply(
+		mustDecodeHex(t, currentMainnetDatum),
+		utxo,
+		validAt,
+	)
+	require.NoError(t, err)
+
+	current, err := tracker.Current(
+		time.UnixMilli(1_784_843_516_001).UTC(),
+	)
+	require.ErrorIs(t, err, ErrExpired)
+	require.Equal(t, utxo.TxHash, current.TxHash)
+}
+
+func TestTrackerRollbackRestoresSpentObservation(t *testing.T) {
+	tracker := NewTracker()
+	now := time.Unix(1_784_842_625, 0).UTC()
+	utxo := currentMainnetUTxO(t)
+	utxo.Slot = 10
+	applied, err := tracker.Apply(
+		mustDecodeHex(t, currentMainnetDatum),
+		utxo,
+		now,
+	)
+	require.NoError(t, err)
+
+	ref := OutputRef{TxHash: utxo.TxHash, TxIndex: utxo.TxIndex}
+	tracker.ConsumeAt(ref, 20)
+	require.ErrorIs(t, currentError(tracker, now), ErrNoCurrentObservation)
+
+	tracker.Rollback(20)
+	current, err := tracker.Current(now)
+	require.NoError(t, err)
+	require.Equal(t, applied, current)
+}
+
+func TestTrackerRollbackRemovesProducedObservation(t *testing.T) {
+	tracker := NewTracker()
+	now := time.Unix(1_784_842_625, 0).UTC()
+	utxo := currentMainnetUTxO(t)
+	utxo.Slot = 20
+	_, err := tracker.Apply(
+		mustDecodeHex(t, currentMainnetDatum),
+		utxo,
+		now,
+	)
+	require.NoError(t, err)
+
+	tracker.Rollback(20)
+	require.ErrorIs(t, currentError(tracker, now), ErrNoCurrentObservation)
+}
+
+func TestTrackerRejectsUnauthenticatedOutput(t *testing.T) {
+	tracker := NewTracker()
+	utxo := currentMainnetUTxO(t)
+	utxo.Assets = nil
+	_, err := tracker.Apply(
+		mustDecodeHex(t, currentMainnetDatum),
+		utxo,
+		time.Unix(1_784_842_625, 0).UTC(),
+	)
+	require.ErrorIs(t, err, ErrMissingNFT)
+	require.ErrorIs(
+		t,
+		currentError(tracker, time.Now()),
+		ErrNoCurrentObservation,
+	)
+}
+
+func currentError(tracker *Tracker, now time.Time) error {
+	_, err := tracker.Current(now)
+	return err
+}

--- a/price/djed/tracker_test.go
+++ b/price/djed/tracker_test.go
@@ -27,6 +27,7 @@ func TestTrackerTracksCurrentUnspentObservation(t *testing.T) {
 	utxo := currentMainnetUTxO(t)
 	utxo.Slot = 193_104_715
 	utxo.BlockHash = "current-block"
+	utxo.TransactionIndex = 4
 
 	applied, err := tracker.Apply(
 		mustDecodeHex(t, currentMainnetDatum),
@@ -36,6 +37,7 @@ func TestTrackerTracksCurrentUnspentObservation(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, utxo.Slot, applied.Slot)
 	require.Equal(t, utxo.BlockHash, applied.BlockHash)
+	require.Equal(t, utxo.TransactionIndex, applied.TransactionIndex)
 
 	current, err := tracker.Current(now)
 	require.NoError(t, err)
@@ -65,7 +67,85 @@ func TestTrackerRejectsExpiredCurrentObservation(t *testing.T) {
 		time.UnixMilli(1_784_843_516_001).UTC(),
 	)
 	require.ErrorIs(t, err, ErrExpired)
-	require.Equal(t, utxo.TxHash, current.TxHash)
+	require.Equal(t, Observation{}, current)
+}
+
+func TestTrackerDuplicateApplyPreservesSpend(t *testing.T) {
+	tracker := NewTracker()
+	now := time.Unix(1_784_842_625, 0).UTC()
+	utxo := currentMainnetUTxO(t)
+	utxo.Slot = 10
+	data := mustDecodeHex(t, currentMainnetDatum)
+	_, err := tracker.Apply(data, utxo, now)
+	require.NoError(t, err)
+
+	ref := OutputRef{TxHash: utxo.TxHash, TxIndex: utxo.TxIndex}
+	tracker.ConsumeAt(ref, 20)
+	_, err = tracker.Apply(data, utxo, now)
+	require.NoError(t, err)
+	require.ErrorIs(t, currentError(tracker, now), ErrNoCurrentObservation)
+}
+
+func TestTrackerRejectsConflictingDuplicate(t *testing.T) {
+	tracker := NewTracker()
+	now := time.Unix(1_784_842_625, 0).UTC()
+	utxo := currentMainnetUTxO(t)
+	data := mustDecodeHex(t, currentMainnetDatum)
+	_, err := tracker.Apply(data, utxo, now)
+	require.NoError(t, err)
+
+	utxo.BlockHash = "conflicting-block"
+	_, err = tracker.Apply(data, utxo, now)
+	require.ErrorIs(t, err, ErrConflictingObservation)
+}
+
+func TestTrackerSelectsNewestCurrentlyValidObservation(t *testing.T) {
+	now := time.Unix(1_784_842_625, 0).UTC()
+	valid := Observation{
+		TxHash:              "valid",
+		Slot:                10,
+		ValidFrom:           now.Add(-time.Minute),
+		ValidFromInclusive:  true,
+		ValidUntil:          now.Add(time.Minute),
+		ValidUntilInclusive: true,
+	}
+	future := valid
+	future.TxHash = "future"
+	future.Slot = 20
+	future.ValidFrom = now.Add(time.Second)
+	tracker := NewTracker()
+	tracker.observations[OutputRef{TxHash: valid.TxHash}] =
+		trackedObservation{observation: valid}
+	tracker.observations[OutputRef{TxHash: future.TxHash}] =
+		trackedObservation{observation: future}
+
+	current, err := tracker.Current(now)
+	require.NoError(t, err)
+	require.Equal(t, valid, current)
+}
+
+func TestTrackerUsesBlockTransactionOrder(t *testing.T) {
+	tracker := NewTracker()
+	now := time.Unix(1_784_842_625, 0).UTC()
+	data := mustDecodeHex(t, currentMainnetDatum)
+	first := currentMainnetUTxO(t)
+	first.TxHash = "ffffffff"
+	first.Slot = 10
+	first.TransactionIndex = 1
+	_, err := tracker.Apply(data, first, now)
+	require.NoError(t, err)
+
+	second := currentMainnetUTxO(t)
+	second.TxHash = "00000000"
+	second.Slot = 10
+	second.TransactionIndex = 2
+	_, err = tracker.Apply(data, second, now)
+	require.NoError(t, err)
+
+	current, err := tracker.Current(now)
+	require.NoError(t, err)
+	require.Equal(t, second.TxHash, current.TxHash)
+	require.Equal(t, second.TransactionIndex, current.TransactionIndex)
 }
 
 func TestTrackerRollbackRestoresSpentObservation(t *testing.T) {
@@ -129,6 +209,27 @@ func TestTrackerRollbackRetainsPointState(t *testing.T) {
 	)
 	tracker.Rollback(20)
 	require.ErrorIs(t, currentError(tracker, now), ErrNoCurrentObservation)
+}
+
+func TestTrackerPrunesOnlyImmutableSpentHistory(t *testing.T) {
+	tracker := NewTracker()
+	now := time.Unix(1_784_842_625, 0).UTC()
+	utxo := currentMainnetUTxO(t)
+	utxo.Slot = 10
+	_, err := tracker.Apply(
+		mustDecodeHex(t, currentMainnetDatum),
+		utxo,
+		now,
+	)
+	require.NoError(t, err)
+	ref := OutputRef{TxHash: utxo.TxHash, TxIndex: utxo.TxIndex}
+	tracker.ConsumeAt(ref, 20)
+
+	require.Equal(t, 0, tracker.Prune(20))
+	require.Len(t, tracker.observations, 1)
+	require.Equal(t, 1, tracker.Prune(21))
+	require.Empty(t, tracker.observations)
+	require.Equal(t, 0, tracker.Prune(21))
 }
 
 func TestTrackerRejectsUnauthenticatedOutput(t *testing.T) {

--- a/price/djed/tracker_test.go
+++ b/price/djed/tracker_test.go
@@ -84,7 +84,7 @@ func TestTrackerRollbackRestoresSpentObservation(t *testing.T) {
 	tracker.ConsumeAt(ref, 20)
 	require.ErrorIs(t, currentError(tracker, now), ErrNoCurrentObservation)
 
-	tracker.Rollback(20)
+	tracker.Rollback(19)
 	current, err := tracker.Current(now)
 	require.NoError(t, err)
 	require.Equal(t, applied, current)
@@ -102,6 +102,31 @@ func TestTrackerRollbackRemovesProducedObservation(t *testing.T) {
 	)
 	require.NoError(t, err)
 
+	tracker.Rollback(19)
+	require.ErrorIs(t, currentError(tracker, now), ErrNoCurrentObservation)
+}
+
+func TestTrackerRollbackRetainsPointState(t *testing.T) {
+	tracker := NewTracker()
+	now := time.Unix(1_784_842_625, 0).UTC()
+	utxo := currentMainnetUTxO(t)
+	utxo.Slot = 20
+	applied, err := tracker.Apply(
+		mustDecodeHex(t, currentMainnetDatum),
+		utxo,
+		now,
+	)
+	require.NoError(t, err)
+
+	tracker.Rollback(20)
+	current, err := tracker.Current(now)
+	require.NoError(t, err)
+	require.Equal(t, applied, current)
+
+	tracker.ConsumeAt(
+		OutputRef{TxHash: utxo.TxHash, TxIndex: utxo.TxIndex},
+		20,
+	)
 	tracker.Rollback(20)
 	require.ErrorIs(t, currentError(tracker, now), ErrNoCurrentObservation)
 }


### PR DESCRIPTION
Tracks authenticated Djed oracle UTxOs across spends and rollbacks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Djed oracle state tracker that picks the newest authenticated, unspent observation across spends and rollbacks, now ordered by block transaction position and with pruning of immutable spent history. Hardens parsing and validity checks to avoid bad data.

- **New Features**
  - In‑memory tracker with Apply, ConsumeAt, Rollback, Current, and Prune; preserves spends across replays and restores on rollbacks; detects conflicting duplicates.
  - Chooses the newest observation by Slot → TransactionIndex → TxIndex → TxHash.
  - Extends OracleUTxO/Observation with Slot, BlockHash, and TransactionIndex; ParseMainnetObservation sets them; adds Observation.ValidateAt(now).

- **Bug Fixes**
  - Rollback retains point state: removes observations produced after the point and restores spends after it.
  - Hardened parsing/validation: centralized interval checks and rejection of non‑finite rate approximations; duplicate Apply does not resurrect spent outputs.

<sup>Written for commit c09f0ae470477199c87eaac87181127c385e7222. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/shai/pull/371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an in-memory tracker for oracle observations.
  - Tracks newly produced and consumed observations, supports chain rollback handling, and identifies the latest valid unspent observation.
  - Observation data now includes slot and block hash context.
  - Added validation for observation validity windows and unauthenticated outputs.

- **Bug Fixes**
  - Centralized validity interval checks to consistently handle not-yet-valid and expired observations.

- **Tests**
  - Added coverage for tracking, expiration, rollback recovery, removal, boundary behavior, and invalid outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->