### PR TITLE
feat: ingest local Djed state

### DIFF
--- a/cmd/shai/main.go
+++ b/cmd/shai/main.go
@@ -97,6 +97,7 @@ func main() {
 	var oracles []*oracle.Oracle
 	var lendingOracles []*oracle.LendingOracle
 	var lendingStorage *oracle.LendingStorage
+	var djedOracle *oracle.DjedOracle
 
 	// Setup profiles
 	for _, profile := range config.GetProfiles() {
@@ -207,6 +208,42 @@ func main() {
 				os.Exit(1)
 			}
 			lendingOracles = append(lendingOracles, o)
+		case config.ProfileTypeDjed:
+			djedCfg, ok := profile.Config.(config.DjedProfileConfig)
+			if !ok {
+				logger.Error(
+					"invalid Djed profile config",
+					"profile",
+					profile.Name,
+				)
+				os.Exit(1)
+			}
+			if djedCfg.OracleAddress == "" {
+				logger.Error(
+					"Djed oracle address is required",
+					"profile",
+					profile.Name,
+				)
+				os.Exit(1)
+			}
+			if djedOracle != nil {
+				logger.Error("multiple Djed profiles are not supported")
+				os.Exit(1)
+			}
+			djedOracle = oracle.NewDjedOracle(
+				idx,
+				cfg.Network,
+				djedCfg.OracleAddress,
+				storage.GetStorage(),
+			)
+			if err := djedOracle.Start(); err != nil {
+				logger.Error(
+					"failed to start Djed oracle",
+					"error",
+					err,
+				)
+				os.Exit(1)
+			}
 		case config.ProfileTypeNone:
 			logger.Error("profile type none given")
 			os.Exit(1)

--- a/internal/config/profiles.go
+++ b/internal/config/profiles.go
@@ -4,6 +4,7 @@ import (
 	"slices"
 
 	"github.com/blinklabs-io/shai/dex"
+	"github.com/blinklabs-io/shai/price/djed"
 )
 
 // poolAddrs builds the monitored-address list for a protocol from the canonical
@@ -26,6 +27,7 @@ const (
 	ProfileTypeOracle
 	ProfileTypeSynthetics
 	ProfileTypeLending
+	ProfileTypeDjed
 )
 
 type Profile struct {
@@ -78,6 +80,11 @@ type LendingProfileConfig struct {
 	MarketAddresses []ProfileConfigAddress  // Market contract addresses to monitor
 	OracleAddresses []ProfileConfigAddress  // Oracle feed addresses
 	InputRefs       []ProfileConfigInputRef // Reference inputs if needed
+}
+
+// DjedProfileConfig identifies the local Open Djed deployment.
+type DjedProfileConfig struct {
+	OracleAddress string
 }
 
 func GetProfiles() []Profile {
@@ -192,6 +199,15 @@ var Profiles = map[string]map[string]Profile{
 		},
 	},
 	"mainnet": {
+		"djed": {
+			Name:          "djed",
+			Type:          ProfileTypeDjed,
+			InterceptSlot: 193878040,
+			InterceptHash: "33d57490677631e36dfd1ad1cb35821f29823ea84012313de3fcce07e4195331",
+			Config: DjedProfileConfig{
+				OracleAddress: djed.MainnetOracleAddress,
+			},
+		},
 		"minswap-v1": {
 			Name:          "minswap-v1",
 			Type:          ProfileTypeOracle,

--- a/internal/oracle/djed_oracle.go
+++ b/internal/oracle/djed_oracle.go
@@ -200,7 +200,9 @@ func (o *DjedOracle) handleRollback(evt event.RollbackEvent) error {
 	if err != nil {
 		return fmt.Errorf("stage Djed tracker: %w", err)
 	}
-	staged.Rollback(evt.SlotNumber)
+	if !staged.Rollback(evt.SlotNumber) {
+		return nil
+	}
 	if err := o.storage.SaveDjedState(
 		o.network,
 		staged.Snapshot(),

--- a/internal/oracle/djed_oracle.go
+++ b/internal/oracle/djed_oracle.go
@@ -1,0 +1,248 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oracle
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/blinklabs-io/adder/event"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/shai/common"
+	"github.com/blinklabs-io/shai/internal/indexer"
+	"github.com/blinklabs-io/shai/internal/storage"
+	"github.com/blinklabs-io/shai/price/djed"
+)
+
+// DjedStateStorage persists rollback-aware Djed tracker snapshots.
+type DjedStateStorage interface {
+	SaveDjedState(string, djed.TrackerState) error
+	LoadDjedState(string) (djed.TrackerState, error)
+}
+
+// DjedOracle adapts local chain-sync events to the authenticated Djed tracker.
+type DjedOracle struct {
+	idx     *indexer.Indexer
+	network string
+	address string
+	storage DjedStateStorage
+
+	mu      sync.RWMutex
+	tracker *djed.Tracker
+}
+
+// NewDjedOracle creates a local-only Djed chain tracker.
+func NewDjedOracle(
+	idx *indexer.Indexer,
+	network string,
+	address string,
+	stateStorage DjedStateStorage,
+) *DjedOracle {
+	return &DjedOracle{
+		idx:     idx,
+		network: network,
+		address: address,
+		storage: stateStorage,
+		tracker: djed.NewTracker(),
+	}
+}
+
+// Start restores persisted history and registers the chain-sync handler.
+func (o *DjedOracle) Start() error {
+	if o.idx == nil {
+		return fmt.Errorf("djed oracle indexer is required")
+	}
+	if o.network != "mainnet" {
+		return fmt.Errorf("djed oracle is only configured for mainnet")
+	}
+	if o.address != djed.MainnetOracleAddress {
+		return fmt.Errorf("djed oracle address does not match mainnet deployment")
+	}
+	if o.storage == nil {
+		return fmt.Errorf("djed oracle storage is required")
+	}
+	state, err := o.storage.LoadDjedState(o.network)
+	if err != nil && !errors.Is(err, storage.ErrDjedStateNotFound) {
+		return err
+	}
+	if err == nil {
+		tracker, restoreErr := djed.NewTrackerFromState(state)
+		if restoreErr != nil {
+			return fmt.Errorf("restore Djed tracker: %w", restoreErr)
+		}
+		o.tracker = tracker
+	}
+	o.idx.AddEventFunc(o.HandleChainsyncEvent)
+	return nil
+}
+
+// Current returns the currently valid authenticated local observation.
+func (o *DjedOracle) Current(now time.Time) (djed.Observation, error) {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+	return o.tracker.Current(now)
+}
+
+// HandleChainsyncEvent applies transactions and rollbacks atomically with
+// their persisted tracker snapshot.
+func (o *DjedOracle) HandleChainsyncEvent(evt event.Event) error {
+	switch payload := evt.Payload.(type) {
+	case event.TransactionEvent:
+		ctx, ok := evt.Context.(event.TransactionContext)
+		if !ok {
+			return fmt.Errorf(
+				"djed oracle: unexpected transaction context %T",
+				evt.Context,
+			)
+		}
+		return o.handleTransaction(evt.Timestamp, ctx, payload)
+	case event.RollbackEvent:
+		return o.handleRollback(payload)
+	default:
+		return nil
+	}
+}
+
+func (o *DjedOracle) handleTransaction(
+	observedAt time.Time,
+	ctx event.TransactionContext,
+	txEvt event.TransactionEvent,
+) error {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	staged, err := djed.NewTrackerFromState(o.tracker.Snapshot())
+	if err != nil {
+		return fmt.Errorf("stage Djed tracker: %w", err)
+	}
+	changed := false
+	for _, input := range transactionInputs(txEvt) {
+		if staged.ConsumeAt(djed.OutputRef{
+			TxHash:  input.Id().String(),
+			TxIndex: input.Index(),
+		}, ctx.SlotNumber) {
+			changed = true
+		}
+	}
+	for _, utxo := range producedUTXOs(txEvt, ctx.TransactionHash) {
+		output := utxo.Output
+		if output.Address().String() != o.address {
+			continue
+		}
+		hasNFT, err := hasDjedNFT(output.Assets())
+		if err != nil {
+			return err
+		}
+		if !hasNFT {
+			continue
+		}
+		if output.Datum() == nil {
+			return fmt.Errorf("djed oracle output has no inline datum")
+		}
+		oracleNFT, err := djedNFT()
+		if err != nil {
+			return err
+		}
+		_, err = staged.Apply(
+			output.Datum().Cbor(),
+			djed.OracleUTxO{
+				Address: output.Address().String(),
+				Assets: []common.AssetAmount{{
+					Class:  oracleNFT,
+					Amount: 1,
+				}},
+				TxHash:           ctx.TransactionHash,
+				TxIndex:          utxo.Id.Index(),
+				TransactionIndex: ctx.TransactionIdx,
+				Slot:             ctx.SlotNumber,
+				BlockHash:        txEvt.BlockHash,
+			},
+			observedAt,
+		)
+		if err != nil {
+			return fmt.Errorf("apply Djed oracle output: %w", err)
+		}
+		changed = true
+	}
+	if !changed {
+		return nil
+	}
+	if err := o.storage.SaveDjedState(
+		o.network,
+		staged.Snapshot(),
+	); err != nil {
+		return err
+	}
+	o.tracker = staged
+	return nil
+}
+
+func (o *DjedOracle) handleRollback(evt event.RollbackEvent) error {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	staged, err := djed.NewTrackerFromState(o.tracker.Snapshot())
+	if err != nil {
+		return fmt.Errorf("stage Djed tracker: %w", err)
+	}
+	staged.Rollback(evt.SlotNumber)
+	if err := o.storage.SaveDjedState(
+		o.network,
+		staged.Snapshot(),
+	); err != nil {
+		return err
+	}
+	o.tracker = staged
+	return nil
+}
+
+func hasDjedNFT(
+	assets *lcommon.MultiAsset[lcommon.MultiAssetTypeOutput],
+) (bool, error) {
+	if assets == nil {
+		return false, nil
+	}
+	policyBytes, err := hex.DecodeString(djed.MainnetOraclePolicy)
+	if err != nil {
+		return false, fmt.Errorf("decode Djed NFT policy: %w", err)
+	}
+	name, err := hex.DecodeString(djed.OracleNFTName)
+	if err != nil {
+		return false, fmt.Errorf("decode Djed NFT name: %w", err)
+	}
+	var policy lcommon.Blake2b224
+	if len(policyBytes) != len(policy) {
+		return false, fmt.Errorf("invalid Djed NFT policy length")
+	}
+	copy(policy[:], policyBytes)
+	return assets.Asset(policy, name).Uint64() == 1, nil
+}
+
+func djedNFT() (common.AssetClass, error) {
+	asset, err := common.NewAssetClass(
+		djed.MainnetOraclePolicy,
+		djed.OracleNFTName,
+	)
+	if err != nil {
+		return common.AssetClass{}, fmt.Errorf(
+			"decode Djed NFT identity: %w",
+			err,
+		)
+	}
+	return asset, nil
+}

--- a/internal/oracle/djed_oracle.go
+++ b/internal/oracle/djed_oracle.go
@@ -25,9 +25,14 @@ import (
 	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
 	"github.com/blinklabs-io/shai/common"
 	"github.com/blinklabs-io/shai/internal/indexer"
+	"github.com/blinklabs-io/shai/internal/logging"
 	"github.com/blinklabs-io/shai/internal/storage"
 	"github.com/blinklabs-io/shai/price/djed"
 )
+
+// The Cardano mainnet stability window is 3k/f = 129,600 slots. Retaining
+// spent observations across that window keeps all rollback-relevant history.
+const djedRollbackRetentionSlots uint64 = 129_600
 
 // DjedStateStorage persists rollback-aware Djed tracker snapshots.
 type DjedStateStorage interface {
@@ -126,20 +131,22 @@ func (o *DjedOracle) handleTransaction(
 	o.mu.Lock()
 	defer o.mu.Unlock()
 
-	staged, err := djed.NewTrackerFromState(o.tracker.Snapshot())
-	if err != nil {
-		return fmt.Errorf("stage Djed tracker: %w", err)
-	}
-	changed := false
+	inputRefs := make([]djed.OutputRef, 0)
 	for _, input := range transactionInputs(txEvt) {
-		if staged.ConsumeAt(djed.OutputRef{
+		ref := djed.OutputRef{
 			TxHash:  input.Id().String(),
 			TxIndex: input.Index(),
-		}, ctx.SlotNumber) {
-			changed = true
+		}
+		if o.tracker.Contains(ref) {
+			inputRefs = append(inputRefs, ref)
 		}
 	}
-	for _, utxo := range producedUTXOs(txEvt, ctx.TransactionHash) {
+
+	logger := logging.GetLogger()
+	utxos := producedUTXOs(txEvt, ctx.TransactionHash)
+	outputIndexes := make([]int, 0)
+	outputData := make([][]byte, 0)
+	for i, utxo := range utxos {
 		output := utxo.Output
 		if output.Address().String() != o.address {
 			continue
@@ -151,15 +158,41 @@ func (o *DjedOracle) handleTransaction(
 		if !hasNFT {
 			continue
 		}
-		if output.Datum() == nil {
-			return fmt.Errorf("djed oracle output has no inline datum")
+		datum := output.Datum()
+		if datum == nil {
+			logger.Warn(
+				"ignoring Djed oracle output without inline datum",
+				"txHash", ctx.TransactionHash,
+				"txIndex", utxo.Id.Index(),
+			)
+			continue
 		}
-		oracleNFT, err := djedNFT()
-		if err != nil {
-			return err
+		outputIndexes = append(outputIndexes, i)
+		outputData = append(outputData, datum.Cbor())
+	}
+	if len(inputRefs) == 0 && len(outputIndexes) == 0 {
+		return nil
+	}
+
+	staged, err := djed.NewTrackerFromState(o.tracker.Snapshot())
+	if err != nil {
+		return fmt.Errorf("stage Djed tracker: %w", err)
+	}
+	changed := false
+	for _, ref := range inputRefs {
+		if staged.ConsumeAt(ref, ctx.SlotNumber) {
+			changed = true
 		}
+	}
+	oracleNFT, err := djedNFT()
+	if err != nil {
+		return err
+	}
+	for candidateIndex, outputIndex := range outputIndexes {
+		utxo := utxos[outputIndex]
+		output := utxo.Output
 		_, err = staged.Apply(
-			output.Datum().Cbor(),
+			outputData[candidateIndex],
 			djed.OracleUTxO{
 				Address: output.Address().String(),
 				Assets: []common.AssetAmount{{
@@ -175,12 +208,21 @@ func (o *DjedOracle) handleTransaction(
 			observedAt,
 		)
 		if err != nil {
-			return fmt.Errorf("apply Djed oracle output: %w", err)
+			logger.Warn(
+				"ignoring invalid Djed oracle output",
+				"error", err,
+				"txHash", ctx.TransactionHash,
+				"txIndex", utxo.Id.Index(),
+			)
+			continue
 		}
 		changed = true
 	}
 	if !changed {
 		return nil
+	}
+	if ctx.SlotNumber > djedRollbackRetentionSlots {
+		staged.Prune(ctx.SlotNumber - djedRollbackRetentionSlots)
 	}
 	if err := o.storage.SaveDjedState(
 		o.network,

--- a/internal/oracle/djed_oracle_test.go
+++ b/internal/oracle/djed_oracle_test.go
@@ -40,6 +40,7 @@ type testDjedStorage struct {
 	state   djed.TrackerState
 	present bool
 	saveErr error
+	saves   int
 }
 
 func (s *testDjedStorage) SaveDjedState(
@@ -51,6 +52,7 @@ func (s *testDjedStorage) SaveDjedState(
 	}
 	s.state = state
 	s.present = true
+	s.saves++
 	return nil
 }
 
@@ -115,6 +117,11 @@ func TestDjedOracleTracksSpendRollbackAndRestart(t *testing.T) {
 	current, err = oracle.Current(now)
 	require.NoError(t, err)
 	require.Equal(t, txHash, current.TxHash)
+	saves := stateStorage.saves
+	require.NoError(t, oracle.HandleChainsyncEvent(event.Event{
+		Payload: event.RollbackEvent{SlotNumber: 100},
+	}))
+	require.Equal(t, saves, stateStorage.saves)
 
 	restarted := NewDjedOracle(
 		indexer.New(),

--- a/internal/oracle/djed_oracle_test.go
+++ b/internal/oracle/djed_oracle_test.go
@@ -163,7 +163,103 @@ func TestDjedOracleReturnsPersistenceErrorsWithoutChangingMemory(t *testing.T) {
 	require.ErrorIs(t, err, djed.ErrNoCurrentObservation)
 }
 
+func TestDjedOracleIgnoresMalformedChainOutputs(t *testing.T) {
+	stateStorage := &testDjedStorage{}
+	oracle := NewDjedOracle(
+		indexer.New(),
+		"mainnet",
+		djed.MainnetOracleAddress,
+		stateStorage,
+	)
+	require.NoError(t, oracle.Start())
+	now := time.Unix(1_784_842_625, 0).UTC()
+	txHashes := []string{
+		strings.Repeat("01", 32),
+		strings.Repeat("02", 32),
+	}
+	for i, output := range []ledger.TransactionOutput{
+		testDjedOutputWithDatum(t, nil),
+		testDjedOutputWithDatum(t, []byte{0x01}),
+	} {
+		require.NoError(t, oracle.HandleChainsyncEvent(event.Event{
+			Timestamp: now,
+			Context: event.TransactionContext{
+				TransactionHash: txHashes[i],
+				SlotNumber:      uint64(100 + i),
+			},
+			Payload: event.TransactionEvent{
+				Outputs: []ledger.TransactionOutput{output},
+			},
+		}))
+	}
+	require.Equal(t, 0, stateStorage.saves)
+	_, err := oracle.Current(now)
+	require.ErrorIs(t, err, djed.ErrNoCurrentObservation)
+}
+
+func TestDjedOraclePrunesSpentHistoryBeyondStabilityWindow(t *testing.T) {
+	stateStorage := &testDjedStorage{}
+	oracle := NewDjedOracle(
+		indexer.New(),
+		"mainnet",
+		djed.MainnetOracleAddress,
+		stateStorage,
+	)
+	require.NoError(t, oracle.Start())
+	now := time.Unix(1_784_842_625, 0).UTC()
+	firstHash := strings.Repeat("ab", 32)
+	require.NoError(t, oracle.HandleChainsyncEvent(event.Event{
+		Timestamp: now,
+		Context: event.TransactionContext{
+			TransactionHash: firstHash,
+			SlotNumber:      100,
+		},
+		Payload: event.TransactionEvent{
+			Outputs: []ledger.TransactionOutput{testDjedOutput(t)},
+		},
+	}))
+	require.NoError(t, oracle.HandleChainsyncEvent(event.Event{
+		Timestamp: now,
+		Context: event.TransactionContext{
+			TransactionHash: strings.Repeat("cd", 32),
+			SlotNumber:      101,
+		},
+		Payload: event.TransactionEvent{
+			Inputs: []ledger.TransactionInput{
+				shelley.NewShelleyTransactionInput(firstHash, 0),
+			},
+		},
+	}))
+	secondHash := strings.Repeat("ef", 32)
+	require.NoError(t, oracle.HandleChainsyncEvent(event.Event{
+		Timestamp: now,
+		Context: event.TransactionContext{
+			TransactionHash: secondHash,
+			SlotNumber:      djedRollbackRetentionSlots + 102,
+		},
+		Payload: event.TransactionEvent{
+			Outputs: []ledger.TransactionOutput{testDjedOutput(t)},
+		},
+	}))
+	require.Len(t, stateStorage.state.Observations, 1)
+	require.Equal(
+		t,
+		secondHash,
+		stateStorage.state.Observations[0].Observation.TxHash,
+	)
+}
+
 func testDjedOutput(t *testing.T) ledger.TransactionOutput {
+	t.Helper()
+	datum, err := hex.DecodeString(djedDatumFixture)
+	require.NoError(t, err)
+	return testDjedOutputWithDatum(t, datum)
+}
+
+func testDjedOutputWithDatum(
+	t *testing.T,
+	datum []byte,
+) ledger.TransactionOutput {
 	t.Helper()
 	address, err := lcommon.NewAddress(djed.MainnetOracleAddress)
 	require.NoError(t, err)
@@ -180,22 +276,27 @@ func testDjedOutput(t *testing.T) ledger.TransactionOutput {
 			},
 		},
 	)
-	datum, err := hex.DecodeString(djedDatumFixture)
-	require.NoError(t, err)
-	outputCbor, err := cbor.Encode(&map[uint64]any{
+	outputFields := map[uint64]any{
 		0: address,
 		1: mary.MaryTransactionOutputValue{
 			Amount: 1_810_200,
 			Assets: &assets,
 		},
-		2: []any{
+	}
+	if datum != nil {
+		outputFields[2] = []any{
 			uint64(1),
 			cbor.Tag{Number: 24, Content: datum},
-		},
-	})
+		}
+	}
+	outputCbor, err := cbor.Encode(&outputFields)
 	require.NoError(t, err)
 	output, err := ledger.NewTransactionOutputFromCbor(outputCbor)
 	require.NoError(t, err)
-	require.NotNil(t, output.Datum())
+	if datum == nil {
+		require.Nil(t, output.Datum())
+	} else {
+		require.NotNil(t, output.Datum())
+	}
 	return output
 }

--- a/internal/oracle/djed_oracle_test.go
+++ b/internal/oracle/djed_oracle_test.go
@@ -1,0 +1,194 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oracle
+
+import (
+	"encoding/hex"
+	"errors"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/adder/event"
+	"github.com/blinklabs-io/gouroboros/cbor"
+	"github.com/blinklabs-io/gouroboros/ledger"
+	lcommon "github.com/blinklabs-io/gouroboros/ledger/common"
+	"github.com/blinklabs-io/gouroboros/ledger/mary"
+	"github.com/blinklabs-io/gouroboros/ledger/shelley"
+	"github.com/blinklabs-io/shai/internal/indexer"
+	"github.com/blinklabs-io/shai/internal/storage"
+	"github.com/blinklabs-io/shai/price/djed"
+	"github.com/stretchr/testify/require"
+)
+
+const djedDatumFixture = "d8799f584004ea10278c7b8c3c636536a8a1b831d8e193e8aca7df1ee2b83fe856f1fede93fb818e3453f135f37a68d464bf3c6e38d1e4e4750d60cba6dbc3a96132aa6507d8799fd8799f1a000f42401a00029463ffd8799fd8799fd87a9f1b0000019f90e8fcc0ffd87a80ffd8799fd87a9f1b0000019f90f6b860ffd87a80ffff43555344ff581c815aca02042ba9188a2ca4f8ce7b276046e2376b4bce56391342299eff"
+
+type testDjedStorage struct {
+	state   djed.TrackerState
+	present bool
+	saveErr error
+}
+
+func (s *testDjedStorage) SaveDjedState(
+	_ string,
+	state djed.TrackerState,
+) error {
+	if s.saveErr != nil {
+		return s.saveErr
+	}
+	s.state = state
+	s.present = true
+	return nil
+}
+
+func (s *testDjedStorage) LoadDjedState(
+	_ string,
+) (djed.TrackerState, error) {
+	if !s.present {
+		return djed.TrackerState{}, storage.ErrDjedStateNotFound
+	}
+	return s.state, nil
+}
+
+func TestDjedOracleTracksSpendRollbackAndRestart(t *testing.T) {
+	stateStorage := &testDjedStorage{}
+	oracle := NewDjedOracle(
+		indexer.New(),
+		"mainnet",
+		djed.MainnetOracleAddress,
+		stateStorage,
+	)
+	require.NoError(t, oracle.Start())
+	now := time.Unix(1_784_842_625, 0).UTC()
+	txHash := strings.Repeat("ab", 32)
+	require.NoError(t, oracle.HandleChainsyncEvent(event.Event{
+		Timestamp: now,
+		Context: event.TransactionContext{
+			TransactionHash: txHash,
+			TransactionIdx:  3,
+			SlotNumber:      100,
+		},
+		Payload: event.TransactionEvent{
+			BlockHash: "block-100",
+			Outputs: []ledger.TransactionOutput{
+				testDjedOutput(t),
+			},
+		},
+	}))
+	current, err := oracle.Current(now)
+	require.NoError(t, err)
+	require.Equal(t, txHash, current.TxHash)
+	require.Equal(t, uint32(3), current.TransactionIndex)
+	require.Equal(t, "block-100", current.BlockHash)
+
+	require.NoError(t, oracle.HandleChainsyncEvent(event.Event{
+		Timestamp: now.Add(time.Minute),
+		Context: event.TransactionContext{
+			TransactionHash: strings.Repeat("cd", 32),
+			SlotNumber:      101,
+		},
+		Payload: event.TransactionEvent{
+			Inputs: []ledger.TransactionInput{
+				shelley.NewShelleyTransactionInput(txHash, 0),
+			},
+		},
+	}))
+	_, err = oracle.Current(now)
+	require.ErrorIs(t, err, djed.ErrNoCurrentObservation)
+
+	require.NoError(t, oracle.HandleChainsyncEvent(event.Event{
+		Payload: event.RollbackEvent{SlotNumber: 100},
+	}))
+	current, err = oracle.Current(now)
+	require.NoError(t, err)
+	require.Equal(t, txHash, current.TxHash)
+
+	restarted := NewDjedOracle(
+		indexer.New(),
+		"mainnet",
+		djed.MainnetOracleAddress,
+		stateStorage,
+	)
+	require.NoError(t, restarted.Start())
+	current, err = restarted.Current(now)
+	require.NoError(t, err)
+	require.Equal(t, txHash, current.TxHash)
+}
+
+func TestDjedOracleReturnsPersistenceErrorsWithoutChangingMemory(t *testing.T) {
+	saveErr := errors.New("disk unavailable")
+	stateStorage := &testDjedStorage{saveErr: saveErr}
+	oracle := NewDjedOracle(
+		indexer.New(),
+		"mainnet",
+		djed.MainnetOracleAddress,
+		stateStorage,
+	)
+	require.NoError(t, oracle.Start())
+	now := time.Unix(1_784_842_625, 0).UTC()
+	err := oracle.HandleChainsyncEvent(event.Event{
+		Timestamp: now,
+		Context: event.TransactionContext{
+			TransactionHash: strings.Repeat("ef", 32),
+			SlotNumber:      100,
+		},
+		Payload: event.TransactionEvent{
+			Outputs: []ledger.TransactionOutput{
+				testDjedOutput(t),
+			},
+		},
+	})
+	require.ErrorIs(t, err, saveErr)
+	_, err = oracle.Current(now)
+	require.ErrorIs(t, err, djed.ErrNoCurrentObservation)
+}
+
+func testDjedOutput(t *testing.T) ledger.TransactionOutput {
+	t.Helper()
+	address, err := lcommon.NewAddress(djed.MainnetOracleAddress)
+	require.NoError(t, err)
+	policyBytes, err := hex.DecodeString(djed.MainnetOraclePolicy)
+	require.NoError(t, err)
+	name, err := hex.DecodeString(djed.OracleNFTName)
+	require.NoError(t, err)
+	var policy lcommon.Blake2b224
+	copy(policy[:], policyBytes)
+	assets := lcommon.NewMultiAsset[lcommon.MultiAssetTypeOutput](
+		map[lcommon.Blake2b224]map[cbor.ByteString]lcommon.MultiAssetTypeOutput{
+			policy: {
+				cbor.NewByteString(name): big.NewInt(1),
+			},
+		},
+	)
+	datum, err := hex.DecodeString(djedDatumFixture)
+	require.NoError(t, err)
+	outputCbor, err := cbor.Encode(&map[uint64]any{
+		0: address,
+		1: mary.MaryTransactionOutputValue{
+			Amount: 1_810_200,
+			Assets: &assets,
+		},
+		2: []any{
+			uint64(1),
+			cbor.Tag{Number: 24, Content: datum},
+		},
+	})
+	require.NoError(t, err)
+	output, err := ledger.NewTransactionOutputFromCbor(outputCbor)
+	require.NoError(t, err)
+	require.NotNil(t, output.Datum())
+	return output
+}

--- a/internal/storage/djed.go
+++ b/internal/storage/djed.go
@@ -1,0 +1,77 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/blinklabs-io/shai/price/djed"
+	"github.com/dgraph-io/badger/v4"
+)
+
+const djedStateKeyPrefix = "price_djed_"
+
+var ErrDjedStateNotFound = errors.New("storage: Djed state not found")
+
+// SaveDjedState atomically persists retained Djed rollback history.
+func (s *Storage) SaveDjedState(
+	network string,
+	state djed.TrackerState,
+) error {
+	if network == "" {
+		return fmt.Errorf("storage: Djed network is required")
+	}
+	data, err := json.Marshal(state)
+	if err != nil {
+		return fmt.Errorf("storage: marshal Djed state: %w", err)
+	}
+	if err := s.db.Update(func(txn *badger.Txn) error {
+		return txn.Set([]byte(djedStateKeyPrefix+network), data)
+	}); err != nil {
+		return fmt.Errorf("storage: save Djed state: %w", err)
+	}
+	return nil
+}
+
+// LoadDjedState loads retained Djed rollback history.
+func (s *Storage) LoadDjedState(network string) (djed.TrackerState, error) {
+	if network == "" {
+		return djed.TrackerState{}, fmt.Errorf(
+			"storage: Djed network is required",
+		)
+	}
+	var state djed.TrackerState
+	err := s.db.View(func(txn *badger.Txn) error {
+		item, err := txn.Get([]byte(djedStateKeyPrefix + network))
+		if err != nil {
+			return err
+		}
+		return item.Value(func(value []byte) error {
+			return json.Unmarshal(value, &state)
+		})
+	})
+	if errors.Is(err, badger.ErrKeyNotFound) {
+		return djed.TrackerState{}, ErrDjedStateNotFound
+	}
+	if err != nil {
+		return djed.TrackerState{}, fmt.Errorf(
+			"storage: load Djed state: %w",
+			err,
+		)
+	}
+	return state, nil
+}

--- a/internal/storage/djed_test.go
+++ b/internal/storage/djed_test.go
@@ -1,0 +1,53 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/shai/price/djed"
+	"github.com/dgraph-io/badger/v4"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDjedStateSaveLoad(t *testing.T) {
+	db, err := badger.Open(
+		badger.DefaultOptions(t.TempDir()).
+			WithLoggingLevel(badger.WARNING),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+	store := &Storage{db: db}
+	state := djed.TrackerState{
+		Observations: []djed.TrackedObservation{{
+			Observation: djed.Observation{
+				Pair:             "ADA/USD",
+				Source:           "djed",
+				PriceNumerator:   17,
+				PriceDenominator: 100,
+				TxHash:           "tx",
+			},
+		}},
+	}
+	require.NoError(t, store.SaveDjedState("mainnet", state))
+	loaded, err := store.LoadDjedState("mainnet")
+	require.NoError(t, err)
+	require.Equal(t, state, loaded)
+
+	_, err = store.LoadDjedState("preview")
+	require.ErrorIs(t, err, ErrDjedStateNotFound)
+}

--- a/price/djed/tracker.go
+++ b/price/djed/tracker.go
@@ -153,6 +153,14 @@ func (t *Tracker) ConsumeAt(ref OutputRef, slot uint64) bool {
 	return true
 }
 
+// Contains reports whether the output reference is retained by the tracker.
+func (t *Tracker) Contains(ref OutputRef) bool {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	_, ok := t.observations[ref]
+	return ok
+}
+
 // Prune removes spent entries older than beforeSlot. Callers should advance
 // beforeSlot only beyond their immutable rollback horizon. Entries spent at the
 // boundary are retained.

--- a/price/djed/tracker.go
+++ b/price/djed/tracker.go
@@ -16,6 +16,8 @@ package djed
 
 import (
 	"errors"
+	"fmt"
+	"sort"
 	"sync"
 	"time"
 )
@@ -28,6 +30,10 @@ var ErrConflictingObservation = errors.New(
 	"djed: output reference has conflicting oracle observations",
 )
 
+var ErrInvalidTrackerState = errors.New(
+	"djed: invalid persisted tracker state",
+)
+
 // OutputRef identifies an on-chain transaction output.
 type OutputRef struct {
 	TxHash  string
@@ -37,6 +43,18 @@ type OutputRef struct {
 type trackedObservation struct {
 	observation Observation
 	spentAt     *uint64
+}
+
+// TrackedObservation is the persistence-safe state for one authenticated
+// oracle output.
+type TrackedObservation struct {
+	Observation Observation `json:"observation"`
+	SpentAt     *uint64     `json:"spentAtSlot,omitempty"`
+}
+
+// TrackerState is a complete snapshot of retained rollback history.
+type TrackerState struct {
+	Observations []TrackedObservation `json:"observations"`
 }
 
 // Tracker maintains Djed observations from a caller's local chain-sync stream.
@@ -51,6 +69,43 @@ func NewTracker() *Tracker {
 	return &Tracker{
 		observations: make(map[OutputRef]trackedObservation),
 	}
+}
+
+// NewTrackerFromState restores a previously persisted tracker snapshot.
+func NewTrackerFromState(state TrackerState) (*Tracker, error) {
+	tracker := NewTracker()
+	for _, persisted := range state.Observations {
+		observation := persisted.Observation
+		if err := validatePersistedObservation(observation); err != nil {
+			return nil, err
+		}
+		if persisted.SpentAt != nil && *persisted.SpentAt < observation.Slot {
+			return nil, fmt.Errorf(
+				"%w: spend predates observation",
+				ErrInvalidTrackerState,
+			)
+		}
+		ref := OutputRef{
+			TxHash:  observation.TxHash,
+			TxIndex: observation.TxIndex,
+		}
+		if _, exists := tracker.observations[ref]; exists {
+			return nil, fmt.Errorf(
+				"%w: duplicate output reference",
+				ErrInvalidTrackerState,
+			)
+		}
+		var spentAt *uint64
+		if persisted.SpentAt != nil {
+			value := *persisted.SpentAt
+			spentAt = &value
+		}
+		tracker.observations[ref] = trackedObservation{
+			observation: observation,
+			spentAt:     spentAt,
+		}
+	}
+	return tracker, nil
 }
 
 // Apply validates and records a produced Djed oracle UTxO.
@@ -78,19 +133,24 @@ func (t *Tracker) Apply(
 	return observation, nil
 }
 
-// ConsumeAt marks an oracle UTxO spent at the supplied chain slot.
-func (t *Tracker) ConsumeAt(ref OutputRef, slot uint64) {
+// ConsumeAt marks an oracle UTxO spent at the supplied chain slot and reports
+// whether retained state changed.
+func (t *Tracker) ConsumeAt(ref OutputRef, slot uint64) bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	tracked, ok := t.observations[ref]
 	if !ok {
 		// A tracker started mid-chain may see a spend whose output predates
 		// its local history. There is no state to update in that case.
-		return
+		return false
+	}
+	if tracked.spentAt != nil && *tracked.spentAt == slot {
+		return false
 	}
 	spentAt := slot
 	tracked.spentAt = &spentAt
 	t.observations[ref] = tracked
+	return true
 }
 
 // Prune removes spent entries older than beforeSlot. Callers should advance
@@ -163,6 +223,49 @@ func (t *Tracker) Current(now time.Time) (Observation, error) {
 		return Observation{}, ErrNoCurrentObservation
 	}
 	return Observation{}, newestInvalidErr
+}
+
+// Snapshot returns a deep persistence-safe copy of retained tracker state.
+func (t *Tracker) Snapshot() TrackerState {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	state := TrackerState{
+		Observations: make(
+			[]TrackedObservation,
+			0,
+			len(t.observations),
+		),
+	}
+	for _, tracked := range t.observations {
+		var spentAt *uint64
+		if tracked.spentAt != nil {
+			value := *tracked.spentAt
+			spentAt = &value
+		}
+		state.Observations = append(state.Observations, TrackedObservation{
+			Observation: tracked.observation,
+			SpentAt:     spentAt,
+		})
+	}
+	sort.Slice(state.Observations, func(i, j int) bool {
+		left := state.Observations[i].Observation
+		right := state.Observations[j].Observation
+		return observationAfter(right, left)
+	})
+	return state
+}
+
+func validatePersistedObservation(observation Observation) error {
+	if observation.Pair != "ADA/USD" ||
+		observation.Source != "djed" ||
+		observation.PriceNumerator == 0 ||
+		observation.PriceDenominator == 0 ||
+		observation.TxHash == "" ||
+		observation.ValidFrom.After(observation.ValidUntil) {
+		return ErrInvalidTrackerState
+	}
+	return nil
 }
 
 func observationAfter(candidate, current Observation) bool {

--- a/price/djed/tracker.go
+++ b/price/djed/tracker.go
@@ -172,19 +172,23 @@ func (t *Tracker) Prune(beforeSlot uint64) int {
 // Rollback removes observations produced after the rollback point and restores
 // observations whose spends occurred after it. State in the point's block is
 // retained.
-func (t *Tracker) Rollback(slot uint64) {
+func (t *Tracker) Rollback(slot uint64) bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	changed := false
 	for ref, tracked := range t.observations {
 		if tracked.observation.Slot > slot {
 			delete(t.observations, ref)
+			changed = true
 			continue
 		}
 		if tracked.spentAt != nil && *tracked.spentAt > slot {
 			tracked.spentAt = nil
 			t.observations[ref] = tracked
+			changed = true
 		}
 	}
+	return changed
 }
 
 // Current returns the newest authenticated, unspent observation and checks its

--- a/price/djed/tracker_test.go
+++ b/price/djed/tracker_test.go
@@ -249,6 +249,41 @@ func TestTrackerRejectsUnauthenticatedOutput(t *testing.T) {
 	)
 }
 
+func TestTrackerSnapshotRoundTripRestoresSpentOutput(t *testing.T) {
+	now := time.Unix(1_784_842_625, 0).UTC()
+	tracker := NewTracker()
+	first := currentMainnetUTxO(t)
+	first.Slot = 100
+	_, err := tracker.Apply(
+		mustDecodeHex(t, currentMainnetDatum),
+		first,
+		now,
+	)
+	require.NoError(t, err)
+	tracker.ConsumeAt(OutputRef{
+		TxHash:  first.TxHash,
+		TxIndex: first.TxIndex,
+	}, 101)
+
+	restored, err := NewTrackerFromState(tracker.Snapshot())
+	require.NoError(t, err)
+	_, err = restored.Current(now)
+	require.ErrorIs(t, err, ErrNoCurrentObservation)
+	restored.Rollback(100)
+	observation, err := restored.Current(now)
+	require.NoError(t, err)
+	require.Equal(t, first.TxHash, observation.TxHash)
+}
+
+func TestTrackerRestoreRejectsInvalidState(t *testing.T) {
+	_, err := NewTrackerFromState(TrackerState{
+		Observations: []TrackedObservation{{
+			Observation: Observation{Pair: "ADA/EUR"},
+		}},
+	})
+	require.ErrorIs(t, err, ErrInvalidTrackerState)
+}
+
 func currentError(tracker *Tracker, now time.Time) error {
 	_, err := tracker.Current(now)
 	return err

--- a/price/djed/tracker_test.go
+++ b/price/djed/tracker_test.go
@@ -223,12 +223,14 @@ func TestTrackerPrunesOnlyImmutableSpentHistory(t *testing.T) {
 	)
 	require.NoError(t, err)
 	ref := OutputRef{TxHash: utxo.TxHash, TxIndex: utxo.TxIndex}
+	require.True(t, tracker.Contains(ref))
 	tracker.ConsumeAt(ref, 20)
 
 	require.Equal(t, 0, tracker.Prune(20))
 	require.Len(t, tracker.observations, 1)
 	require.Equal(t, 1, tracker.Prune(21))
 	require.Empty(t, tracker.observations)
+	require.False(t, tracker.Contains(ref))
 	require.Equal(t, 0, tracker.Prune(21))
 }
 


### PR DESCRIPTION
Closes #342

- track authenticated Djed UTxOs from chain sync
- persist rollback history

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a local Djed oracle that ingests authenticated on-chain observations, restores on restart, and persists rollback-aware state. Adds a mainnet `djed` profile and bounds per-event work and retained history.

- New Features
  - Mainnet `djed` profile (`ProfileTypeDjed`) with `OracleAddress` in `internal/config`.
  - `cmd/shai` runs a single `DjedOracle`; validates mainnet and address before start.
  - `internal/oracle.DjedOracle` restores persisted state, tracks authenticated Djed UTxOs (NFT + inline datum), handles spends/rollbacks, prunes spent history beyond the stability window, and exposes `Current(now)`.
  - Durable state via `internal/storage` (`SaveDjedState`/`LoadDjedState`, `ErrDjedStateNotFound`); `price/djed` adds `TrackerState`/`TrackedObservation`, `Snapshot()`, `NewTrackerFromState(...)`, and `ErrInvalidTrackerState`.

- Bug Fixes
  - Skip storage writes when rollbacks don’t change tracker state.
  - Bound ingestion work by only processing relevant inputs/outputs and early-returning when no changes are detected.

<sup>Written for commit 4dd316d605eb5bfdb2b90d3db39bcc8883a95f9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/shai/pull/380?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for running a Djed oracle profile on mainnet.
  * The oracle tracks authenticated price observations, handles chain rollbacks, and restores its state after restart.
  * Added persistent storage for Djed oracle history.
  * Added validation for invalid or conflicting Djed profile configurations.

* **Tests**
  * Added coverage for state persistence, rollback recovery, restart behavior, and invalid state handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->