### PR TITLE
feat: persist local TWAP state

### DIFF
--- a/internal/storage/twap.go
+++ b/internal/storage/twap.go
@@ -1,0 +1,74 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/blinklabs-io/shai/price"
+	"github.com/dgraph-io/badger/v4"
+)
+
+const twapStateKeyPrefix = "price_twap_"
+
+var ErrTWAPStateNotFound = errors.New("storage: TWAP state not found")
+
+// SaveTWAPState atomically persists a bounded TWAP engine snapshot.
+func (s *Storage) SaveTWAPState(name string, state price.TWAPState) error {
+	if name == "" {
+		return fmt.Errorf("storage: TWAP state name is required")
+	}
+	data, err := json.Marshal(state)
+	if err != nil {
+		return fmt.Errorf("storage: marshal TWAP state: %w", err)
+	}
+	if err := s.db.Update(func(txn *badger.Txn) error {
+		return txn.Set([]byte(twapStateKeyPrefix+name), data)
+	}); err != nil {
+		return fmt.Errorf("storage: save TWAP state: %w", err)
+	}
+	return nil
+}
+
+// LoadTWAPState loads a persisted TWAP engine snapshot.
+func (s *Storage) LoadTWAPState(name string) (price.TWAPState, error) {
+	if name == "" {
+		return price.TWAPState{}, fmt.Errorf(
+			"storage: TWAP state name is required",
+		)
+	}
+	var state price.TWAPState
+	err := s.db.View(func(txn *badger.Txn) error {
+		item, err := txn.Get([]byte(twapStateKeyPrefix + name))
+		if err != nil {
+			return err
+		}
+		return item.Value(func(value []byte) error {
+			return json.Unmarshal(value, &state)
+		})
+	})
+	if errors.Is(err, badger.ErrKeyNotFound) {
+		return price.TWAPState{}, ErrTWAPStateNotFound
+	}
+	if err != nil {
+		return price.TWAPState{}, fmt.Errorf(
+			"storage: load TWAP state: %w",
+			err,
+		)
+	}
+	return state, nil
+}

--- a/internal/storage/twap_test.go
+++ b/internal/storage/twap_test.go
@@ -1,0 +1,89 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"errors"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/shai/price"
+	"github.com/dgraph-io/badger/v4"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTWAPStateSurvivesRestartAndRollback(t *testing.T) {
+	dbPath := t.TempDir()
+	store := openTWAPTestStorage(t, dbPath)
+	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	engine, err := price.NewTWAPEngine(price.TWAPConfig{
+		Window:          10 * time.Minute,
+		MinCoverage:     time.Minute,
+		MaxStaleness:    10 * time.Minute,
+		MaxObservations: 10,
+	})
+	require.NoError(t, err)
+	require.NoError(t, engine.Observe(
+		100,
+		now.Add(-2*time.Minute),
+		big.NewRat(1, 5),
+	))
+	require.NoError(t, engine.Observe(
+		101,
+		now.Add(-time.Minute),
+		big.NewRat(21, 100),
+	))
+	require.NoError(t, store.SaveTWAPState("ada-usd", engine.Snapshot()))
+	require.NoError(t, store.db.Close())
+
+	store = openTWAPTestStorage(t, dbPath)
+	state, err := store.LoadTWAPState("ada-usd")
+	require.NoError(t, err)
+	restored, err := price.NewTWAPEngineFromState(state)
+	require.NoError(t, err)
+	require.Equal(t, 2, restored.Len())
+	require.NoError(t, restored.Rollback(100))
+	require.Equal(t, 1, restored.Len())
+	require.NoError(t, store.SaveTWAPState("ada-usd", restored.Snapshot()))
+}
+
+func TestLoadTWAPStateReportsMissingAndCorruptState(t *testing.T) {
+	store := openTWAPTestStorage(t, t.TempDir())
+	_, err := store.LoadTWAPState("missing")
+	require.ErrorIs(t, err, ErrTWAPStateNotFound)
+
+	require.NoError(t, store.db.Update(func(txn *badger.Txn) error {
+		return txn.Set([]byte(twapStateKeyPrefix+"bad"), []byte("{"))
+	}))
+	_, err = store.LoadTWAPState("bad")
+	require.Error(t, err)
+	require.False(t, errors.Is(err, ErrTWAPStateNotFound))
+}
+
+func openTWAPTestStorage(t *testing.T, path string) *Storage {
+	t.Helper()
+	db, err := badger.Open(
+		badger.DefaultOptions(path).WithLoggingLevel(badger.WARNING),
+	)
+	require.NoError(t, err)
+	store := &Storage{db: db}
+	t.Cleanup(func() {
+		if !store.db.IsClosed() {
+			require.NoError(t, store.db.Close())
+		}
+	})
+	return store
+}

--- a/price/twap.go
+++ b/price/twap.go
@@ -16,6 +16,7 @@ package price
 
 import (
 	"errors"
+	"fmt"
 	"math/big"
 	"sync"
 	"time"
@@ -34,6 +35,7 @@ var (
 	ErrTWAPRollbackUnavailable = errors.New(
 		"price: TWAP rollback history is unavailable",
 	)
+	ErrInvalidTWAPState = errors.New("price: invalid persisted TWAP state")
 )
 
 // TWAPConfig controls the time-weighted average and retained history.
@@ -57,6 +59,23 @@ type TWAPResult struct {
 	LastObservedAt   time.Time     `json:"lastObservedAt"`
 
 	price *big.Rat
+}
+
+// TWAPObservation is the persistence-safe representation of one exact price
+// observation.
+type TWAPObservation struct {
+	Slot     uint64    `json:"slot"`
+	At       time.Time `json:"observedAt"`
+	PriceNum string    `json:"priceNumerator"`
+	PriceDen string    `json:"priceDenominator"`
+}
+
+// TWAPState is a complete bounded snapshot that can restore an engine after a
+// restart without weakening rollback detection.
+type TWAPState struct {
+	Config        TWAPConfig        `json:"config"`
+	Observations  []TWAPObservation `json:"observations"`
+	HistoryPruned bool              `json:"historyPruned"`
 }
 
 // Rat returns a copy of the exact time-weighted average.
@@ -93,6 +112,46 @@ func NewTWAPEngine(config TWAPConfig) (*TWAPEngine, error) {
 		return nil, ErrInvalidTWAPConfig
 	}
 	return &TWAPEngine{config: config}, nil
+}
+
+// NewTWAPEngineFromState restores a previously persisted engine snapshot.
+func NewTWAPEngineFromState(state TWAPState) (*TWAPEngine, error) {
+	engine, err := NewTWAPEngine(state.Config)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidTWAPState, err)
+	}
+	engine.historyPruned = state.HistoryPruned
+	for _, persisted := range state.Observations {
+		numerator, ok := new(big.Int).SetString(persisted.PriceNum, 10)
+		if !ok {
+			return nil, fmt.Errorf(
+				"%w: invalid price numerator",
+				ErrInvalidTWAPState,
+			)
+		}
+		denominator, ok := new(big.Int).SetString(persisted.PriceDen, 10)
+		if !ok || denominator.Sign() <= 0 {
+			return nil, fmt.Errorf(
+				"%w: invalid price denominator",
+				ErrInvalidTWAPState,
+			)
+		}
+		value := new(big.Rat).SetFrac(numerator, denominator)
+		if err := engine.Observe(persisted.Slot, persisted.At, value); err != nil {
+			return nil, fmt.Errorf("%w: %v", ErrInvalidTWAPState, err)
+		}
+	}
+	// Observe may prune while validating a snapshot. A valid persisted state is
+	// already bounded, so any additional pruning means it was inconsistent
+	// with its own configuration.
+	if len(engine.observations) != len(state.Observations) {
+		return nil, fmt.Errorf(
+			"%w: observations exceed configured retention",
+			ErrInvalidTWAPState,
+		)
+	}
+	engine.historyPruned = state.HistoryPruned
+	return engine, nil
 }
 
 // Observe adds an exact confirmed observation. Slots and timestamps must both
@@ -230,6 +289,27 @@ func (e *TWAPEngine) Len() int {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 	return len(e.observations)
+}
+
+// Snapshot returns a deep persistence-safe copy of the bounded engine state.
+func (e *TWAPEngine) Snapshot() TWAPState {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	state := TWAPState{
+		Config:        e.config,
+		Observations:  make([]TWAPObservation, 0, len(e.observations)),
+		HistoryPruned: e.historyPruned,
+	}
+	for _, observation := range e.observations {
+		state.Observations = append(state.Observations, TWAPObservation{
+			Slot:     observation.slot,
+			At:       observation.at,
+			PriceNum: observation.price.Num().String(),
+			PriceDen: observation.price.Denom().String(),
+		})
+	}
+	return state
 }
 
 func (e *TWAPEngine) prune(latest time.Time) {

--- a/price/twap_test.go
+++ b/price/twap_test.go
@@ -318,6 +318,44 @@ func TestNewTWAPEngineRejectsInvalidConfig(t *testing.T) {
 	}
 }
 
+func TestTWAPSnapshotRoundTripPreservesRollbackBoundary(t *testing.T) {
+	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	config := validTWAPConfig()
+	config.MaxObservations = 2
+	engine := newTestTWAP(t, config)
+	for i := range 3 {
+		require.NoError(t, engine.Observe(
+			uint64(i+1),
+			now.Add(time.Duration(i)*time.Second),
+			big.NewRat(int64(i+1), 10),
+		))
+	}
+
+	restored, err := NewTWAPEngineFromState(engine.Snapshot())
+	require.NoError(t, err)
+	require.Equal(t, engine.Snapshot(), restored.Snapshot())
+	require.ErrorIs(t, restored.Rollback(0), ErrTWAPRollbackUnavailable)
+}
+
+func TestTWAPRestoreRejectsInvalidState(t *testing.T) {
+	state := TWAPState{
+		Config: validTWAPConfig(),
+		Observations: []TWAPObservation{{
+			Slot:     1,
+			At:       time.Now(),
+			PriceNum: "not-an-integer",
+			PriceDen: "1",
+		}},
+	}
+	_, err := NewTWAPEngineFromState(state)
+	require.ErrorIs(t, err, ErrInvalidTWAPState)
+
+	state.Observations[0].PriceNum = "1"
+	state.Observations[0].PriceDen = "0"
+	_, err = NewTWAPEngineFromState(state)
+	require.ErrorIs(t, err, ErrInvalidTWAPState)
+}
+
 func newTestTWAP(t *testing.T, config TWAPConfig) *TWAPEngine {
 	t.Helper()
 	engine, err := NewTWAPEngine(config)


### PR DESCRIPTION
- snapshot and restore exact TWAP history
- persist rollback state in BadgerDB

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist and restore local TWAP engine state so prices survive restarts and rollback detection stays correct. Adds snapshot APIs and `github.com/dgraph-io/badger/v4`-backed storage.

- **New Features**
  - In `price`: add `TWAPState` and `TWAPObservation`, `Snapshot()` to export state, and `NewTWAPEngineFromState` to restore it. Validates data, enforces retention, and preserves rollback boundary. Returns `ErrInvalidTWAPState` on bad input.
  - In `internal/storage`: add `SaveTWAPState(name, state)` and `LoadTWAPState(name)` using key prefix `price_twap_`; validates non-empty name. Returns `ErrTWAPStateNotFound` when missing.
  - Tests cover restart + rollback flow, snapshot round-trip preserving rollback boundary, and missing/corrupt state.

<sup>Written for commit 37849d681f304ec4d472e7dc174d3ee5308580cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/shai/pull/382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

