### PR TITLE
fix: correct CSWAP mainnet intercept

### DIFF
--- a/internal/config/profiles.go
+++ b/internal/config/profiles.go
@@ -288,7 +288,7 @@ var Profiles = map[string]map[string]Profile{
 			Type: ProfileTypeOracle,
 			// CSWAP DEX pool script launch (mainnet)
 			InterceptSlot: 149650740,
-			InterceptHash: "6027a8e3af4cd1cd2b3de0a1b583882573953c200c0ccf120119a04d1def5b49",
+			InterceptHash: "76e1965f49d2ed87150045666c4a9abec1b9439338b87eb50331797b8f37205b",
 			Config: OracleProfileConfig{
 				Protocol:      "cswap",
 				PoolAddresses: poolAddrs("cswap"),

--- a/internal/config/profiles_test.go
+++ b/internal/config/profiles_test.go
@@ -24,8 +24,11 @@ func TestMainnetCSwapProfileIsWired(t *testing.T) {
 	if profile.InterceptSlot == 0 {
 		t.Fatal("cswap intercept slot must be non-zero")
 	}
-	if len(profile.InterceptHash) != 64 {
-		t.Fatalf("unexpected intercept hash length: got %d want 64", len(profile.InterceptHash))
+	if profile.InterceptSlot != 149650740 {
+		t.Fatalf("unexpected intercept slot: got %d", profile.InterceptSlot)
+	}
+	if profile.InterceptHash != "76e1965f49d2ed87150045666c4a9abec1b9439338b87eb50331797b8f37205b" {
+		t.Fatalf("unexpected intercept hash: got %q", profile.InterceptHash)
 	}
 
 	oracleCfg, ok := profile.Config.(OracleProfileConfig)


### PR DESCRIPTION
Corrects the CSWAP intercept block hash and pins it with a regression test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the mainnet cswap intercept hash to the correct value.

* **Tests**
  * Improved validation to verify the exact intercept slot and hash.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->