### PR TITLE
feat: expose local pool volume

### DIFF
--- a/internal/oracle/api.go
+++ b/internal/oracle/api.go
@@ -291,9 +291,14 @@ func (a *OracleAPI) HandleGetPoolVolume(
 	volume, found, available, err := a.getPoolVolume(poolID)
 	switch {
 	case err != nil:
+		logging.GetLogger().Error(
+			"failed to compute pool volume",
+			"error", err,
+			"poolId", poolID,
+		)
 		a.writeJSON(w, http.StatusInternalServerError, apiErrorResponse{
 			Code:  "volume_error",
-			Error: err.Error(),
+			Error: "failed to compute pool volume",
 		})
 	case !found:
 		a.writeJSON(w, http.StatusNotFound, apiErrorResponse{

--- a/internal/oracle/api.go
+++ b/internal/oracle/api.go
@@ -181,6 +181,10 @@ func normalizeHostPort(hostPort, scheme string) string {
 func (a *OracleAPI) RegisterHandlers(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/v1/pools", a.HandleListPools)
 	mux.HandleFunc("GET /api/v1/pools/{poolId}", a.HandleGetPool)
+	mux.HandleFunc(
+		"GET /api/v1/pools/{poolId}/volume",
+		a.HandleGetPoolVolume,
+	)
 	mux.HandleFunc("GET /api/v1/cdps", a.HandleListCDPs)
 	mux.HandleFunc("GET /api/v1/cdps/{cdpId}", a.HandleGetCDP)
 	mux.HandleFunc("GET /api/v1/prices", a.HandleListPrices)
@@ -262,6 +266,48 @@ func (a *OracleAPI) HandleGetPool(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(pool)
+}
+
+type apiErrorResponse struct {
+	Code  string `json:"code"`
+	Error string `json:"error"`
+}
+
+// HandleGetPoolVolume returns confirmed swap-shaped reserve turnover over the
+// oracle's configured rolling slot window.
+func (a *OracleAPI) HandleGetPoolVolume(
+	w http.ResponseWriter,
+	r *http.Request,
+) {
+	poolID := r.PathValue("poolId")
+	if poolID == "" {
+		a.writeJSON(w, http.StatusBadRequest, apiErrorResponse{
+			Code:  "pool_id_required",
+			Error: "pool ID required",
+		})
+		return
+	}
+
+	volume, found, available, err := a.getPoolVolume(poolID)
+	switch {
+	case err != nil:
+		a.writeJSON(w, http.StatusInternalServerError, apiErrorResponse{
+			Code:  "volume_error",
+			Error: err.Error(),
+		})
+	case !found:
+		a.writeJSON(w, http.StatusNotFound, apiErrorResponse{
+			Code:  "pool_not_found",
+			Error: "pool not found",
+		})
+	case !available:
+		a.writeJSON(w, http.StatusServiceUnavailable, apiErrorResponse{
+			Code:  "volume_unavailable",
+			Error: "confirmed pool volume is unavailable",
+		})
+	default:
+		a.writeJSON(w, http.StatusOK, volume)
+	}
 }
 
 // HandleListCDPs returns all tracked CDPs.
@@ -534,6 +580,45 @@ func (a *OracleAPI) getPoolState(poolId string) (*PoolState, bool) {
 		}
 	}
 	return nil, false
+}
+
+func (a *OracleAPI) getPoolVolume(
+	poolID string,
+) (PoolVolume, bool, bool, error) {
+	for _, o := range a.oracles {
+		state, found := o.GetPoolState(poolID)
+		if !found || state == nil {
+			continue
+		}
+
+		// Activity is advanced by all confirmed pool transitions handled by an
+		// oracle, so evaluate at that oracle's newest locally tracked slot.
+		atSlot := state.Slot
+		for _, pool := range o.GetAllPools() {
+			if pool != nil && !pool.FromMempool && pool.Slot > atSlot {
+				atSlot = pool.Slot
+			}
+		}
+		volume, available, err := o.GetPoolVolume(poolID, atSlot)
+		return volume, true, available, err
+	}
+	return PoolVolume{}, false, false, nil
+}
+
+func (a *OracleAPI) writeJSON(
+	w http.ResponseWriter,
+	status int,
+	value interface{},
+) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(value); err != nil {
+		logging.GetLogger().Error(
+			"failed to encode oracle API response",
+			"error", err,
+			"status", status,
+		)
+	}
 }
 
 func (a *OracleAPI) getCDPState(cdpId string) (*CDPState, bool) {

--- a/internal/oracle/api_test.go
+++ b/internal/oracle/api_test.go
@@ -357,6 +357,16 @@ func TestHandleGetPoolVolumeTrackerError(t *testing.T) {
 		t.Fatalf("expected status 500, got %d", rr.Code)
 	}
 	assertAPIErrorCode(t, rr, "volume_error")
+	var response apiErrorResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to decode error response: %v", err)
+	}
+	if response.Error != "failed to compute pool volume" {
+		t.Fatalf("unexpected client-facing error %q", response.Error)
+	}
+	if strings.Contains(response.Error, "out of order") {
+		t.Fatalf("internal tracker error leaked to client: %q", response.Error)
+	}
 }
 
 func TestHandleListPrices(t *testing.T) {

--- a/internal/oracle/api_test.go
+++ b/internal/oracle/api_test.go
@@ -168,6 +168,197 @@ func TestHandleGetPoolNotFound(t *testing.T) {
 	}
 }
 
+func TestHandleGetPoolVolume(t *testing.T) {
+	activity, err := NewActivityTracker(100)
+	if err != nil {
+		t.Fatalf("failed to create activity tracker: %v", err)
+	}
+	token, err := common.NewAssetClass("aa", "bb")
+	if err != nil {
+		t.Fatalf("failed to create test asset: %v", err)
+	}
+	previous := &PoolState{
+		PoolId:   "pool-volume",
+		Network:  "mainnet",
+		Protocol: "minswap-v2",
+		Slot:     90,
+		AssetX: common.AssetAmount{
+			Class:  common.Lovelace(),
+			Amount: 1_000,
+		},
+		AssetY: common.AssetAmount{
+			Class:  token,
+			Amount: 2_000,
+		},
+	}
+	current := clonePoolState(previous)
+	current.Slot = 100
+	current.BlockHash = "block-100"
+	current.TxHash = "tx-100"
+	current.AssetX.Amount = 1_100
+	current.AssetY.Amount = 1_800
+	recorded, err := activity.Observe(previous, current)
+	if err != nil {
+		t.Fatalf("failed to record activity: %v", err)
+	}
+	if !recorded {
+		t.Fatal("expected swap-shaped activity to be recorded")
+	}
+	api := NewOracleAPI(&Oracle{
+		pools: map[string]*PoolState{
+			current.PoolId: current,
+			"newer-pool": {
+				PoolId:    "newer-pool",
+				Network:   "mainnet",
+				Protocol:  "splash-v1",
+				Slot:      105,
+				AssetX:    common.AssetAmount{Class: common.Lovelace()},
+				AssetY:    common.AssetAmount{Class: token},
+				Timestamp: time.Now(),
+			},
+		},
+		stopChan: make(chan struct{}),
+		activity: activity,
+	})
+	mux := http.NewServeMux()
+	api.RegisterHandlers(mux)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v1/pools/pool-volume/volume",
+		nil,
+	)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rr.Code, rr.Body)
+	}
+	if got := rr.Header().Get("Content-Type"); got != "application/json" {
+		t.Fatalf("unexpected content type %q", got)
+	}
+	var response PoolVolume
+	if err := json.Unmarshal(rr.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if response.PoolID != "pool-volume" ||
+		response.VolumeX != 100 ||
+		response.VolumeY != 200 ||
+		response.SwapCount != 1 {
+		t.Fatalf("unexpected volume response: %+v", response)
+	}
+	if response.WindowSlots != 100 || response.WindowEnd != 105 {
+		t.Fatalf("unexpected rolling window: %+v", response)
+	}
+	if response.FirstSwapSlot != 100 || response.LastSwapSlot != 100 {
+		t.Fatalf("unexpected swap provenance: %+v", response)
+	}
+}
+
+func TestHandleGetPoolVolumeUnavailable(t *testing.T) {
+	oracle := newTestOracleWithPools()
+	activity, err := NewActivityTracker(100)
+	if err != nil {
+		t.Fatalf("failed to create activity tracker: %v", err)
+	}
+	oracle.activity = activity
+	api := NewOracleAPI(oracle)
+	mux := http.NewServeMux()
+	api.RegisterHandlers(mux)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v1/pools/pool-1/volume",
+		nil,
+	)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected status 503, got %d", rr.Code)
+	}
+	assertAPIErrorCode(t, rr, "volume_unavailable")
+}
+
+func TestHandleGetPoolVolumeNotFound(t *testing.T) {
+	api := NewOracleAPI(newTestOracleWithPools())
+	mux := http.NewServeMux()
+	api.RegisterHandlers(mux)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v1/pools/missing/volume",
+		nil,
+	)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected status 404, got %d", rr.Code)
+	}
+	assertAPIErrorCode(t, rr, "pool_not_found")
+}
+
+func TestHandleGetPoolVolumeRequiresPoolID(t *testing.T) {
+	api := NewOracleAPI(newTestOracleWithPools())
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/pools/volume", nil)
+	rr := httptest.NewRecorder()
+
+	api.HandleGetPoolVolume(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", rr.Code)
+	}
+	assertAPIErrorCode(t, rr, "pool_id_required")
+}
+
+func TestHandleGetPoolVolumeTrackerError(t *testing.T) {
+	activity, err := NewActivityTracker(100)
+	if err != nil {
+		t.Fatalf("failed to create activity tracker: %v", err)
+	}
+	newer := &PoolState{
+		PoolId:   "unpublished-pool",
+		Network:  "mainnet",
+		Protocol: "test",
+		Slot:     200,
+		AssetX: common.AssetAmount{
+			Class:  common.Lovelace(),
+			Amount: 200,
+		},
+		AssetY: common.AssetAmount{
+			Class:  common.Lovelace(),
+			Amount: 100,
+		},
+	}
+	if _, err := activity.Observe(nil, newer); err != nil {
+		t.Fatalf("failed to advance activity tracker: %v", err)
+	}
+	api := NewOracleAPI(&Oracle{
+		pools: map[string]*PoolState{
+			"pool-1": {
+				PoolId:   "pool-1",
+				Network:  "mainnet",
+				Protocol: "test",
+				Slot:     100,
+			},
+		},
+		stopChan: make(chan struct{}),
+		activity: activity,
+	})
+	mux := http.NewServeMux()
+	api.RegisterHandlers(mux)
+
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/v1/pools/pool-1/volume",
+		nil,
+	)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", rr.Code)
+	}
+	assertAPIErrorCode(t, rr, "volume_error")
+}
+
 func TestHandleListPrices(t *testing.T) {
 	api := NewOracleAPI(newTestOracleWithPools())
 	mux := http.NewServeMux()
@@ -411,6 +602,24 @@ func newTestOracleWithPools() *Oracle {
 			},
 		},
 		stopChan: make(chan struct{}),
+	}
+}
+
+func assertAPIErrorCode(
+	t *testing.T,
+	recorder *httptest.ResponseRecorder,
+	expected string,
+) {
+	t.Helper()
+	var response apiErrorResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("failed to decode error response: %v", err)
+	}
+	if response.Code != expected {
+		t.Fatalf("expected error code %q, got %q", expected, response.Code)
+	}
+	if response.Error == "" {
+		t.Fatal("expected non-empty error message")
 	}
 }
 


### PR DESCRIPTION
Adds a REST endpoint for locally inferred confirmed pool volume.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds GET /api/v1/pools/{poolId}/volume to return confirmed pool volume from local activity over a rolling slot window. Clients can read swap volume without querying historical data.

- **New Features**
  - New endpoint: GET /api/v1/pools/{poolId}/volume returns confirmed swap-shaped reserve turnover for the configured rolling slot window.
  - Evaluates at the newest locally tracked slot and returns PoolVolume JSON (pool ID, X/Y volumes, swap count, window size/end, first/last swap slots).
  - Errors are JSON {code, error}: 400 pool_id_required, 404 pool_not_found, 503 volume_unavailable, 500 volume_error (generic message, no internals).

<sup>Written for commit 15cfb7e1b6fd6038694bf17932239aa82b36a50a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/shai/pull/383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

