### PR TITLE
feat: qualify prices by pool activity

### DIFF
--- a/dex/activity.go
+++ b/dex/activity.go
@@ -70,6 +70,16 @@ type PoolVolume struct {
 	LastSwapSlot  uint64            `json:"lastSwapSlot,omitempty"`
 }
 
+// Key returns the canonical identity shared with PoolState.
+func (v PoolVolume) Key() string {
+	pool := PoolState{
+		PoolId:   v.PoolID,
+		Network:  v.Network,
+		Protocol: v.Protocol,
+	}
+	return pool.Key()
+}
+
 // ActivityTracker retains confirmed swap-shaped pool transitions over a
 // bounded slot window. Slot windows make historical chain sync deterministic
 // and avoid mistaking sync wall-clock time for trading time.

--- a/dex/activity_test.go
+++ b/dex/activity_test.go
@@ -240,6 +240,16 @@ func cswapActivityPool(
 	}
 }
 
+func TestPoolVolumeKeyMatchesPoolState(t *testing.T) {
+	pool := activityPool(100, 1_000, 2_000)
+	volume := PoolVolume{
+		PoolID:   pool.PoolId,
+		Network:  pool.Network,
+		Protocol: pool.Protocol,
+	}
+	require.Equal(t, pool.Key(), volume.Key())
+}
+
 func activityPool(slot, reserveX, reserveY uint64) *PoolState {
 	return &PoolState{
 		PoolId:   "pool",

--- a/price/ada_usd.go
+++ b/price/ada_usd.go
@@ -35,6 +35,8 @@ var (
 	ErrConcentratedLiquidity    = errors.New("price: one pool dominates qualified liquidity")
 	ErrDivergentPrices          = errors.New("price: qualified pool prices diverge")
 	ErrNonFinitePrice           = errors.New("price: non-finite floating-point price")
+	ErrInvalidActivityConfig    = errors.New("price: invalid pool activity configuration")
+	ErrInvalidPoolActivity      = errors.New("price: invalid pool activity")
 )
 
 const (
@@ -57,6 +59,22 @@ type Config struct {
 	IncludeMempool  bool
 }
 
+// ActivityConfig controls confirmed-volume qualification. Stablecoin volume is
+// normalized to six decimal places, matching StableMicros.
+type ActivityConfig struct {
+	MinSwapCount    uint64
+	MinStableVolume uint64
+}
+
+// DefaultActivityConfig requires both confirmed turnover and at least $100 of
+// stablecoin-side volume over the tracker's configured rolling window.
+func DefaultActivityConfig() ActivityConfig {
+	return ActivityConfig{
+		MinSwapCount:    1,
+		MinStableVolume: 100_000_000,
+	}
+}
+
 // DefaultConfig rejects dust pools while accepting the independently pegged
 // mainnet USDM and USDCx CSWAP pools observed during implementation. A pool
 // holding up to 75% of qualified liquidity may determine the weighted median;
@@ -77,22 +95,25 @@ func DefaultConfig() Config {
 
 // PoolObservation is one qualified ADA/stablecoin spot price.
 type PoolObservation struct {
-	PoolID        string    `json:"poolId"`
-	Protocol      string    `json:"protocol"`
-	Stablecoin    string    `json:"stablecoin"`
-	ADAReserve    uint64    `json:"adaReserve"`
-	StableReserve uint64    `json:"stableReserve"`
-	StableMicros  uint64    `json:"stableMicros"`
-	PriceNum      string    `json:"priceNumerator"`
-	PriceDen      string    `json:"priceDenominator"`
-	Price         float64   `json:"price"`
-	Slot          uint64    `json:"slot"`
-	BlockHash     string    `json:"blockHash"`
-	TxHash        string    `json:"txHash"`
-	TxIndex       uint32    `json:"txIndex"`
-	ObservedAt    time.Time `json:"observedAt"`
-	AgeSeconds    *int64    `json:"ageSeconds"`
-	Validation    string    `json:"validation"`
+	PoolID             string    `json:"poolId"`
+	Protocol           string    `json:"protocol"`
+	Stablecoin         string    `json:"stablecoin"`
+	ADAReserve         uint64    `json:"adaReserve"`
+	StableReserve      uint64    `json:"stableReserve"`
+	StableMicros       uint64    `json:"stableMicros"`
+	PriceNum           string    `json:"priceNumerator"`
+	PriceDen           string    `json:"priceDenominator"`
+	Price              float64   `json:"price"`
+	Slot               uint64    `json:"slot"`
+	BlockHash          string    `json:"blockHash"`
+	TxHash             string    `json:"txHash"`
+	TxIndex            uint32    `json:"txIndex"`
+	ObservedAt         time.Time `json:"observedAt"`
+	AgeSeconds         *int64    `json:"ageSeconds"`
+	Validation         string    `json:"validation"`
+	StableVolumeMicros uint64    `json:"stableVolumeMicros,omitempty"`
+	SwapCount          uint64    `json:"swapCount,omitempty"`
+	ActivitySlots      uint64    `json:"activityWindowSlots,omitempty"`
 
 	price *big.Rat
 }
@@ -218,6 +239,139 @@ func AggregateADAUSDAt(
 		}
 	}
 	return result, nil
+}
+
+// AggregateADAUSDWithActivity qualifies pools by locally inferred confirmed
+// swap volume before applying the normal liquidity and agreement checks.
+func AggregateADAUSDWithActivity(
+	pools []*dex.PoolState,
+	volumes []dex.PoolVolume,
+	config Config,
+	activityConfig ActivityConfig,
+) (Result, error) {
+	return AggregateADAUSDWithActivityAt(
+		pools,
+		volumes,
+		config,
+		activityConfig,
+		time.Now(),
+	)
+}
+
+// AggregateADAUSDWithActivityAt is AggregateADAUSDWithActivity with an
+// explicit evaluation time.
+func AggregateADAUSDWithActivityAt(
+	pools []*dex.PoolState,
+	volumes []dex.PoolVolume,
+	config Config,
+	activityConfig ActivityConfig,
+	now time.Time,
+) (Result, error) {
+	if activityConfig.MinSwapCount == 0 ||
+		activityConfig.MinStableVolume == 0 {
+		return Result{}, ErrInvalidActivityConfig
+	}
+	activityByPool := make(map[string]dex.PoolVolume, len(volumes))
+	for _, volume := range volumes {
+		key := volume.Key()
+		if volume.PoolID == "" ||
+			volume.Network == "" ||
+			volume.Protocol == "" {
+			return Result{}, ErrInvalidPoolActivity
+		}
+		if _, exists := activityByPool[key]; exists {
+			return Result{}, fmt.Errorf(
+				"%w: duplicate volume for %s",
+				ErrInvalidPoolActivity,
+				key,
+			)
+		}
+		activityByPool[key] = volume
+	}
+
+	qualified := make([]*dex.PoolState, 0, len(pools))
+	qualifiedActivity := make(map[string]dex.PoolVolume)
+	for _, pool := range pools {
+		if pool == nil {
+			continue
+		}
+		volume, ok := activityByPool[pool.Key()]
+		if !ok {
+			continue
+		}
+		stableVolume, err := stableVolumeMicros(pool, volume, config)
+		if err != nil {
+			return Result{}, err
+		}
+		if stableVolume < activityConfig.MinStableVolume ||
+			volume.SwapCount < activityConfig.MinSwapCount {
+			continue
+		}
+		qualified = append(qualified, pool)
+		qualifiedActivity[pool.Key()] = volume
+	}
+
+	result, err := AggregateADAUSDAt(qualified, config, now)
+	for i := range result.Observations {
+		observation := &result.Observations[i]
+		for _, pool := range qualified {
+			if pool.PoolId != observation.PoolID ||
+				pool.Protocol != observation.Protocol {
+				continue
+			}
+			volume := qualifiedActivity[pool.Key()]
+			stableVolume, volumeErr := stableVolumeMicros(
+				pool,
+				volume,
+				config,
+			)
+			if volumeErr != nil {
+				return Result{}, volumeErr
+			}
+			observation.StableVolumeMicros = stableVolume
+			observation.SwapCount = volume.SwapCount
+			observation.ActivitySlots = volume.WindowSlots
+			break
+		}
+	}
+	return result, err
+}
+
+func stableVolumeMicros(
+	pool *dex.PoolState,
+	volume dex.PoolVolume,
+	config Config,
+) (uint64, error) {
+	if pool == nil ||
+		volume.Key() != pool.Key() ||
+		volume.WindowSlots == 0 ||
+		volume.WindowEnd < pool.Slot ||
+		!pool.AssetX.IsAsset(volume.AssetX) ||
+		!pool.AssetY.IsAsset(volume.AssetY) {
+		return 0, ErrInvalidPoolActivity
+	}
+	var stable common.AssetAmount
+	var amount uint64
+	switch {
+	case pool.AssetX.IsLovelace():
+		stable = pool.AssetY
+		amount = volume.VolumeY
+	case pool.AssetY.IsLovelace():
+		stable = pool.AssetX
+		amount = volume.VolumeX
+	default:
+		return 0, ErrInvalidPoolActivity
+	}
+	for _, candidate := range config.Stablecoins {
+		if stable.IsAsset(candidate.Asset) {
+			normalized, ok := normalizeToMicros(amount, candidate.Decimals)
+			if !ok {
+				return 0, ErrInvalidPoolActivity
+			}
+			return normalized, nil
+		}
+	}
+	return 0, ErrInvalidPoolActivity
 }
 
 func liquidityWeightedMedian(

--- a/price/ada_usd_test.go
+++ b/price/ada_usd_test.go
@@ -236,6 +236,92 @@ func TestAggregateADAUSDCanUseOneQualifiedPool(t *testing.T) {
 	require.Equal(t, "1/5", result.Rat().String())
 }
 
+func TestAggregateADAUSDWithActivityCanUseOneLiquidActivePool(t *testing.T) {
+	config := DefaultConfig()
+	config.MinObservations = 1
+	config.MinStablecoins = 1
+	config.MaxPoolShare = 1
+	pool := poolFixture(
+		t,
+		"single",
+		USDCxPolicyID,
+		USDCxAssetName,
+		5_000_000_000,
+		1_000_000_000,
+		"single",
+		1,
+	)
+	pool.Network = "mainnet"
+	volume := poolVolume(pool, 3, 250_000_000)
+
+	result, err := AggregateADAUSDWithActivity(
+		[]*dex.PoolState{pool},
+		[]dex.PoolVolume{volume},
+		config,
+		DefaultActivityConfig(),
+	)
+	require.NoError(t, err)
+	require.Equal(t, "1/5", result.Rat().String())
+	require.Equal(
+		t,
+		uint64(250_000_000),
+		result.Observations[0].StableVolumeMicros,
+	)
+	require.Equal(t, uint64(3), result.Observations[0].SwapCount)
+}
+
+func TestAggregateADAUSDWithActivityRejectsInactivePool(t *testing.T) {
+	config := DefaultConfig()
+	config.MinObservations = 1
+	config.MinStablecoins = 1
+	config.MaxPoolShare = 1
+	pool := poolFixture(
+		t,
+		"inactive",
+		USDCxPolicyID,
+		USDCxAssetName,
+		5_000_000_000,
+		1_000_000_000,
+		"inactive",
+		1,
+	)
+	pool.Network = "mainnet"
+	volume := poolVolume(pool, 1, 99_999_999)
+
+	result, err := AggregateADAUSDWithActivity(
+		[]*dex.PoolState{pool},
+		[]dex.PoolVolume{volume},
+		config,
+		DefaultActivityConfig(),
+	)
+	require.ErrorIs(t, err, ErrInsufficientObservations)
+	require.Empty(t, result.Observations)
+}
+
+func TestAggregateADAUSDWithActivityRejectsInvalidVolume(t *testing.T) {
+	pool := poolFixture(
+		t,
+		"pool",
+		USDCxPolicyID,
+		USDCxAssetName,
+		5_000_000_000,
+		1_000_000_000,
+		"pool",
+		1,
+	)
+	pool.Network = "mainnet"
+	volume := poolVolume(pool, 1, 100_000_000)
+	volume.AssetY = common.Lovelace()
+
+	_, err := AggregateADAUSDWithActivity(
+		[]*dex.PoolState{pool},
+		[]dex.PoolVolume{volume},
+		DefaultConfig(),
+		DefaultActivityConfig(),
+	)
+	require.ErrorIs(t, err, ErrInvalidPoolActivity)
+}
+
 func TestLiquidityWeightedMedianRejectsInvalidWeights(t *testing.T) {
 	_, _, err := liquidityWeightedMedian(nil)
 	require.ErrorIs(t, err, ErrInsufficientObservations)
@@ -572,5 +658,23 @@ func poolFixture(
 		Slot:    193_000_000,
 		TxHash:  txHash,
 		TxIndex: txIndex,
+	}
+}
+
+func poolVolume(
+	pool *dex.PoolState,
+	swaps uint64,
+	stableVolume uint64,
+) dex.PoolVolume {
+	return dex.PoolVolume{
+		PoolID:      pool.PoolId,
+		Network:     pool.Network,
+		Protocol:    pool.Protocol,
+		AssetX:      pool.AssetX.Class,
+		AssetY:      pool.AssetY.Class,
+		VolumeY:     stableVolume,
+		SwapCount:   swaps,
+		WindowSlots: 86_400,
+		WindowEnd:   pool.Slot,
 	}
 }


### PR DESCRIPTION
- qualify local ADA/USD pools by confirmed volume
- retain single-pool operation when configured

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds activity-based gating to ADA/USD price aggregation, pre-filtering pools by confirmed swap count and stablecoin volume before liquidity and agreement checks. Preserves single-pool mode when allowed by config.

- **New Features**
  - Added `AggregateADAUSDWithActivity`/`AggregateADAUSDWithActivityAt` to pre-filter by confirmed activity.
  - Introduced `ActivityConfig` and `DefaultActivityConfig` (≥1 swap and ≥$100 stable-side volume), plus `ErrInvalidActivityConfig` and `ErrInvalidPoolActivity`.
  - Extended `PoolObservation` with `StableVolumeMicros`, `SwapCount`, and `ActivitySlots`.
  - Added `dex.PoolVolume.Key()` to match `PoolState.Key()` for reliable pool–volume pairing.

- **Migration**
  - Existing `AggregateADAUSDAt` stays unchanged; to enable activity gating, call `AggregateADAUSDWithActivity` with `[]dex.PoolVolume` and an `ActivityConfig`.
  - Ensure `dex.PoolVolume` matches pool identity and assets, and includes `SwapCount`, `VolumeX/Y`, `WindowSlots`, and `WindowEnd`; stable volume is normalized to micros using configured stablecoins.
  - Handle `ErrInvalidActivityConfig` and `ErrInvalidPoolActivity`.

<sup>Written for commit 622e70dd17a946bfb0c5524fd34954ef1dbec8fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/shai/pull/381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

