### PR TITLE
feat: persist pool activity history

### DIFF
--- a/dex/activity_state.go
+++ b/dex/activity_state.go
@@ -1,0 +1,208 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dex
+
+import (
+	"bytes"
+	"errors"
+	"sort"
+)
+
+var (
+	ErrInvalidActivityState  = errors.New("dex: invalid persisted activity state")
+	ErrActivityWindowChanged = errors.New(
+		"dex: persisted activity window does not match tracker",
+	)
+)
+
+// ActivityState is the durable representation of a rolling activity tracker.
+type ActivityState struct {
+	WindowSlots uint64           `json:"windowSlots"`
+	LatestSlot  uint64           `json:"latestSlot"`
+	Swaps       []SwapTransition `json:"swaps"`
+}
+
+// ObserveTransition records a confirmed state and returns the inferred swap
+// when one was added. It provides callers the exact value to persist.
+func (t *ActivityTracker) ObserveTransition(
+	previous,
+	current *PoolState,
+) (SwapTransition, bool, error) {
+	if current == nil || current.FromMempool {
+		return SwapTransition{}, false, nil
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if current.Slot < t.latestSlot {
+		return SwapTransition{}, false, ErrOutOfOrderActivity
+	}
+	t.latestSlot = current.Slot
+	t.prune(current.Slot)
+
+	transition, ok, err := InferSwapTransition(previous, current)
+	if err != nil || !ok {
+		return SwapTransition{}, false, err
+	}
+	key := current.Key()
+	swaps := t.swaps[key]
+	for _, existing := range swaps {
+		if existing.Slot != transition.Slot {
+			continue
+		}
+		if sameSwapIdentity(existing, transition) {
+			if !equalSwapTransition(existing, transition) {
+				return SwapTransition{}, false, ErrInvalidActivityState
+			}
+			return cloneSwapTransition(transition), false, nil
+		}
+	}
+	t.swaps[key] = append(swaps, cloneSwapTransition(transition))
+	return cloneSwapTransition(transition), true, nil
+}
+
+// WindowSlots returns the tracker's configured rolling window.
+func (t *ActivityTracker) WindowSlots() uint64 {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.windowSlots
+}
+
+// Snapshot returns a deep copy suitable for durable storage.
+func (t *ActivityTracker) Snapshot() ActivityState {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	state := ActivityState{
+		WindowSlots: t.windowSlots,
+		LatestSlot:  t.latestSlot,
+	}
+	for _, swaps := range t.swaps {
+		for _, swap := range swaps {
+			state.Swaps = append(state.Swaps, cloneSwapTransition(swap))
+		}
+	}
+	sortSwapTransitions(state.Swaps)
+	return state
+}
+
+// Restore replaces the tracker contents with validated durable state. The
+// configured window must match so a restart cannot silently change retention
+// and therefore the reported volume.
+func (t *ActivityTracker) Restore(state ActivityState) error {
+	if state.WindowSlots == 0 {
+		return ErrInvalidActivityState
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if state.WindowSlots != t.windowSlots {
+		return ErrActivityWindowChanged
+	}
+
+	swaps := make([]SwapTransition, len(state.Swaps))
+	for i, swap := range state.Swaps {
+		if err := validateSwapTransition(swap, state.LatestSlot); err != nil {
+			return err
+		}
+		swaps[i] = cloneSwapTransition(swap)
+	}
+	sortSwapTransitions(swaps)
+
+	restored := make(map[string][]SwapTransition)
+	for _, swap := range swaps {
+		pool := PoolState{
+			PoolId:   swap.PoolID,
+			Network:  swap.Network,
+			Protocol: swap.Protocol,
+		}
+		key := pool.Key()
+		poolSwaps := restored[key]
+		if len(poolSwaps) > 0 &&
+			sameSwapIdentity(poolSwaps[len(poolSwaps)-1], swap) {
+			return ErrInvalidActivityState
+		}
+		restored[key] = append(poolSwaps, swap)
+	}
+
+	t.latestSlot = state.LatestSlot
+	t.swaps = restored
+	t.prune(state.LatestSlot)
+	return nil
+}
+
+func validateSwapTransition(swap SwapTransition, latestSlot uint64) error {
+	if swap.PoolID == "" ||
+		swap.Network == "" ||
+		swap.Protocol == "" ||
+		swap.AmountX == 0 ||
+		swap.AmountY == 0 ||
+		swap.Slot > latestSlot ||
+		(bytes.Equal(swap.AssetX.PolicyId, swap.AssetY.PolicyId) &&
+			bytes.Equal(swap.AssetX.Name, swap.AssetY.Name)) {
+		return ErrInvalidActivityState
+	}
+	return nil
+}
+
+func cloneSwapTransition(swap SwapTransition) SwapTransition {
+	swap.AssetX.PolicyId = append([]byte(nil), swap.AssetX.PolicyId...)
+	swap.AssetX.Name = append([]byte(nil), swap.AssetX.Name...)
+	swap.AssetY.PolicyId = append([]byte(nil), swap.AssetY.PolicyId...)
+	swap.AssetY.Name = append([]byte(nil), swap.AssetY.Name...)
+	return swap
+}
+
+func sortSwapTransitions(swaps []SwapTransition) {
+	sort.Slice(swaps, func(i, j int) bool {
+		if swaps[i].Slot != swaps[j].Slot {
+			return swaps[i].Slot < swaps[j].Slot
+		}
+		if swaps[i].TxHash != swaps[j].TxHash {
+			return swaps[i].TxHash < swaps[j].TxHash
+		}
+		if swaps[i].TxIndex != swaps[j].TxIndex {
+			return swaps[i].TxIndex < swaps[j].TxIndex
+		}
+		if swaps[i].Network != swaps[j].Network {
+			return swaps[i].Network < swaps[j].Network
+		}
+		if swaps[i].Protocol != swaps[j].Protocol {
+			return swaps[i].Protocol < swaps[j].Protocol
+		}
+		return swaps[i].PoolID < swaps[j].PoolID
+	})
+}
+
+func sameSwapIdentity(a, b SwapTransition) bool {
+	return a.Slot == b.Slot &&
+		a.TxHash == b.TxHash &&
+		a.TxIndex == b.TxIndex &&
+		a.Network == b.Network &&
+		a.Protocol == b.Protocol &&
+		a.PoolID == b.PoolID
+}
+
+func equalSwapTransition(a, b SwapTransition) bool {
+	return sameSwapIdentity(a, b) &&
+		a.AmountX == b.AmountX &&
+		a.AmountY == b.AmountY &&
+		a.InputIsX == b.InputIsX &&
+		a.BlockHash == b.BlockHash &&
+		bytes.Equal(a.AssetX.PolicyId, b.AssetX.PolicyId) &&
+		bytes.Equal(a.AssetX.Name, b.AssetX.Name) &&
+		bytes.Equal(a.AssetY.PolicyId, b.AssetY.PolicyId) &&
+		bytes.Equal(a.AssetY.Name, b.AssetY.Name)
+}

--- a/dex/activity_state_test.go
+++ b/dex/activity_state_test.go
@@ -1,0 +1,113 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dex
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestActivityTrackerSnapshotRestoreAndRollback(t *testing.T) {
+	tracker, err := NewActivityTracker(100)
+	require.NoError(t, err)
+
+	transition, recorded, err := tracker.ObserveTransition(
+		activityPool(9, 1_000, 2_000),
+		activityPool(10, 1_100, 1_820),
+	)
+	require.NoError(t, err)
+	require.True(t, recorded)
+	require.Equal(t, uint64(100), transition.AmountX)
+
+	_, recorded, err = tracker.ObserveTransition(
+		activityPool(9, 1_000, 2_000),
+		activityPool(10, 1_100, 1_820),
+	)
+	require.NoError(t, err)
+	require.False(t, recorded, "replayed transition must be idempotent")
+
+	_, recorded, err = tracker.ObserveTransition(
+		activityPool(49, 1_100, 1_820),
+		activityPool(50, 900, 2_200),
+	)
+	require.NoError(t, err)
+	require.True(t, recorded)
+
+	state := tracker.Snapshot()
+	restored, err := NewActivityTracker(100)
+	require.NoError(t, err)
+	require.NoError(t, restored.Restore(state))
+
+	volume, ok, err := restored.Volume("mainnet", "test", "pool", 50)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, uint64(2), volume.SwapCount)
+	require.Equal(t, uint64(300), volume.VolumeX)
+	require.Equal(t, uint64(560), volume.VolumeY)
+
+	restored.Rollback(50)
+	volume, ok, err = restored.Volume("mainnet", "test", "pool", 49)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, uint64(1), volume.SwapCount)
+	require.Equal(t, uint64(10), volume.LastSwapSlot)
+}
+
+func TestActivityTrackerRestoreRejectsInvalidState(t *testing.T) {
+	tracker, err := NewActivityTracker(100)
+	require.NoError(t, err)
+
+	require.ErrorIs(
+		t,
+		tracker.Restore(ActivityState{WindowSlots: 200}),
+		ErrActivityWindowChanged,
+	)
+	require.ErrorIs(
+		t,
+		tracker.Restore(ActivityState{
+			WindowSlots: 100,
+			LatestSlot:  9,
+			Swaps: []SwapTransition{{
+				PoolID:   "pool",
+				Network:  "mainnet",
+				Protocol: "test",
+				TxHash:   "tx",
+				Slot:     10,
+				AmountX:  1,
+				AmountY:  1,
+			}},
+		}),
+		ErrInvalidActivityState,
+	)
+	require.Empty(t, tracker.Snapshot().Swaps)
+}
+
+func TestActivityTrackerSnapshotIsIndependent(t *testing.T) {
+	tracker, err := NewActivityTracker(100)
+	require.NoError(t, err)
+	_, recorded, err := tracker.ObserveTransition(
+		activityPool(9, 1_000, 2_000),
+		activityPool(10, 1_100, 1_820),
+	)
+	require.NoError(t, err)
+	require.True(t, recorded)
+
+	state := tracker.Snapshot()
+	state.Swaps[0].AssetY.PolicyId[0] = 99
+
+	second := tracker.Snapshot()
+	require.Equal(t, byte(1), second.Swaps[0].AssetY.PolicyId[0])
+}

--- a/internal/oracle/activity_restore_test.go
+++ b/internal/oracle/activity_restore_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oracle
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOracleLoadsPersistedPoolActivity(t *testing.T) {
+	storage := newTestOracleStorage(t)
+	swap := activityStorageSwap(100, "swap", 100, 180)
+	require.NoError(t, storage.SavePoolStateAndActivity(
+		activityStoragePool(100),
+		&swap,
+		defaultPoolActivityWindowSlots,
+	))
+	activity, err := NewActivityTracker(defaultPoolActivityWindowSlots)
+	require.NoError(t, err)
+	o := &Oracle{
+		pools:      make(map[string]*PoolState),
+		cdps:       make(map[string]*CDPState),
+		storage:    storage,
+		mempoolMgr: NewMempoolStateManager(),
+		activity:   activity,
+	}
+
+	require.NoError(t, o.loadPersistedStates())
+	volume, ok, err := o.GetPoolVolume("pool", 100)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, uint64(1), volume.SwapCount)
+	require.Equal(t, uint64(100), volume.VolumeX)
+	require.Equal(t, uint64(180), volume.VolumeY)
+}

--- a/internal/oracle/activity_storage.go
+++ b/internal/oracle/activity_storage.go
@@ -1,0 +1,286 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oracle
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/dgraph-io/badger/v4"
+)
+
+const (
+	activityKeyPrefix = "oracle_activity_swap_"
+	activityMetaKey   = "oracle_activity_meta"
+)
+
+type activityMetadata struct {
+	WindowSlots uint64 `json:"windowSlots"`
+	LatestSlot  uint64 `json:"latestSlot"`
+}
+
+// SavePoolStateAndActivity atomically persists the latest pool state, the
+// optional confirmed swap, and rolling activity metadata.
+func (s *OracleStorage) SavePoolStateAndActivity(
+	state *PoolState,
+	swap *SwapTransition,
+	windowSlots uint64,
+) error {
+	if state == nil {
+		return errors.New("failed to save pool activity: nil pool state")
+	}
+	if windowSlots == 0 {
+		return errors.New("failed to save pool activity: zero window")
+	}
+	poolData, err := json.Marshal(state)
+	if err != nil {
+		return fmt.Errorf("failed to marshal pool state: %w", err)
+	}
+	var swapData []byte
+	var swapKey string
+	if swap != nil {
+		if swap.Network != state.Network ||
+			swap.Protocol != state.Protocol ||
+			swap.PoolID != state.PoolId ||
+			swap.Slot != state.Slot {
+			return errors.New(
+				"failed to save pool activity: swap does not match pool state",
+			)
+		}
+		swapData, err = json.Marshal(swap)
+		if err != nil {
+			return fmt.Errorf("failed to marshal pool activity: %w", err)
+		}
+		swapKey = poolActivityKey(*swap)
+	}
+
+	err = s.db.Update(func(txn *badger.Txn) error {
+		meta := activityMetadata{
+			WindowSlots: windowSlots,
+			LatestSlot:  state.Slot,
+		}
+		item, err := txn.Get([]byte(activityMetaKey))
+		if err == nil {
+			if err := item.Value(func(value []byte) error {
+				return json.Unmarshal(value, &meta)
+			}); err != nil {
+				return err
+			}
+			if meta.WindowSlots != windowSlots {
+				return fmt.Errorf(
+					"persisted activity window is %d, requested %d",
+					meta.WindowSlots,
+					windowSlots,
+				)
+			}
+			if state.Slot > meta.LatestSlot {
+				meta.LatestSlot = state.Slot
+			}
+		} else if !errors.Is(err, badger.ErrKeyNotFound) {
+			return err
+		}
+		metaData, err := json.Marshal(meta)
+		if err != nil {
+			return err
+		}
+		if err := txn.Set(
+			[]byte(poolStateKey(state.Network, state.Protocol, state.PoolId)),
+			poolData,
+		); err != nil {
+			return err
+		}
+		if swap != nil {
+			if err := txn.Set([]byte(swapKey), swapData); err != nil {
+				return err
+			}
+		}
+		if err := txn.Set([]byte(activityMetaKey), metaData); err != nil {
+			return err
+		}
+		var cutoff uint64
+		if meta.LatestSlot > windowSlots {
+			cutoff = meta.LatestSlot - windowSlots
+		}
+		return deleteActivityKeys(txn, func(slot uint64) bool {
+			return slot < cutoff
+		})
+	})
+	if err != nil {
+		return fmt.Errorf("failed to save pool state and activity: %w", err)
+	}
+	return nil
+}
+
+// LoadActivityState loads all retained confirmed swaps and tracker metadata.
+func (s *OracleStorage) LoadActivityState() (ActivityState, error) {
+	var state ActivityState
+	err := s.db.View(func(txn *badger.Txn) error {
+		item, err := txn.Get([]byte(activityMetaKey))
+		if errors.Is(err, badger.ErrKeyNotFound) {
+			opts := badger.DefaultIteratorOptions
+			opts.Prefix = []byte(activityKeyPrefix)
+			it := txn.NewIterator(opts)
+			defer it.Close()
+			it.Rewind()
+			if it.Valid() {
+				return errors.New(
+					"pool activity swaps exist without metadata",
+				)
+			}
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if err := item.Value(func(value []byte) error {
+			var meta activityMetadata
+			if err := json.Unmarshal(value, &meta); err != nil {
+				return err
+			}
+			state.WindowSlots = meta.WindowSlots
+			state.LatestSlot = meta.LatestSlot
+			return nil
+		}); err != nil {
+			return err
+		}
+
+		opts := badger.DefaultIteratorOptions
+		opts.Prefix = []byte(activityKeyPrefix)
+		it := txn.NewIterator(opts)
+		defer it.Close()
+		for it.Rewind(); it.Valid(); it.Next() {
+			item := it.Item()
+			if _, err := activitySlotFromKey(item.Key()); err != nil {
+				return err
+			}
+			if err := item.Value(func(value []byte) error {
+				var swap SwapTransition
+				if err := json.Unmarshal(value, &swap); err != nil {
+					return err
+				}
+				state.Swaps = append(state.Swaps, swap)
+				return nil
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return ActivityState{}, fmt.Errorf(
+			"failed to load pool activity: %w",
+			err,
+		)
+	}
+	return state, nil
+}
+
+// RollbackActivity removes swaps at or after the rollback slot and rewinds the
+// persisted latest slot while preserving earlier confirmed history.
+func (s *OracleStorage) RollbackActivity(slot uint64) error {
+	err := s.db.Update(func(txn *badger.Txn) error {
+		if err := deleteActivityKeys(txn, func(activitySlot uint64) bool {
+			return activitySlot >= slot
+		}); err != nil {
+			return err
+		}
+
+		item, err := txn.Get([]byte(activityMetaKey))
+		if errors.Is(err, badger.ErrKeyNotFound) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		var meta activityMetadata
+		if err := item.Value(func(value []byte) error {
+			return json.Unmarshal(value, &meta)
+		}); err != nil {
+			return err
+		}
+		meta.LatestSlot = 0
+		if slot > 0 {
+			meta.LatestSlot = slot - 1
+		}
+		data, err := json.Marshal(meta)
+		if err != nil {
+			return err
+		}
+		return txn.Set([]byte(activityMetaKey), data)
+	})
+	if err != nil {
+		return fmt.Errorf("failed to rollback pool activity: %w", err)
+	}
+	return nil
+}
+
+func poolActivityKey(swap SwapTransition) string {
+	identity := sha256.Sum256([]byte(
+		swap.Network + "\x00" + swap.Protocol + "\x00" + swap.PoolID,
+	))
+	return fmt.Sprintf(
+		"%s%020d:%s:%d:%x",
+		activityKeyPrefix,
+		swap.Slot,
+		swap.TxHash,
+		swap.TxIndex,
+		identity,
+	)
+}
+
+func activitySlotFromKey(key []byte) (uint64, error) {
+	value := strings.TrimPrefix(string(key), activityKeyPrefix)
+	slotText, _, ok := strings.Cut(value, ":")
+	if !ok || len(slotText) != 20 {
+		return 0, fmt.Errorf("invalid pool activity key %q", key)
+	}
+	slot, err := strconv.ParseUint(slotText, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid pool activity key %q: %w", key, err)
+	}
+	return slot, nil
+}
+
+func deleteActivityKeys(
+	txn *badger.Txn,
+	shouldDelete func(uint64) bool,
+) error {
+	opts := badger.DefaultIteratorOptions
+	opts.Prefix = []byte(activityKeyPrefix)
+	it := txn.NewIterator(opts)
+	var keys [][]byte
+	for it.Rewind(); it.Valid(); it.Next() {
+		key := it.Item().KeyCopy(nil)
+		slot, err := activitySlotFromKey(key)
+		if err != nil {
+			it.Close()
+			return err
+		}
+		if shouldDelete(slot) {
+			keys = append(keys, key)
+		}
+	}
+	it.Close()
+	for _, key := range keys {
+		if err := txn.Delete(key); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/oracle/activity_storage_test.go
+++ b/internal/oracle/activity_storage_test.go
@@ -1,0 +1,180 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oracle
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/blinklabs-io/shai/common"
+	"github.com/dgraph-io/badger/v4"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOracleStorageActivitySurvivesRestartAndRollback(t *testing.T) {
+	dir := t.TempDir()
+	storage := openActivityStorage(t, dir)
+
+	first := activityStorageSwap(10, "tx10", 100, 180)
+	second := activityStorageSwap(50, "tx50", 200, 380)
+	require.NoError(t, storage.SavePoolStateAndActivity(
+		activityStoragePool(10),
+		&first,
+		100,
+	))
+	require.NoError(t, storage.SavePoolStateAndActivity(
+		activityStoragePool(50),
+		&second,
+		100,
+	))
+	require.NoError(t, storage.Close())
+
+	storage = openActivityStorage(t, dir)
+	state, err := storage.LoadActivityState()
+	require.NoError(t, err)
+	require.Equal(t, uint64(50), state.LatestSlot)
+	require.Len(t, state.Swaps, 2)
+
+	tracker, err := NewActivityTracker(100)
+	require.NoError(t, err)
+	require.NoError(t, tracker.Restore(state))
+	volume, ok, err := tracker.Volume("mainnet", "test", "pool", 50)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, uint64(2), volume.SwapCount)
+	require.Equal(t, uint64(300), volume.VolumeX)
+
+	require.NoError(t, storage.RollbackActivity(50))
+	require.NoError(t, storage.Close())
+
+	storage = openActivityStorage(t, dir)
+	t.Cleanup(func() {
+		require.NoError(t, storage.Close())
+	})
+	state, err = storage.LoadActivityState()
+	require.NoError(t, err)
+	require.Equal(t, uint64(49), state.LatestSlot)
+	require.Len(t, state.Swaps, 1)
+	require.Equal(t, uint64(10), state.Swaps[0].Slot)
+
+	restored, err := NewActivityTracker(100)
+	require.NoError(t, err)
+	require.NoError(t, restored.Restore(state))
+	volume, ok, err = restored.Volume("mainnet", "test", "pool", 49)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, uint64(1), volume.SwapCount)
+}
+
+func TestOracleStorageActivityPrunesRollingWindow(t *testing.T) {
+	storage := newTestOracleStorage(t)
+	old := activityStorageSwap(10, "old", 100, 180)
+	require.NoError(t, storage.SavePoolStateAndActivity(
+		activityStoragePool(10),
+		&old,
+		100,
+	))
+	require.NoError(t, storage.SavePoolStateAndActivity(
+		activityStoragePool(111),
+		nil,
+		100,
+	))
+	olderOtherPool := activityStoragePool(50)
+	olderOtherPool.PoolId = "other"
+	require.NoError(t, storage.SavePoolStateAndActivity(
+		olderOtherPool,
+		nil,
+		100,
+	))
+
+	state, err := storage.LoadActivityState()
+	require.NoError(t, err)
+	require.Equal(t, uint64(111), state.LatestSlot)
+	require.Empty(t, state.Swaps)
+}
+
+func TestOracleStorageActivityReturnsCorruption(t *testing.T) {
+	t.Run("malformed metadata", func(t *testing.T) {
+		storage := newTestOracleStorage(t)
+		require.NoError(t, storage.db.Update(func(txn *badger.Txn) error {
+			return txn.Set([]byte(activityMetaKey), []byte("{"))
+		}))
+
+		_, err := storage.LoadActivityState()
+		require.Error(t, err)
+	})
+	t.Run("orphaned swap", func(t *testing.T) {
+		storage := newTestOracleStorage(t)
+		swap := activityStorageSwap(10, "orphaned", 1, 1)
+		data, err := json.Marshal(swap)
+		require.NoError(t, err)
+		require.NoError(t, storage.db.Update(func(txn *badger.Txn) error {
+			return txn.Set([]byte(poolActivityKey(swap)), data)
+		}))
+
+		_, err = storage.LoadActivityState()
+		require.Error(t, err)
+	})
+}
+
+func openActivityStorage(t *testing.T, dir string) *OracleStorage {
+	t.Helper()
+	opts := badger.DefaultOptions(dir).WithLoggingLevel(badger.WARNING)
+	db, err := badger.Open(opts)
+	require.NoError(t, err)
+	return &OracleStorage{db: db}
+}
+
+func activityStoragePool(slot uint64) *PoolState {
+	return &PoolState{
+		PoolId:   "pool",
+		Network:  "mainnet",
+		Protocol: "test",
+		Slot:     slot,
+		TxHash:   "pool-state",
+		AssetX: common.AssetAmount{
+			Class:  common.Lovelace(),
+			Amount: 1_000,
+		},
+		AssetY: common.AssetAmount{
+			Class: common.AssetClass{
+				PolicyId: []byte{1},
+				Name:     []byte{2},
+			},
+			Amount: 2_000,
+		},
+	}
+}
+
+func activityStorageSwap(
+	slot uint64,
+	txHash string,
+	amountX,
+	amountY uint64,
+) SwapTransition {
+	return SwapTransition{
+		PoolID:   "pool",
+		Network:  "mainnet",
+		Protocol: "test",
+		AssetX:   common.Lovelace(),
+		AssetY: common.AssetClass{
+			PolicyId: []byte{1},
+			Name:     []byte{2},
+		},
+		AmountX: amountX,
+		AmountY: amountY,
+		Slot:    slot,
+		TxHash:  txHash,
+	}
+}

--- a/internal/oracle/dex.go
+++ b/internal/oracle/dex.go
@@ -33,6 +33,12 @@ type PoolParser = dex.PoolParser
 // PoolVolume is an alias for dex.PoolVolume.
 type PoolVolume = dex.PoolVolume
 
+// SwapTransition is an alias for dex.SwapTransition.
+type SwapTransition = dex.SwapTransition
+
+// ActivityState is an alias for dex.ActivityState.
+type ActivityState = dex.ActivityState
+
 // ActivityTracker is an alias for dex.ActivityTracker.
 type ActivityTracker = dex.ActivityTracker
 

--- a/internal/oracle/oracle.go
+++ b/internal/oracle/oracle.go
@@ -15,6 +15,7 @@
 package oracle
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -120,9 +121,14 @@ func (o *Oracle) Start() error {
 		return err
 	}
 
-	// Load persisted pool states
+	// Load persisted pool and activity states.
 	if err := o.loadPersistedStates(); err != nil {
-		logger.Warn("failed to load persisted pool states", "error", err)
+		closeErr := o.storage.Close()
+		o.storage = nil
+		return errors.Join(
+			fmt.Errorf("failed to load persisted oracle states: %w", err),
+			closeErr,
+		)
 	}
 
 	// Register event handler with indexer
@@ -338,33 +344,49 @@ func (o *Oracle) handleTransaction(
 			prevPrice = prev.PriceXY()
 			prevState = prev
 		}
+		var transition *SwapTransition
 		if o.activity != nil {
-			if _, err := o.activity.Observe(prevState, state); err != nil {
-				logger.Warn(
-					"failed to record pool activity",
-					"error", err,
-					"poolId", state.PoolId,
-					"slot", state.Slot,
+			swap, recorded, err := o.activity.ObserveTransition(
+				prevState,
+				state,
+			)
+			if err != nil {
+				o.poolsMu.Unlock()
+				return fmt.Errorf(
+					"failed to record activity for pool %s: %w",
+					state.PoolId,
+					err,
 				)
+			}
+			if recorded {
+				transition = &swap
 			}
 		}
 		o.pools[state.PoolId] = state
 		o.poolsMu.Unlock()
 
-		// Notify subscribers of price update
-		o.notifySubscribers(state, prevPrice)
-
-		// Update mempool manager's confirmed state for this pool
-		o.mempoolMgr.UpdateConfirmedState(state.PoolId, state)
-
-		// Persist to storage
-		if err := o.storage.SavePoolState(state); err != nil {
-			logger.Error(
-				"failed to persist pool state",
-				"error", err,
-				"poolId", state.PoolId,
+		// Persist the pool and its inferred activity atomically.
+		var persistErr error
+		if o.activity == nil {
+			persistErr = o.storage.SavePoolState(state)
+		} else {
+			persistErr = o.storage.SavePoolStateAndActivity(
+				state,
+				transition,
+				o.activity.WindowSlots(),
 			)
 		}
+		if persistErr != nil {
+			return fmt.Errorf(
+				"failed to persist pool %s: %w",
+				state.PoolId,
+				persistErr,
+			)
+		}
+
+		// Publish the confirmed state only after its durable write succeeds.
+		o.mempoolMgr.UpdateConfirmedState(state.PoolId, state)
+		o.notifySubscribers(state, prevPrice)
 
 		logger.Debug(
 			"pool state updated",
@@ -557,8 +579,12 @@ func (o *Oracle) handleRollback(evt event.RollbackEvent) error {
 	}
 	o.cdpsMu.Unlock()
 
+	var errs []error
 	if o.activity != nil {
 		o.activity.Rollback(evt.SlotNumber)
+		if err := o.storage.RollbackActivity(evt.SlotNumber); err != nil {
+			errs = append(errs, err)
+		}
 	}
 
 	// Invalidate mempool tracking for rolled-back pools. Otherwise the reorged
@@ -569,7 +595,6 @@ func (o *Oracle) handleRollback(evt event.RollbackEvent) error {
 	}
 
 	// Delete from persistent storage
-	var errs []error
 	for _, state := range toDelete {
 		if err := o.storage.DeletePoolState(state); err != nil {
 			logger.Error(
@@ -578,7 +603,10 @@ func (o *Oracle) handleRollback(evt event.RollbackEvent) error {
 				"poolId", state.PoolId,
 				"slot", state.Slot,
 			)
-			errs = append(errs, err)
+			errs = append(
+				errs,
+				fmt.Errorf("delete rolled-back pool %s: %w", state.PoolId, err),
+			)
 		} else {
 			logger.Info(
 				"invalidated pool state due to rollback",
@@ -600,7 +628,10 @@ func (o *Oracle) handleRollback(evt event.RollbackEvent) error {
 				"cdpId", state.CDPId,
 				"slot", state.Slot,
 			)
-			errs = append(errs, err)
+			errs = append(
+				errs,
+				fmt.Errorf("delete rolled-back CDP %s: %w", state.CDPId, err),
+			)
 		} else {
 			logger.Info(
 				"invalidated CDP state due to rollback",
@@ -613,8 +644,8 @@ func (o *Oracle) handleRollback(evt event.RollbackEvent) error {
 
 	if len(errs) > 0 {
 		return fmt.Errorf(
-			"failed to delete %d oracle states during rollback",
-			len(errs),
+			"failed to persist oracle rollback: %w",
+			errors.Join(errs...),
 		)
 	}
 
@@ -636,6 +667,23 @@ func (o *Oracle) loadPersistedStates() error {
 	cdpStates, err := o.storage.LoadAllCDPStates()
 	if err != nil {
 		return err
+	}
+	activityState, err := o.storage.LoadActivityState()
+	if err != nil {
+		return err
+	}
+	if o.activity == nil {
+		o.activity, err = NewActivityTracker(
+			defaultPoolActivityWindowSlots,
+		)
+		if err != nil {
+			return err
+		}
+	}
+	if activityState.WindowSlots != 0 {
+		if err := o.activity.Restore(activityState); err != nil {
+			return fmt.Errorf("failed to restore pool activity: %w", err)
+		}
 	}
 
 	o.poolsMu.Lock()
@@ -668,6 +716,7 @@ func (o *Oracle) loadPersistedStates() error {
 		"loaded persisted oracle states",
 		"pools", len(states),
 		"cdps", len(cdpStates),
+		"swaps", len(activityState.Swaps),
 	)
 
 	return nil


### PR DESCRIPTION
Persists confirmed pool activity across restarts and rollbacks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist confirmed pool swap history with a rolling window and restore it on startup. Keeps volume metrics accurate across restarts and rollbacks.

- New Features
  - Added durable rolling activity tracking in `dex` with snapshot/restore, dedupe, validation, and rollback pruning.
  - Implemented activity storage in `internal/oracle` using `badger`: atomic save of pool state + optional swap, window-based pruning, load on startup, and rollback removal.
  - Oracle now infers `SwapTransition` on confirmed updates, persists pool+activity atomically, restores activity on start, rewinds on rollback, and notifies subscribers only after a successful write.
  - Startup now fails if persisted states cannot be loaded.

<sup>Written for commit bdd4d4ecf7aab2a38ac97415381eb39e8adc91de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/shai/pull/384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

