### PR TITLE
feat: use liquidity-weighted median pricing

### DIFF
--- a/price/ada_usd.go
+++ b/price/ada_usd.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	"slices"
 	"sort"
 	"strconv"
 	"time"
@@ -33,6 +34,7 @@ var (
 	ErrInsufficientDiversity    = errors.New("price: insufficient stablecoin diversity")
 	ErrConcentratedLiquidity    = errors.New("price: one pool dominates qualified liquidity")
 	ErrDivergentPrices          = errors.New("price: qualified pool prices diverge")
+	ErrNonFinitePrice           = errors.New("price: non-finite floating-point price")
 )
 
 const (
@@ -55,9 +57,12 @@ type Config struct {
 	IncludeMempool  bool
 }
 
-// DefaultConfig is conservative enough to reject dust pools while accepting
-// the independently pegged mainnet USDM and USDCx CSWAP pools observed during
-// implementation.
+// DefaultConfig rejects dust pools while accepting the independently pegged
+// mainnet USDM and USDCx CSWAP pools observed during implementation. A pool
+// holding up to 75% of qualified liquidity may determine the weighted median;
+// the remaining pools must still agree within MaxDivergence. Operators may
+// explicitly lower the minimum counts and raise MaxPoolShare when only one
+// sufficiently liquid pool is available.
 func DefaultConfig() Config {
 	return Config{
 		Stablecoins:     MainnetStablecoins(),
@@ -136,7 +141,10 @@ func AggregateADAUSDAt(
 	if err := validateConfig(config); err != nil {
 		return Result{}, err
 	}
-	observations := observationsFromPools(pools, config, now)
+	observations, err := observationsFromPools(pools, config, now)
+	if err != nil {
+		return Result{}, err
+	}
 	result := Result{
 		Pair:         "ADA/USD",
 		Source:       SourceLocalDEXStablecoins,
@@ -149,19 +157,15 @@ func AggregateADAUSDAt(
 	}
 
 	symbols := make(map[string]struct{}, len(observations))
-	var totalWeight uint64
 	for _, observation := range observations {
 		symbols[observation.Stablecoin] = struct{}{}
-		if ^uint64(0)-totalWeight < observation.StableMicros {
-			return result, fmt.Errorf("price: aggregate liquidity overflows uint64")
-		}
-		totalWeight += observation.StableMicros
 	}
 	if len(symbols) < config.MinStablecoins {
 		return result, ErrInsufficientDiversity
 	}
-	if totalWeight == 0 {
-		return result, ErrInsufficientObservations
+	medianPrice, totalWeight, err := liquidityWeightedMedian(observations)
+	if err != nil {
+		return result, err
 	}
 	maxPoolShare := configRatio(config.MaxPoolShare)
 	for _, observation := range observations {
@@ -188,15 +192,20 @@ func AggregateADAUSDAt(
 		new(big.Rat).Sub(maxPrice, minPrice),
 		minPrice,
 	)
-	result.Spread, _ = spread.Float64()
+	result.Spread, err = finiteFloat64(spread)
+	if err != nil {
+		return result, err
+	}
 	if spread.Cmp(configRatio(config.MaxDivergence)) > 0 {
 		return result, ErrDivergentPrices
 	}
-	medianPrice := liquidityWeightedMedian(observations, totalWeight)
 	result.price = medianPrice
 	result.PriceNum = medianPrice.Num().String()
 	result.PriceDen = medianPrice.Denom().String()
-	result.Price, _ = medianPrice.Float64()
+	result.Price, err = finiteFloat64(medianPrice)
+	if err != nil {
+		return result, err
+	}
 	result.Validation = ValidationQualified
 	for _, observation := range observations {
 		if observation.ObservedAt.IsZero() {
@@ -213,12 +222,31 @@ func AggregateADAUSDAt(
 
 func liquidityWeightedMedian(
 	observations []PoolObservation,
-	totalWeight uint64,
-) *big.Rat {
+) (*big.Rat, uint64, error) {
 	ordered := append([]PoolObservation(nil), observations...)
-	sort.SliceStable(ordered, func(i, j int) bool {
-		return ordered[i].price.Cmp(ordered[j].price) < 0
+	for _, observation := range ordered {
+		if observation.price == nil || observation.price.Sign() <= 0 {
+			return nil, 0, fmt.Errorf(
+				"price: invalid pool observation price",
+			)
+		}
+	}
+	slices.SortStableFunc(ordered, func(a, b PoolObservation) int {
+		return a.price.Cmp(b.price)
 	})
+
+	var totalWeight uint64
+	for _, observation := range ordered {
+		if ^uint64(0)-totalWeight < observation.StableMicros {
+			return nil, 0, fmt.Errorf(
+				"price: aggregate liquidity overflows uint64",
+			)
+		}
+		totalWeight += observation.StableMicros
+	}
+	if totalWeight == 0 {
+		return nil, 0, ErrInsufficientObservations
+	}
 
 	var cumulative uint64
 	for i, observation := range ordered {
@@ -229,27 +257,28 @@ func liquidityWeightedMedian(
 		remaining := totalWeight - cumulative
 		switch {
 		case cumulative > remaining:
-			return new(big.Rat).Set(observation.price)
+			return new(big.Rat).Set(observation.price), totalWeight, nil
 		case cumulative == remaining:
 			for _, next := range ordered[i+1:] {
 				if next.StableMicros == 0 {
 					continue
 				}
-				return new(big.Rat).Quo(
+				median := new(big.Rat).Quo(
 					new(big.Rat).Add(observation.price, next.price),
 					big.NewRat(2, 1),
 				)
+				return median, totalWeight, nil
 			}
 		}
 	}
-	panic("qualified observations have no positive liquidity")
+	return nil, 0, ErrInsufficientObservations
 }
 
 func observationsFromPools(
 	pools []*dex.PoolState,
 	config Config,
 	now time.Time,
-) []PoolObservation {
+) ([]PoolObservation, error) {
 	latest := make(map[string]*dex.PoolState)
 	for _, pool := range pools {
 		if pool == nil || (!config.IncludeMempool && pool.FromMempool) {
@@ -270,7 +299,10 @@ func observationsFromPools(
 
 	var observations []PoolObservation
 	for _, pool := range latest {
-		observation, ok := observationFromPool(pool, config, now)
+		observation, ok, err := observationFromPool(pool, config, now)
+		if err != nil {
+			return nil, err
+		}
 		if ok {
 			observations = append(observations, observation)
 		}
@@ -284,14 +316,14 @@ func observationsFromPools(
 		}
 		return observations[i].PoolID < observations[j].PoolID
 	})
-	return observations
+	return observations, nil
 }
 
 func observationFromPool(
 	pool *dex.PoolState,
 	config Config,
 	now time.Time,
-) (PoolObservation, bool) {
+) (PoolObservation, bool, error) {
 	var ada common.AssetAmount
 	var stable common.AssetAmount
 	var stablecoin Stablecoin
@@ -303,7 +335,7 @@ func observationFromPool(
 		ada = pool.AssetY
 		stable = pool.AssetX
 	default:
-		return PoolObservation{}, false
+		return PoolObservation{}, false, nil
 	}
 	for _, candidate := range config.Stablecoins {
 		if stable.IsAsset(candidate.Asset) {
@@ -315,11 +347,11 @@ func observationFromPool(
 		ada.Amount == 0 ||
 		stable.Amount == 0 ||
 		ada.Amount < config.MinADAReserve {
-		return PoolObservation{}, false
+		return PoolObservation{}, false, nil
 	}
 	stableMicros, ok := normalizeToMicros(stable.Amount, stablecoin.Decimals)
 	if !ok || stableMicros < config.MinStableUSD {
-		return PoolObservation{}, false
+		return PoolObservation{}, false, nil
 	}
 	price := new(big.Rat).SetFrac(
 		new(big.Int).Mul(
@@ -331,7 +363,10 @@ func observationFromPool(
 			pow10Big(stablecoin.Decimals),
 		),
 	)
-	priceFloat, _ := price.Float64()
+	priceFloat, err := finiteFloat64(price)
+	if err != nil {
+		return PoolObservation{}, false, err
+	}
 	var ageSeconds *int64
 	if !pool.Timestamp.IsZero() {
 		age := int64(now.Sub(pool.Timestamp).Seconds())
@@ -355,7 +390,19 @@ func observationFromPool(
 		AgeSeconds:    ageSeconds,
 		Validation:    ValidationQualified,
 		price:         price,
-	}, true
+	}, true, nil
+}
+
+func finiteFloat64(value *big.Rat) (float64, error) {
+	approximation, exact := value.Float64()
+	if math.IsInf(approximation, 0) || math.IsNaN(approximation) {
+		return 0, ErrNonFinitePrice
+	}
+	if exact {
+		return approximation, nil
+	}
+	// JSON exposes a float approximation alongside the exact rational fields.
+	return approximation, nil
 }
 
 func normalizeToMicros(

--- a/price/ada_usd.go
+++ b/price/ada_usd.go
@@ -118,7 +118,7 @@ func (r Result) Rat() *big.Rat {
 }
 
 // AggregateADAUSD qualifies ADA/stablecoin pools, enforces diversity and
-// agreement, then computes a stablecoin-liquidity-weighted mean.
+// agreement, then computes a stablecoin-liquidity-weighted median.
 func AggregateADAUSD(
 	pools []*dex.PoolState,
 	config Config,
@@ -140,7 +140,7 @@ func AggregateADAUSDAt(
 	result := Result{
 		Pair:         "ADA/USD",
 		Source:       SourceLocalDEXStablecoins,
-		Method:       "local-dex-stablecoin-weighted",
+		Method:       "local-dex-liquidity-weighted-median",
 		Validation:   ValidationUnavailable,
 		Observations: observations,
 	}
@@ -176,7 +176,6 @@ func AggregateADAUSDAt(
 
 	minPrice := new(big.Rat).Set(observations[0].price)
 	maxPrice := new(big.Rat).Set(observations[0].price)
-	weightedPrice := new(big.Rat)
 	for _, observation := range observations {
 		if observation.price.Cmp(minPrice) < 0 {
 			minPrice.Set(observation.price)
@@ -184,13 +183,6 @@ func AggregateADAUSDAt(
 		if observation.price.Cmp(maxPrice) > 0 {
 			maxPrice.Set(observation.price)
 		}
-		term := new(big.Rat).Mul(
-			observation.price,
-			new(big.Rat).SetInt(
-				new(big.Int).SetUint64(observation.StableMicros),
-			),
-		)
-		weightedPrice.Add(weightedPrice, term)
 	}
 	spread := new(big.Rat).Quo(
 		new(big.Rat).Sub(maxPrice, minPrice),
@@ -200,14 +192,11 @@ func AggregateADAUSDAt(
 	if spread.Cmp(configRatio(config.MaxDivergence)) > 0 {
 		return result, ErrDivergentPrices
 	}
-	weightedPrice.Quo(
-		weightedPrice,
-		new(big.Rat).SetInt(new(big.Int).SetUint64(totalWeight)),
-	)
-	result.price = weightedPrice
-	result.PriceNum = weightedPrice.Num().String()
-	result.PriceDen = weightedPrice.Denom().String()
-	result.Price, _ = weightedPrice.Float64()
+	medianPrice := liquidityWeightedMedian(observations, totalWeight)
+	result.price = medianPrice
+	result.PriceNum = medianPrice.Num().String()
+	result.PriceDen = medianPrice.Denom().String()
+	result.Price, _ = medianPrice.Float64()
 	result.Validation = ValidationQualified
 	for _, observation := range observations {
 		if observation.ObservedAt.IsZero() {
@@ -220,6 +209,40 @@ func AggregateADAUSDAt(
 		}
 	}
 	return result, nil
+}
+
+func liquidityWeightedMedian(
+	observations []PoolObservation,
+	totalWeight uint64,
+) *big.Rat {
+	ordered := append([]PoolObservation(nil), observations...)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		return ordered[i].price.Cmp(ordered[j].price) < 0
+	})
+
+	var cumulative uint64
+	for i, observation := range ordered {
+		if observation.StableMicros == 0 {
+			continue
+		}
+		cumulative += observation.StableMicros
+		remaining := totalWeight - cumulative
+		switch {
+		case cumulative > remaining:
+			return new(big.Rat).Set(observation.price)
+		case cumulative == remaining:
+			for _, next := range ordered[i+1:] {
+				if next.StableMicros == 0 {
+					continue
+				}
+				return new(big.Rat).Quo(
+					new(big.Rat).Add(observation.price, next.price),
+					big.NewRat(2, 1),
+				)
+			}
+		}
+	}
+	panic("qualified observations have no positive liquidity")
 }
 
 func observationsFromPools(

--- a/price/ada_usd_test.go
+++ b/price/ada_usd_test.go
@@ -17,6 +17,7 @@ package price
 import (
 	"errors"
 	"math"
+	"math/big"
 	"testing"
 	"time"
 
@@ -175,6 +176,91 @@ func TestAggregateADAUSDSelectsPriceAboveHalfWeight(t *testing.T) {
 	result, err := AggregateADAUSD(pools, config)
 	require.NoError(t, err)
 	require.Equal(t, "1/10", result.Rat().String())
+}
+
+func TestAggregateADAUSDDefaultAllowsDominantQualifiedLiquidity(
+	t *testing.T,
+) {
+	config := DefaultConfig()
+	config.MinADAReserve = 0
+	config.MinStableUSD = 0
+	pools := []*dex.PoolState{
+		poolFixture(
+			t,
+			"dominant",
+			USDCxPolicyID,
+			USDCxAssetName,
+			10_000,
+			2_100,
+			"dominant",
+			1,
+		),
+		poolFixture(
+			t,
+			"minority",
+			USDMPolicyID,
+			USDMAssetName,
+			3_500,
+			700,
+			"minority",
+			1,
+		),
+	}
+
+	result, err := AggregateADAUSD(pools, config)
+	require.NoError(t, err)
+	require.Equal(t, "21/100", result.Rat().String())
+	require.Equal(t, 0.05, result.Spread)
+}
+
+func TestAggregateADAUSDCanUseOneQualifiedPool(t *testing.T) {
+	config := DefaultConfig()
+	config.MinADAReserve = 0
+	config.MinStableUSD = 0
+	config.MinObservations = 1
+	config.MinStablecoins = 1
+	config.MaxPoolShare = 1
+	pool := poolFixture(
+		t,
+		"single",
+		USDCxPolicyID,
+		USDCxAssetName,
+		1_000,
+		200,
+		"single",
+		1,
+	)
+
+	result, err := AggregateADAUSD([]*dex.PoolState{pool}, config)
+	require.NoError(t, err)
+	require.Equal(t, "1/5", result.Rat().String())
+}
+
+func TestLiquidityWeightedMedianRejectsInvalidWeights(t *testing.T) {
+	_, _, err := liquidityWeightedMedian(nil)
+	require.ErrorIs(t, err, ErrInsufficientObservations)
+
+	_, _, err = liquidityWeightedMedian([]PoolObservation{{
+		StableMicros: 1,
+	}})
+	require.ErrorContains(t, err, "invalid pool observation price")
+
+	observations := []PoolObservation{
+		{StableMicros: ^uint64(0), price: big.NewRat(1, 5)},
+		{StableMicros: 1, price: big.NewRat(1, 5)},
+	}
+	_, _, err = liquidityWeightedMedian(observations)
+	require.ErrorContains(t, err, "overflows")
+}
+
+func TestFiniteFloat64RejectsOverflow(t *testing.T) {
+	hugeInteger := new(big.Int).Exp(
+		big.NewInt(10),
+		big.NewInt(400),
+		nil,
+	)
+	_, err := finiteFloat64(new(big.Rat).SetInt(hugeInteger))
+	require.ErrorIs(t, err, ErrNonFinitePrice)
 }
 
 func TestAggregateADAUSDReportsLocalProvenance(t *testing.T) {
@@ -411,11 +497,12 @@ func TestObservationsFromPoolsUsesLatestSameSlotOutput(t *testing.T) {
 		2,
 	)
 
-	observations := observationsFromPools(
+	observations, err := observationsFromPools(
 		[]*dex.PoolState{newer, older},
 		DefaultConfig(),
 		time.Now(),
 	)
+	require.NoError(t, err)
 	require.Len(t, observations, 1)
 	require.Equal(t, uint32(2), observations[0].TxIndex)
 	require.Equal(t, uint64(1_250_000_000), observations[0].StableReserve)

--- a/price/ada_usd_test.go
+++ b/price/ada_usd_test.go
@@ -53,12 +53,128 @@ func TestAggregateADAUSDCurrentCSwapFixtures(t *testing.T) {
 	result, err := AggregateADAUSD(pools, DefaultConfig())
 	require.NoError(t, err)
 	require.Equal(t, "ADA/USD", result.Pair)
-	require.Equal(t, "local-dex-stablecoin-weighted", result.Method)
+	require.Equal(t, "local-dex-liquidity-weighted-median", result.Method)
 	require.Len(t, result.Observations, 2)
 	require.Less(t, result.Spread, 0.01)
-	require.InDelta(t, 0.16868, result.Price, 0.0001)
-	require.NotZero(t, result.PriceNum)
-	require.NotZero(t, result.PriceDen)
+	require.Equal(t, "205637633/1221039384", result.Rat().String())
+	require.InDelta(t, 0.168412, result.Price, 0.000001)
+	require.Equal(t, "205637633", result.PriceNum)
+	require.Equal(t, "1221039384", result.PriceDen)
+}
+
+func TestAggregateADAUSDUsesLiquidityWeightedMedian(t *testing.T) {
+	config := DefaultConfig()
+	config.MinADAReserve = 0
+	config.MinStableUSD = 0
+	config.MinObservations = 3
+	config.MaxPoolShare = 1
+	config.MaxDivergence = 10
+	pools := []*dex.PoolState{
+		poolFixture(
+			t,
+			"low",
+			USDCxPolicyID,
+			USDCxAssetName,
+			200,
+			20,
+			"low",
+			1,
+		),
+		poolFixture(
+			t,
+			"median",
+			USDMPolicyID,
+			USDMAssetName,
+			250,
+			50,
+			"median",
+			1,
+		),
+		poolFixture(
+			t,
+			"high",
+			USDCxPolicyID,
+			USDCxAssetName,
+			100,
+			30,
+			"high",
+			1,
+		),
+	}
+
+	result, err := AggregateADAUSD(pools, config)
+	require.NoError(t, err)
+	require.Equal(t, "1/5", result.Rat().String())
+	require.Equal(t, 0.2, result.Price)
+}
+
+func TestAggregateADAUSDMidpointsExactWeightSplit(t *testing.T) {
+	config := DefaultConfig()
+	config.MinADAReserve = 0
+	config.MinStableUSD = 0
+	config.MaxPoolShare = 0.5
+	config.MaxDivergence = 10
+	pools := []*dex.PoolState{
+		poolFixture(
+			t,
+			"low",
+			USDCxPolicyID,
+			USDCxAssetName,
+			600,
+			60,
+			"low",
+			1,
+		),
+		poolFixture(
+			t,
+			"high",
+			USDMPolicyID,
+			USDMAssetName,
+			200,
+			60,
+			"high",
+			1,
+		),
+	}
+
+	result, err := AggregateADAUSD(pools, config)
+	require.NoError(t, err)
+	require.Equal(t, "1/5", result.Rat().String())
+	require.Equal(t, 0.2, result.Price)
+}
+
+func TestAggregateADAUSDSelectsPriceAboveHalfWeight(t *testing.T) {
+	config := DefaultConfig()
+	config.MinADAReserve = 0
+	config.MinStableUSD = 0
+	config.MaxPoolShare = 1
+	config.MaxDivergence = 10
+	pools := []*dex.PoolState{
+		poolFixture(
+			t,
+			"low",
+			USDCxPolicyID,
+			USDCxAssetName,
+			510,
+			51,
+			"low",
+			1,
+		),
+		poolFixture(
+			t,
+			"high",
+			USDMPolicyID,
+			USDMAssetName,
+			245,
+			49,
+			"high",
+			1,
+		),
+	}
+
+	result, err := AggregateADAUSD(pools, config)
+	require.NoError(t, err)
+	require.Equal(t, "1/10", result.Rat().String())
 }
 
 func TestAggregateADAUSDReportsLocalProvenance(t *testing.T) {


### PR DESCRIPTION
Uses exact liquidity-weighted median aggregation for qualified local ADA/USD pools.

The `method` value changes from `local-dex-stablecoin-weighted` to `local-dex-liquidity-weighted-median`. Dominant qualified liquidity may select the median; other qualified pools enforce the divergence bound.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ADA/USD estimates now use a liquidity-weighted median for more representative pricing.
  * Price results include more precise rational pricing details.
  * Invalid or non-finite price calculations now return a clear error.

* **Bug Fixes**
  * Improved handling of pool liquidity, qualification, and price-conversion edge cases.
  * Preserved accurate results when a single qualifying pool or a midpoint liquidity split determines the estimate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->